### PR TITLE
Fix dd wipe call

### DIFF
--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -539,7 +539,7 @@ class PartitionDevice(StorageDevice):
         # Erase 1MiB or to end of partition
         count = min(int(Size("1 MiB") // bs), part_len)
 
-        cmd = ["dd", "if=/dev/zero", "of=%s" % device, "bs=%s" % bs,
+        cmd = ["dd", "if=/dev/zero", "of=%s" % device, "bs=%d" % int(bs),
                "seek=%s" % start, "count=%s" % count]
         try:
             util.run_program(cmd)


### PR DESCRIPTION
When running test script:

```python
b = blivet.Blivet()
b.reset()
disk = b.devicetree.getDeviceByName('sda')
part = b.newPartition(parents=[disk], size=10*1024*1024, grow=False)
action = blivet.deviceaction.ActionCreateDevice(part)
b.devicetree.registerAction(action)
blivet.partitioning.doPartitioning(storage=b)
b.devicetree.processActions()
```
I see in the log:

INFO:program:Running... dd if=/dev/zero of=/dev/sda bs=512 Б seek=22022144 count=2048
INFO:program:stderr:
INFO:program:dd: invalid number '512 \320\221'
DEBUG:program:Return code: 1

Where 'Б' is first letter in Russian 'Байт' (Bytes).
It seems, blivet should pass sector size as a number, not as a human-readable string.

BTW, result code is not checked so you can see the error only when increasing log verbosity.
