### PR TITLE
Require the Python 2 version of pykickstart (#1202255)

### DIFF
--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -24,7 +24,7 @@ BuildRequires: python-setuptools
 
 Requires: python
 Requires: python-six
-Requires: pykickstart >= %{pykickstartver}
+Requires: python-kickstart >= %{pykickstartver}
 Requires: util-linux >= %{utillinuxver}
 Requires: python-pyudev
 Requires: parted >= %{partedver}


### PR DESCRIPTION
The 'pykickstart' package now pulls in the Python 3 version.