### PR TITLE
Prevent issues caused by passing XFS/BTRFS max sizes to libblockdev (#1200812)

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -1115,7 +1115,7 @@ class BTRFS(FS):
     _supported = True
     _packages = ["btrfs-progs"]
     _minSize = Size("256 MiB")
-    _maxSize = Size("16 EiB")
+    _maxSize = Size("15 EiB")
     # FIXME parted needs to be taught about btrfs so that we can set the
     # partition table type correctly for btrfs partitions
     # partedSystem = fileSystemType["btrfs"]
@@ -1254,7 +1254,7 @@ class XFS(FS):
     _modules = ["xfs"]
     _labelfs = fslabeling.XFSLabeling()
     _defaultFormatOptions = ["-f"]
-    _maxSize = Size("16 EiB")
+    _maxSize = Size("15 EiB")
     _formattable = True
     _linuxNative = True
     _supported = True

--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -936,16 +936,15 @@ class LVRequest(Request):
         self.base = int(lv.vg.align(lv.req_size, roundup=True) // lv.vg.peSize)
 
         if lv.req_grow:
-            limits = [int(l // lv.vg.peSize) for l in
-                        (lv.vg.align(lv.req_max_size),
-                         lv.vg.align(lv.format.maxSize)) if l > Size(0)]
+            limit = min(l for l in (blockdev.lvm_get_max_lv_size(),
+                                    lv.req_max_size, lv.format.maxSize) if l > Size(0))
 
-            if limits:
-                max_units = min(limits)
-                self.max_growth = max_units - self.base
-                if self.max_growth <= 0:
-                    # max size is less than or equal to base, so we're done
-                    self.done = True
+            limit = lv.vg.align(limit)
+            max_units = int(limit // lv.vg.peSize)
+            self.max_growth = max_units - self.base
+            if self.max_growth <= 0:
+                # max size is less than or equal to base, so we're done
+                self.done = True
 
 
 class Chunk(object):


### PR DESCRIPTION
These should be max 64-bit unsigned integer value which is 16 EiB - 1.