### PR TITLE
Wrap keys() with a list so that the dictionary can be changed

### DIFF
--- a/blivet/osinstall.py
+++ b/blivet/osinstall.py
@@ -706,7 +706,7 @@ class FSSet(object):
         devices = list(self.mountpoints.values()) + self.swapDevices
 
         # prune crypttab -- only mappings required by one or more entries
-        for name in self.cryptTab.mappings.keys():
+        for name in list(self.cryptTab.mappings.keys()):
             keep = False
             mapInfo = self.cryptTab[name]
             cryptoDev = mapInfo['device']


### PR DESCRIPTION
In Python 3 the keys() dictionary method returns and iterator,
which we can't use if we want to modify the dictionary while iterating over it 
(it raises a RuntimeError). So wrap keys() with a list to prevent this from
happening.