### PR TITLE
Dynamic mountpoint detection -- new version

### DIFF
--- a/blivet/__init__.py
+++ b/blivet/__init__.py
@@ -387,7 +387,7 @@ class Blivet(object):
             self.dumpState("initial")
 
         if not flags.installer_mode:
-            self.devicetree.getActiveMounts()
+            self.devicetree.handleNodevFilesystems()
 
         self.updateBootLoaderDiskList()
 

--- a/blivet/devices/btrfs.py
+++ b/blivet/devices/btrfs.py
@@ -195,6 +195,7 @@ class BTRFSVolumeDevice(BTRFSDevice, ContainerDevice, RaidDevice):
                                     label=label,
                                     volUUID=self.uuid,
                                     device=self.path,
+                                    subvolspec=self.vol_id,
                                     mountopts="subvolid=%d" % self.vol_id)
             self.originalFormat = copy.copy(self.format)
 

--- a/blivet/devices/file.py
+++ b/blivet/devices/file.py
@@ -65,7 +65,7 @@ class FileDevice(StorageDevice):
     @property
     def path(self):
         try:
-            root = self.parents[0].format._mountpoint
+            root = self.parents[0].format.systemMountpoint
             mountpoint = self.parents[0].format.mountpoint
         except (AttributeError, IndexError):
             root = ""

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -1740,6 +1740,7 @@ class DeviceTree(object):
 
                 fmt = getFormat("btrfs", device=btrfs_dev.path, exists=True,
                                 volUUID=btrfs_dev.format.volUUID,
+                                subvolspec=vol_path,
                                 mountopts="subvol=%s" % vol_path)
                 if vol_id in snapshot_ids:
                     device_class = BTRFSSnapShotDevice

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -2649,26 +2649,14 @@ class DeviceTree(object):
             log.debug("failed to resolve '%s'", devspec)
         return device
 
-    def getActiveMounts(self):
-        """ Reflect active mounts in the appropriate devices' formats. """
-        log.info("collecting information about active mounts")
+    def handleNodevFilesystems(self):
+
         for line in open("/proc/mounts").readlines():
             try:
                 (devspec, mountpoint, fstype, options, _rest) = line.split(None, 4)
             except ValueError:
                 log.error("failed to parse /proc/mounts line: %s", line)
                 continue
-
-            if fstype == "btrfs":
-                # get the subvol name from /proc/self/mountinfo
-                for line in open("/proc/self/mountinfo").readlines():
-                    fields = line.split()
-                    _subvol = fields[3]
-                    _mountpoint = fields[4]
-                    _devspec = fields[9]
-                    if _mountpoint == mountpoint and _devspec == devspec:
-                        log.debug("subvol %s", _subvol)
-                        options += ",subvol=%s" % _subvol[1:]
 
             if fstype in nodev_filesystems:
                 if not flags.include_nodev:
@@ -2691,10 +2679,3 @@ class DeviceTree(object):
                 n = len([d for d in self.devices if d.format.type == fstype])
                 device._name += ".%d" % n
                 self._addDevice(device)
-                devspec = device.name
-
-            device = self.resolveDevice(devspec, options=options)
-            if device is not None:
-                device.format.mountpoint = mountpoint   # for future mounts
-                device.format._mountpoint = mountpoint  # active mountpoint
-                device.format.mountopts = options

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -39,6 +39,7 @@ from ..size import Size, ROUND_UP, ROUND_DOWN, unitStr
 from ..size import B, KiB, MiB, GiB, KB, MB, GB
 from ..i18n import _, N_
 from .. import udev
+from ..mounts import mountsCache
 
 import logging
 log = logging.getLogger("blivet")
@@ -110,7 +111,6 @@ class FS(DeviceFormat):
         # filesystem size does not necessarily equal device size
         self._size = kwargs.get("size", Size(0))
         self._minInstanceSize = Size(0)    # min size of this FS instance
-        self._mountpoint = None     # the current mountpoint when mounted
 
         # Resize operations are limited to error-free filesystems whose current
         # size is known.
@@ -582,6 +582,21 @@ class FS(DeviceFormat):
         # also need to update the list of supported filesystems.
         update_kernel_filesystems()
 
+    @property
+    def systemMountpoint(self):
+        """ Get current mountpoint
+
+            returns: mountpoint
+            rtype: str or None
+
+        """
+
+        if not self.exists:
+            return None
+
+        return mountsCache.getMountpoint(self.device,
+                                         getattr(self, "subvolspec", None))
+
     def testMount(self):
         """ Try to mount the fs and return True if successful. """
         ret = False
