### PR TITLE
Robustify PartitionDevice._wipe() method.

### DIFF
--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -552,8 +552,8 @@ class PartitionDevice(StorageDevice):
         count = min(count, part_len)
 
         device = self.partedPartition.geometry.device.path
-        cmd = ["dd", "if=/dev/zero", "of=%s" % device, "bs=%d" % int(bs),
-               "seek=%s" % start, "count=%s" % count]
+        cmd = ["dd", "if=/dev/zero", "of=%s" % device, "bs=%d" % bs,
+               "seek=%d" % start, "count=%d" % count]
         try:
             util.run_program(cmd)
         except OSError as e:


### PR DESCRIPTION
Previously, if block size is larger than 1 MiB, nothing gets erased.
Now, the smallest number of blocks that erases at least 1 MiB is wiped.