### PR TITLE
Make size._parseSpec a public method.

### DIFF
--- a/blivet/size.py
+++ b/blivet/size.py
@@ -151,7 +151,7 @@ def parseUnits(spec, xlate):
 
     return None
 
-def _parseSpec(spec):
+def parseSpec(spec):
     """ Parse string representation of size.
 
         :param spec: the specification of a size with, optionally, units
@@ -243,7 +243,7 @@ class Size(Decimal):
             you can use the letter 'b' or 'B' or omit the size specifier.
         """
         if isinstance(value, (six.string_types, bytes)):
-            size = _parseSpec(value)
+            size = parseSpec(value)
         elif isinstance(value, (six.integer_types, float, Decimal)):
             size = Decimal(value)
         elif isinstance(value, Size):

--- a/tests/size_test.py
+++ b/tests/size_test.py
@@ -226,34 +226,34 @@ class TranslationTestCase(unittest.TestCase):
             self.assertEqual(res, exp)
 
     def testParseSpec(self):
-        """ Tests for _parseSpec(). """
+        """ Tests for parseSpec(). """
         for lang in  self.TEST_LANGS:
             os.environ['LANG'] = lang
             locale.setlocale(locale.LC_ALL, '')
 
             # Test parsing English spec in foreign locales
-            self.assertEqual(size._parseSpec("1 kibibytes"), Decimal(1024))
-            self.assertEqual(size._parseSpec("2 kibibyte"), Decimal(2048))
-            self.assertEqual(size._parseSpec("2 kilobyte"), Decimal(2000))
-            self.assertEqual(size._parseSpec("2 kilobytes"), Decimal(2000))
-            self.assertEqual(size._parseSpec("2 KB"), Decimal(2000))
-            self.assertEqual(size._parseSpec("2 K"), Decimal(2048))
-            self.assertEqual(size._parseSpec("2 k"), Decimal(2048))
-            self.assertEqual(size._parseSpec("2 Ki"), Decimal(2048))
-            self.assertEqual(size._parseSpec("2 g"), Decimal(2 * 1024 ** 3))
-            self.assertEqual(size._parseSpec("2 G"), Decimal(2 * 1024 ** 3))
+            self.assertEqual(size.parseSpec("1 kibibytes"), Decimal(1024))
+            self.assertEqual(size.parseSpec("2 kibibyte"), Decimal(2048))
+            self.assertEqual(size.parseSpec("2 kilobyte"), Decimal(2000))
+            self.assertEqual(size.parseSpec("2 kilobytes"), Decimal(2000))
+            self.assertEqual(size.parseSpec("2 KB"), Decimal(2000))
+            self.assertEqual(size.parseSpec("2 K"), Decimal(2048))
+            self.assertEqual(size.parseSpec("2 k"), Decimal(2048))
+            self.assertEqual(size.parseSpec("2 Ki"), Decimal(2048))
+            self.assertEqual(size.parseSpec("2 g"), Decimal(2 * 1024 ** 3))
+            self.assertEqual(size.parseSpec("2 G"), Decimal(2 * 1024 ** 3))
 
             # Test parsing foreign spec
-            self.assertEqual(size._parseSpec("1 %s%s" % (_("kibi"), _("bytes"))), Decimal(1024))
+            self.assertEqual(size.parseSpec("1 %s%s" % (_("kibi"), _("bytes"))), Decimal(1024))
 
             # Can't parse a valueless number
             with self.assertRaises(ValueError):
-                size._parseSpec("Ki")
+                size.parseSpec("Ki")
 
-            self.assertEqual(size._parseSpec("2 %s" % _("K")), Decimal(2048))
-            self.assertEqual(size._parseSpec("2 %s" % _("Ki")), Decimal(2048))
-            self.assertEqual(size._parseSpec("2 %s" % _("g")), Decimal(2 * 1024 ** 3))
-            self.assertEqual(size._parseSpec("2 %s" % _("G")), Decimal(2 * 1024 ** 3))
+            self.assertEqual(size.parseSpec("2 %s" % _("K")), Decimal(2048))
+            self.assertEqual(size.parseSpec("2 %s" % _("Ki")), Decimal(2048))
+            self.assertEqual(size.parseSpec("2 %s" % _("g")), Decimal(2 * 1024 ** 3))
+            self.assertEqual(size.parseSpec("2 %s" % _("G")), Decimal(2 * 1024 ** 3))
 
     def testTranslated(self):
         s = Size("56.19 MiB")


### PR DESCRIPTION
This will allow it to be used by client code to prepare for a switch
to new implementation of Size which does not take an arbitrary string
specification as a constructor argument.

Signed-off-by: mulhern <amulhern@redhat.com>