### PR TITLE
Bits needed to enforce sane disk selection in anaconda

### DIFF
--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -361,23 +361,30 @@ class DeviceTree(object):
                              dryRun=dryRun,
                              callbacks=callbacks)
 
-    def getDependentDevices(self, dep):
+    def getDependentDevices(self, dep, hidden=False):
         """ Return a list of devices that depend on dep.
 
             The list includes both direct and indirect dependents.
 
             :param dep: the device whose dependents we are looking for
             :type dep: :class:`~.devices.StorageDevice`
+            :keyword bool hidden: include hidden devices in search
         """
         dependents = []
+        log_method_call(self, dep=dep, hidden=hidden)
 
         # don't bother looping looking for dependents if this is a leaf device
-        if dep.isleaf:
+        # XXX all hidden devices are leaves
+        if dep.isleaf and not hidden:
+            log.debug("dep is a leaf")
             return dependents
 
-        incomplete = [d for d in self._devices
-                            if not getattr(d, "complete", True)]
-        for device in self.devices + incomplete:
+        devices = self._devices[:]
+        if hidden:
+            devices.extend(self._hidden)
+
+        for device in devices:
+            log.debug("checking if %s depends on %s", device.name, dep.name)
             if device.dependsOn(dep):
                 dependents.append(device)
 

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -390,6 +390,21 @@ class DeviceTree(object):
 
         return dependents
 
+    def getRelatedDisks(self, disk):
+        """ Return disks related to disk by container membership.
+
+            :param :class:`~.devices.StorageDevice` disk: the disk
+            :returns: related disks
+            :rtype: set of :class:`~.devices.StorageDevice`
+
+            .. note::
+
+                The disk may be hidden.
+
+        """
+        return set(d for dep in self.getDependentDevices(disk, hidden=True)
+                        for d in dep.disks)
+
     def hide(self, device):
         """ Hide the specified device.
 


### PR DESCRIPTION
This goes with rhinstaller/anaconda#60

- move getRelatedDisks into blivet as suggested by both @vpodzime and @mulkieran
- tweak getDependentDevices to (optionally) work with hidden devices

