### PR TITLE
Dynamic mountpoint detection

### DIFF
--- a/blivet/__init__.py
+++ b/blivet/__init__.py
@@ -387,7 +387,7 @@ class Blivet(object):
             self.dumpState("initial")
 
         if not flags.installer_mode:
-            self.devicetree.getActiveMounts()
+            self.devicetree.handleNodevFilesystems()
 
         self.updateBootLoaderDiskList()
 

--- a/blivet/devices/btrfs.py
+++ b/blivet/devices/btrfs.py
@@ -195,6 +195,7 @@ class BTRFSVolumeDevice(BTRFSDevice, ContainerDevice, RaidDevice):
                                     label=label,
                                     volUUID=self.uuid,
                                     device=self.path,
+                                    subvolspec=self.vol_id,
                                     mountopts="subvolid=%d" % self.vol_id)
             self.originalFormat = copy.copy(self.format)
 

--- a/blivet/devices/file.py
+++ b/blivet/devices/file.py
@@ -65,7 +65,7 @@ class FileDevice(StorageDevice):
     @property
     def path(self):
         try:
-            root = self.parents[0].format._mountpoint
+            root = self.parents[0].format.systemMountpoint
             mountpoint = self.parents[0].format.mountpoint
         except (AttributeError, IndexError):
             root = ""

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -1740,6 +1740,7 @@ class DeviceTree(object):
 
                 fmt = getFormat("btrfs", device=btrfs_dev.path, exists=True,
                                 volUUID=btrfs_dev.format.volUUID,
+                                subvolspec=vol_path,
                                 mountopts="subvol=%s" % vol_path)
                 if vol_id in snapshot_ids:
                     device_class = BTRFSSnapShotDevice

--- a/blivet/formats/__init__.py
+++ b/blivet/formats/__init__.py
@@ -160,6 +160,7 @@ class DeviceFormat(ObjectID):
     _check = False
     _hidden = False                     # hide devices with this formatting?
     _ksMountpoint = None