@@ -665,28 +680,24 @@ class FS(DeviceFormat):
             if not ret:
                 log.warning("Failed to set SELinux context for newly mounted filesystem lost+found directory at %s to %s", lost_and_found_path, lost_and_found_context)
 
-        self._mountpoint = chrootedMountpoint
-
     def unmount(self):
         """ Unmount this filesystem. """
         if not self.exists:
             raise FSError("filesystem has not been created")
 
-        if not self._mountpoint:
+        if not self.systemMountpoint:
             # not mounted
             return
 
-        if not os.path.exists(self._mountpoint):
+        if not os.path.exists(self.systemMountpoint):
             raise FSError("mountpoint does not exist")
 
         udev.settle()
-        rc = util.umount(self._mountpoint)
+        rc = util.umount(self.systemMountpoint)
         if rc:
             # try and catch whatever is causing the umount problem
-            util.run_program(["lsof", self._mountpoint])
+            util.run_program(["lsof", self.systemMountpoint])
             raise FSError("umount failed")
-
-        self._mountpoint = None
 
     def readLabel(self):
         """Read this filesystem's label.
@@ -900,7 +911,7 @@ class FS(DeviceFormat):
         # FIXME check /proc/mounts or similar
         if not self.exists:
             return False
-        return self._mountpoint is not None
+        return self.systemMountpoint is not None
 
     def sync(self, root="/"):
         pass
@@ -1272,16 +1283,17 @@ class XFS(FS):
             This is a little odd because xfs_freeze will only be
             available under the install root.
         """
-        if not self.status or not self._mountpoint.startswith(root):
+        if not self.status or not self.systemMountpoint or \
+            not self.systemMountpoint.startswith(root):
             return
 
         try:
-            util.run_program(["xfs_freeze", "-f", self.mountpoint], root=root)
+            util.run_program(["xfs_freeze", "-f", self.systemMountpoint], root=root)
         except OSError as e:
             log.error("failed to run xfs_freeze: %s", e)
 
         try:
-            util.run_program(["xfs_freeze", "-u", self.mountpoint], root=root)
+            util.run_program(["xfs_freeze", "-u", self.systemMountpoint], root=root)
         except OSError as e:
             log.error("failed to run xfs_freeze: %s", e)
 
@@ -1605,14 +1617,14 @@ class TmpFS(NoDevFS):
 
     @property
     def free(self):
-        if self._mountpoint:
-            # If self._mountpoint is defined, it means this tmpfs mount
+        if self.systemMountpoint:
+            # If self.systemMountpoint is defined, it means this tmpfs mount
             # has been mounted and there is a path we can use as a handle to
             # look-up the free space on the filesystem.
             # When running with changeroot, such as during installation,
-            # self._mountpoint is set to the full changeroot path once mounted,
-            # so even with changeroot, statvfs should still work fine.
-            st = os.statvfs(self._mountpoint)
+            # self.systemMountpoint is set to the full changeroot path once
+            # mounted so even with changeroot, statvfs should still work fine.
+            st = os.statvfs(self.systemMountpoint)
             free_space = Size(st.f_bavail*st.f_frsize)
         else:
             # Free might be called even if the tmpfs mount has not been
@@ -1646,7 +1658,7 @@ class TmpFS(NoDevFS):
         # if any mount options are defined, append them
         if self._options:
             remount_options = "%s,%s" % (remount_options, self._options)
-        return ['-o', remount_options, self._type, self._mountpoint]
+        return ['-o', remount_options, self._type, self.systemMountpoint]
 
     def doResize(self):
         # we need to override doResize, because the

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -1123,6 +1123,7 @@ class BTRFS(FS):
     def __init__(self, **kwargs):
         super(BTRFS, self).__init__(**kwargs)
         self.volUUID = kwargs.pop("volUUID", None)
+        self.subvolspec = kwargs.pop("subvolspec", None)
 
     def create(self, **kwargs):
         # filesystem creation is done in storage.devicelibs.btrfs.create_volume

