### PR TITLE
Catch GLib.GError in places where we catch StorageError (#1202505)

### DIFF
--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -33,6 +33,7 @@ from .partitioning import TotalSizeSet
 from .partitioning import doPartitioning
 from .size import Size
 
+from gi.repository import GLib
 from gi.repository import BlockDev as blockdev
 
 import logging
@@ -595,7 +596,7 @@ class DeviceFactory(object):
         e = None
         try:
             self._post_create()
-        except StorageError as e:
+        except (StorageError, GLib.GError) as e:
             log.error("device post-create method failed: %s", e)
         else:
             if not device.size:
@@ -651,7 +652,7 @@ class DeviceFactory(object):
 
         try:
             self._post_create()
-        except StorageError as e:
+        except (StorageError, GLib.GError) as e:
             log.error("device post-create method failed: %s", e)
             raise
         else:
@@ -900,7 +901,7 @@ class PartitionFactory(DeviceFactory):
     def _post_create(self):
         try:
             doPartitioning(self.storage)
-        except StorageError as e:
+        except (StorageError, GLib.GError) as e:
             log.error("failed to allocate partitions: %s", e)
             raise
 
@@ -1056,7 +1057,7 @@ class PartitionSetFactory(PartitionFactory):
                 member = self.storage.newPartition(parents=[disk], grow=True,
                                            size=base_size,
                                            fmt_type=member_format)
-            except StorageError as e:
+            except (StorageError, GLib.GError) as e:
                 log.error("failed to create new member partition: %s", e)
                 continue
 

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -2213,7 +2213,7 @@ class DeviceTree(object):
 
             try:
                 device.teardown(recursive=True)
-            except StorageError as e:
+            except (StorageError, GLib.GError) as e:
                 log.info("teardown of %s failed: %s", device.name, e)
 
     def teardownDiskImages(self):
@@ -2550,7 +2550,7 @@ class DeviceTree(object):
                 if devspec.startswith("/dev/dm-"):
                     try:
                         dm_name = blockdev.dm_name_from_node(devspec[5:])
-                    except StorageError as e:
+                    except GLib.GError as e:
                         log.info("failed to resolve %s: %s", devspec, e)
                         dm_name = None
 
@@ -2560,7 +2560,7 @@ class DeviceTree(object):
                 if re.match(r'/dev/md\d+(p\d+)?$', devspec):
                     try:
                         md_name = blockdev.md_name_from_node(devspec[5:])
-                    except StorageError as e:
+                    except GLib.GError as e:
                         log.info("failed to resolve %s: %s", devspec, e)
                         md_name = None
 

--- a/blivet/osinstall.py
+++ b/blivet/osinstall.py
@@ -24,6 +24,7 @@ import shlex
 import os
 import stat
 import time
+from gi.repository import GLib
 from gi.repository import BlockDev as blockdev
 
 from . import util
@@ -528,7 +529,7 @@ class FSSet(object):
                 try:
                     device.setup()
                     device.format.setup()
-                except StorageError as e:
+                except (StorageError, GLib.GError) as e:
                     if errorHandler.cb(e) == ERROR_RAISE:
                         raise
                 else:


### PR DESCRIPTION
Previously, all errors that could have been raised from running storage actions
from blivet were inherited from the StorageError class. This no longer holds
with libblockdev being used because libblockdev raises exceptions through GI
introspection and thus as GLib.GError. In places we catch the all-covering
StorageError we should also catch GLib.GError and in some places we should only
catch GLib.GError if a libblockdev call is the only thing in the try-except
block.

**This is a temporary fix until libblockdev adds some better exception hierarchy into it's GI overrides.**