### PR TITLE
devices: LoopDevice is partitionable

### DIFF
--- a/blivet/devices.py
+++ b/blivet/devices.py
@@ -3921,6 +3921,7 @@ class DirectoryDevice(FileDevice):
 class LoopDevice(StorageDevice):
     """ A loop device. """
     _type = "loop"
+    _partitionable = True
 
     def __init__(self, name=None, format=None, size=None, sysfsPath=None,
                  exists=False, parents=None):


### PR DESCRIPTION
Thus we set the attribute correctly

Signed-off-by: Fabian Deutsch <fabiand@fedoraproject.org>