### PR TITLE
Use LVname not VG-LVname when adding LVs

### DIFF
--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -145,7 +145,7 @@ class DeviceTree(object):
     def lvInfo(self):
         if self._lvs_cache is None:
             lvs = blockdev.lvm_lvs()
-            self._lvs_cache = dict((lv.lv_name, lv) for lv in lvs) # pylint: disable=attribute-defined-outside-init
+            self._lvs_cache = dict(("%s-%s" % (lv.vg_name, lv.lv_name), lv) for lv in lvs) # pylint: disable=attribute-defined-outside-init
 
         return self._lvs_cache
 


### PR DESCRIPTION
The VG-LVname string is not a key in the dictionary constructed from the 'lvm
lvs' output and if by some chance (really high on Python 3) e.g. a thin pool is
requested to be added by a thin LV, using VG-LVname as the key raises a KeyError
while the info about the pool LV is in the dictionary as expected.