--- a/blivet/mounts.py
+++ b/blivet/mounts.py
@@ -1,0 +1,90 @@
+# mounts.py
+# Active mountpoints cache.
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Vojtech Trefny <vtrefny@redhat.com>
+#
+
+from . import util
+
+import logging
+log = logging.getLogger("blivet")
+
+class MountsCache(object):
+    """ Cache object for system mountpoints; checks /proc/mounts and
+        /proc/self/mountinfo for up-to-date information.
+    """
+
+    def __init__(self):
+        self.mountsHash = 0
+        self.mountpoints = {}
+
+    def getMountpoint(self, devspec, subvolspec=None):
+        """ Get mountpoint for selected device
+
+            :param devscpec: device specification, eg. "/dev/vda1"
+            :type devspec: str
+            :param subvolspec: btrfs subvolume specification, eg. ID or name
+            :type subvolspec: str
+            :returns: mountpoint (path)
+            :rtype: str or NoneType
+
+        """
+
+        self._cacheCheck()
+
+        return self.mountpoints.get((devspec, subvolspec))
+
+    def _getActiveMounts(self):
+        """ Get information about mounted devices from /proc/mounts and
+            /proc/self/mountinfo
+        """
+
+        for line in open("/proc/mounts").readlines():
+            try:
+                (devspec, mountpoint, fstype, options, _rest) = line.split(None, 4)
+            except ValueError:
+                log.error("failed to parse /proc/mounts line: %s", line)
+                continue
+
+            if fstype == "btrfs":
+                # get the subvol name from /proc/self/mountinfo
+                for line in open("/proc/self/mountinfo").readlines():
+                    fields = line.split()
+                    _subvol = fields[3]
+                    _mountpoint = fields[4]
+                    _devspec = fields[9]
+                    if _mountpoint == mountpoint and _devspec == devspec:
+                        # empty _subvol[1:] means it is a top-level volume
+                        subvolspec = _subvol[1:] or 5
+
+                        self.mountpoints[(devspec, subvolspec)] = mountpoint
+
+            else:
+                self.mountpoints[(devspec, None)] = mountpoint
+
+    def _cacheCheck(self):
+
+        md5hash = util.md5_file("/proc/mounts")
+
+        if md5hash != self.mountsHash:
+            self.mountsHash = md5hash
+            self.mountpoints = {}
+            self._getActiveMounts()
+
+mountsCache = MountsCache()

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -9,6 +9,7 @@ import re
 import sys
 import tempfile
 import uuid
+import hashlib
 from decimal import Decimal
 from contextlib import contextmanager
 
@@ -356,6 +357,18 @@ def insert_colons(a_string):
         return insert_colons(a_string[:-2]) + ':' + suffix
     else:
         return suffix
+
+def md5_file(filename):
+
+    md5 = hashlib.md5()
+    with open(filename, "rb") as f:
+
+        block = f.read(65536)
+        while block:
+            md5.update(block)
+            block = f.read(65536)
+
+    return md5.hexdigest()
 
 class ObjectID(object):
     """This class is meant to be extended by other classes which require

--- a/tests/formats_test/fstesting.py
+++ b/tests/formats_test/fstesting.py
@@ -3,6 +3,9 @@
 import abc
 from six import add_metaclass
 
+import os
+import tempfile
+
 from tests import loopbackedtestcase
 from blivet.errors import FSError, FSResizeError
 from blivet.size import Size, ROUND_DOWN
@@ -163,6 +166,22 @@ class FSAsRoot(loopbackedtestcase.LoopBackedTestCase):
         an_fs.device = self.loopDevices[0]
         self.assertIsNone(an_fs.create())
         self.assertTrue(an_fs.testMount())
+
+    def testMountpoint(self):
+        an_fs = self._fs_class()
+        # FIXME: BTRFS fails to mount
+        if isinstance(an_fs, fs.BTRFS):
+            return
+        if not an_fs.formattable or not an_fs.mountable:
+            return
+        an_fs.device = self.loopDevices[0]
+        self.assertIsNone(an_fs.create())
+        mountpoint = tempfile.mkdtemp()
+        an_fs.mount(mountpoint=mountpoint)
+        self.assertEqual(an_fs.systemMountpoint, mountpoint)
+        an_fs.unmount()
+        self.assertIsNone(an_fs.systemMountpoint)
+        os.rmdir(mountpoint)
 
     def testResize(self):
         an_fs = self._fs_class()


### PR DESCRIPTION
New version of previous pull request -- https://github.com/rhinstaller/blivet/pull/47

Changes:
 - MountsCache is now a singleton
 - It is not neccessary to add devices to cache from devicetree
 - Opening files using "with"
 - One line return in MountsCache.getMountpoint
 - tests