### PR TITLE
Set format options for mkfs

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -69,6 +69,7 @@ class FS(DeviceFormat):
     _fsck = ""                           # fs check utility
     _fsckErrors = {}                     # fs check command error codes & msgs
     _infofs = ""                         # fs info utility
+    _formatOptions = []
     _defaultFormatOptions = []           # default options passed to mkfs
     _defaultMountOptions = ["defaults"]  # default options passed to mount
     _defaultCheckOptions = []
@@ -363,6 +364,16 @@ class FS(DeviceFormat):
         """
         return max(Size(0), self.currentSize - self.minSize)
 
+    @property
+    def formatOptions(self):
+        """ Get format options passed to mkfs for this filesystem type. """
+        return self._formatOptions[:]
+
+    @formatOptions.setter
+    def formatOptions(self, options=[]):
+        """ Set format options passed to mkfs for this filesystem type. """
+        return self._formatOptions = options
+
     def _getFormatOptions(self, options=None, do_labeling=False):
         """Get a list of format options to be used when creating the
            filesystem.
@@ -375,7 +386,9 @@ class FS(DeviceFormat):
         argv = []
         if options and isinstance(options, list):
             argv.extend(options)
-        argv.extend(self.defaultFormatOptions)
+        if not self.formatOptions:
+            argv.extend(self.defaultFormatOptions)
+        argv.extend(self.formatOptions)
         if self._fsProfileSpecifier and self.fsprofile:
             argv.extend([self._fsProfileSpecifier, self.fsprofile])
 


### PR DESCRIPTION
Currently format options can be specified only for doFormat
function. This patch provides options to set the format options.

Usage ex:-
format = blivet.formats.getFormat("xfs", device=lv.path)
format.formatOptions = ["-f", "-K", "-i", "size=256", "-d", ...]
blivetEnv.formatDevice(lv, format)
blivetEnv.doIt()

bug-url: https://bugzilla.redhat.com/show_bug.cgi?id=1180221
Signed-off-by: Timothy Asir Jeyasingh <tjeyasin@redhat.com>