### PR TITLE
Allow passing fractional MiB values to vgcreate -s option

### DIFF
--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -339,7 +339,7 @@ def pvinfo(device=None):
 def vgcreate(vg_name, pv_list, pe_size):
     argv = ["vgcreate"]
     if pe_size:
-        argv.extend(["-s", "%sm" % pe_size.convertTo(spec="mib")])
+        argv.extend(["-s", "%sm" % pe_size.convertTo(spec="KiB")])
     argv.extend(_getConfigArgs())
     argv.append(vg_name)
     argv.extend(pv_list)

--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -339,7 +339,7 @@ def pvinfo(device=None):
 def vgcreate(vg_name, pv_list, pe_size):
     argv = ["vgcreate"]
     if pe_size:
-        argv.extend(["-s", "%sm" % pe_size.convertTo(spec="KiB")])
+        argv.extend(["-s", "%sk" % pe_size.convertTo(spec="KiB")])
     argv.extend(_getConfigArgs())
     argv.append(vg_name)
     argv.extend(pv_list)

--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -339,7 +339,7 @@ def pvinfo(device=None):
 def vgcreate(vg_name, pv_list, pe_size):
     argv = ["vgcreate"]
     if pe_size:
-        argv.extend(["-s", "%dm" % pe_size.convertTo(spec="mib")])
+        argv.extend(["-s", "%sm" % pe_size.convertTo(spec="mib")])
     argv.extend(_getConfigArgs())
     argv.append(vg_name)
     argv.extend(pv_list)


### PR DESCRIPTION
Currently blivet expects pesize parm of the vgcreate function
to be in MiB. However it does not accept any floating values.
This limits passing any values which are KiBs for pesize to create a vg.
This patch fixes the issue by accepting floating values also.

Bug url: https://bugzilla.redhat.com/show_bug.cgi?id=1198568

Signed-off-by: Timothy Asir Jeyasingh <tjeyasin@redhat.com>