### PR TITLE
Allow to resize a partition with a resizable filesystem on it

### DIFF
--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -736,7 +736,7 @@ class ActionResizeFormat(DeviceAction):
         if device.formatImmutable:
             raise ValueError("this device's formatting cannot be modified")
 
-        if not device.format.resizable:
+        if not device.format.resizeSupported:
             raise ValueError("format is not resizable")
 
         if device.format.currentSize == newsize:

--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -338,7 +338,7 @@ class StorageDevice(Device):
     def resizable(self):
         """ Can this device be resized? """
         return (self._resizable and self.exists and
-                (self.format.type is None or self.format.resizable or
+                (self.format.type is None or self.format.resizeSupported or
                  not self.format.exists))
 
     def notifyKernel(self):

--- a/blivet/formats/__init__.py
+++ b/blivet/formats/__init__.py
@@ -454,8 +454,13 @@ class DeviceFormat(ObjectID):
 
     @property
     def resizable(self):
-        """ Can formats of this type be resized? """
+        """ Can this device format be resized? """
         return self._resizable and self.exists
+
+    @property
+    def resizeSupported(self):
+        """ Can formats of this type be resized? """
+        return self.__class__._resizable
 
     @property
     def linuxNative(self):

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -442,6 +442,7 @@ class FS(DeviceFormat):
         if not self.exists:
             raise FSResizeError("filesystem does not exist", self.device)
 
+        self.updateSizeInfo()
         if not self.resizable:
             raise FSResizeError("filesystem not resizable", self.device)
 
@@ -459,12 +460,6 @@ class FS(DeviceFormat):
         # properly unmounted. After doCheck the minimum size will be correct
         # so run the check one last time and bump up the size if it was too
         # small.
-        self.updateSizeInfo()
-
-        # Check again if resizable is True, as updateSizeInfo() can change that
-        if not self.resizable:
-            raise FSResizeError("filesystem not resizable", self.device)
-
         if self.targetSize < self.minSize:
             self.targetSize = self.minSize
             log.info("Minimum size changed, setting targetSize on %s to %s",
@@ -810,7 +805,7 @@ class FS(DeviceFormat):
 
     @property
     def resizable(self):
-        """ Can formats of this filesystem type be resized? """
+        """ Can this filesystem be resized? """
         return super(FS, self).resizable and self.utilsAvailable
 
     @property


### PR DESCRIPTION
With the recent changes to resize logic (resizable is set to false until updateSizeInfo) it's now impossible to resize a partition with a resizable filesystem on it (such StorageDevice is considered as not resizable).
It seems that I need to updateSizeInfo before creating ActionResizeDevice object, but then it will be called again when proccessing the action.
So I think it's needed to introduce a distinct property for FS to show that it supports resizing in principle.