+    mountsCache = None
 
     def __init__(self, **kwargs):
         """

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -1123,6 +1123,7 @@ class BTRFS(FS):
     def __init__(self, **kwargs):
         super(BTRFS, self).__init__(**kwargs)
         self.volUUID = kwargs.pop("volUUID", None)
+        self.subvolspec = kwargs.pop("subvolspec", None)
 
     def create(self, **kwargs):
         # filesystem creation is done in storage.devicelibs.btrfs.create_volume

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -110,7 +110,6 @@ class FS(DeviceFormat):
         # filesystem size does not necessarily equal device size
         self._size = kwargs.get("size", Size(0))
         self._minInstanceSize = Size(0)    # min size of this FS instance
-        self._mountpoint = None     # the current mountpoint when mounted
 
         # Resize operations are limited to error-free filesystems whose current
         # size is known.
@@ -581,6 +580,13 @@ class FS(DeviceFormat):
         # If we successfully loaded a kernel module for this filesystem, we
         # also need to update the list of supported filesystems.
         update_kernel_filesystems()
+
+    @property
+    def systemMountpoint(self):
+        if not self.mountsCache:
+            return None
+
+        return self.mountsCache.getMountpoint(self.device)
 
     def testMount(self):
         """ Try to mount the fs and return True if successful. """
@@ -1159,6 +1165,13 @@ class BTRFS(FS):
             return
 
         return self.mount(**kwargs)
+
+    @property
+    def systemMountpoint(self):
+        if not self.mountsCache:
+            return None
+
+        return self.mountsCache.getMountpoint(self.device, self.subvolspec)
 
 register_device_format(BTRFS)
 

--- a/blivet/mounts.py
+++ b/blivet/mounts.py
@@ -1,0 +1,137 @@
+# mounts.py
+# Active mountpoints cache.
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vojtech Trefny <vtrefny@redhat.com>
+#
+
+from . import util
+
+import logging
+log = logging.getLogger("blivet")
+
+class MountsCache(object):
+
+    def __init__(self):
+        self.mountsHash = 0
+        self.mountpoints = {}
+
+        # new device manually added to cache since last check
+        self.newDevice = False
+
+    def add(self, devspec, subvolspec=None):
+        """ Add device to cache
+
+            :param devscpec: device specification, eg. "/dev/vda1"
+            :type devspec: str
+            :param subvolspec: btrfs subvolume specification, eg. ID or name
+            :type subvolspec: str
+
+        """
+
+        self.mountpoints[(devspec, subvolspec)] = None
+        self.newDevice = True
+
+    def remove(self, devspec, subvolspec=None):
+        """ Remove device from cache
+
+            :param devscpec: device specification, eg. "/dev/vda1"
+            :type devspec: str
+            :param subvolspec: btrfs subvolume specification, eg. ID or name
+            :type subvolspec: str
+
+        """
+
+        if (devspec, subvolspec) in self.mountpoints:
+            del self.mountpoints[(devspec, subvolspec)]
+
+    def clear(self):
+        """ Clear cache
+        """
+
+        for key in self.mountpoints.keys():
+            self.mountpoints[key] = None
+
+        self._getActiveMounts()
+
+    def getMountpoint(self, devspec, subvolspec=None):
+        """ Get mountpoint for selected device
+
+            :param devscpec: device specification, eg. "/dev/vda1"
+            :type devspec: str
+            :param subvolspec: btrfs subvolume specification, eg. ID or name
+            :type subvolspec: str
+            :returns: mountpoint (path)
+            :rtype: str
+
+        """
+
+        self._cacheCheck()
+
+        if (devspec, subvolspec) not in self.mountpoints.keys():
+            return None
+
+        else:
+            return self.mountpoints[(devspec, subvolspec)]
+
+    def _getActiveMounts(self):
+
+        for line in open("/proc/mounts").readlines():
+            try:
+                (devspec, mountpoint, fstype, options, _rest) = line.split(None, 4)
+            except ValueError:
+                log.error("failed to parse /proc/mounts line: %s", line)
+                continue
+
+            if fstype == "btrfs":
+                # get the subvol name from /proc/self/mountinfo
+                for line in open("/proc/self/mountinfo").readlines():
+                    fields = line.split()
+                    _subvol = fields[3]
+                    _mountpoint = fields[4]
+                    _devspec = fields[9]
+                    if _mountpoint == mountpoint and _devspec == devspec:
+                        # empty _subvol[1:] means it is a top-level volume
+                        subvolspec = _subvol[1:] or 5
+
+                        fmt = self._resolveFormat(devspec, subvolspec)
+
+            else:
+                fmt = self._resolveFormat(devspec)
+
+            if fmt:
+                self.mountpoints[fmt] = mountpoint
+
+    def _resolveFormat(self, devspec, subvolspec=None):
+
+        for fmt in self.mountpoints.keys():
+            if fmt[0] == devspec:
+                if not fmt[1]:
+                    return fmt
+
+                elif fmt[1] == subvolspec:
+                    return fmt
+
+    def _cacheCheck(self):
+
+        md5hash = util.md5_file("/proc/mounts")
+
+        if md5hash != self.mountsHash or self.newDevice:
+            self.newDevice = False
+            self.mountsHash = md5hash
+            self.clear()

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -9,6 +9,7 @@ import re
 import sys
 import tempfile
 import uuid
+import hashlib
 from decimal import Decimal
 from contextlib import contextmanager
 
@@ -356,6 +357,18 @@ def insert_colons(a_string):
         return insert_colons(a_string[:-2]) + ':' + suffix
     else:
         return suffix
+
+def md5_file(filename):
+
+    f = open(filename, "rb")
+    md5 = hashlib.md5()
+
+    block = f.read(65536)
+    while block:
+        md5.update(block)
+        block = f.read(65536)
+
+    return md5.hexdigest()
 
 class ObjectID(object):
     """This class is meant to be extended by other classes which require


### PR DESCRIPTION
Dynamic detection of mountpoints for existing devices.

blivet.mounts.MountCache parses /proc/mounts and /proc/self/mountinfo to get information about mounted devices. See https://github.com/rhinstaller/blivet/issues/13 for more information.