### PR TITLE
Fix some Python 3 compatibility issues and add the python3 subpackage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ RC_RELEASE ?= $(shell date -u +0.1.%Y%m%d%H%M%S)
 RELEASE_TAG=$(PKGNAME)-$(VERSION)-$(RELEASE)
 VERSION_TAG=$(PKGNAME)-$(VERSION)
 
+PYTHON=python2
 ZANATA_PULL_ARGS = --transdir ./po/
 ZANATA_PUSH_ARGS = --srcdir ./po/ --push-type source --force
 
@@ -27,7 +28,7 @@ po-empty:
 
 test:
 	@echo "*** Running unittests ***"
-	PYTHONPATH=.:tests/ python -m unittest discover -v -s tests/ -p '*_test.py'
+	PYTHONPATH=.:tests/ $(PYTHON) -m unittest discover -v -s tests/ -p '*_test.py'
 
 coverage:
 	@which coverage || (echo "*** Please install python-coverage ***"; exit 2)
@@ -38,10 +39,10 @@ coverage:
 clean:
 	-rm *.tar.gz blivet/*.pyc blivet/*/*.pyc ChangeLog
 	$(MAKE) -C po clean
-	python setup.py -q clean --all
+	$(PYTHON) setup.py -q clean --all
 
 install:
-	python setup.py install --root=$(DESTDIR)
+	$(PYTHON) setup.py install --root=$(DESTDIR)
 	$(MAKE) -C po install
 
 ChangeLog:
@@ -79,7 +80,7 @@ local: po-pull
 	@rm -rf $(PKGNAME)-$(VERSION).tar.gz
 	@rm -rf /tmp/$(PKGNAME)-$(VERSION) /tmp/$(PKGNAME)
 	@dir=$$PWD; cp -a $$dir /tmp/$(PKGNAME)-$(VERSION)
-	@cd /tmp/$(PKGNAME)-$(VERSION) ; python setup.py -q sdist
+	@cd /tmp/$(PKGNAME)-$(VERSION) ; $(PYTHON) setup.py -q sdist
 	@cp /tmp/$(PKGNAME)-$(VERSION)/dist/$(PKGNAME)-$(VERSION).tar.gz .
 	@rm -rf /tmp/$(PKGNAME)-$(VERSION)
 	@echo "The archive is in $(PKGNAME)-$(VERSION).tar.gz"

--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -1684,6 +1684,7 @@ class Blivet(object):
             root.swaps = [s for s in root.swaps if s]
 
             for (mountpoint, old_dev) in root.mounts.items():
+                removed = set()
                 if old_dev is None:
                     continue
 
@@ -1691,9 +1692,12 @@ class Blivet(object):
                 if new_dev is None:
                     # if the device has been removed don't include this
                     # mountpoint at all
-                    del root.mounts[mountpoint]
+                    removed.add(mountpoint)
                 else:
                     root.mounts[mountpoint] = new_dev
+
+            for mnt in removed:
+                del root.mounts[mnt]
 
         log.debug("finished Blivet copy")
         return new

--- a/blivet/devices/file.py
+++ b/blivet/devices/file.py
@@ -112,11 +112,12 @@ class FileDevice(StorageDevice):
 
         zeros = zero * block_size
         for _n in range(count):
-            os.write(fd, zeros)
+            os.write(fd, zeros.encode("utf-8"))
 
         if rem:
             # write out however many more zeros it takes to hit our size target
-            os.write(fd, zero * rem)
+            size_target = zero * rem
+            os.write(fd, size_target.encode("utf-8"))
 
         os.close(fd)
 

--- a/blivet/fcoe.py
+++ b/blivet/fcoe.py
@@ -150,19 +150,21 @@ class fcoe(object):
         for nic, dcb, auto_vlan in self.nics:
             fd = os.open(root + "/etc/fcoe/cfg-" + nic,
                          os.O_RDWR | os.O_CREAT)
-            os.write(fd, '# Created by anaconda\n')
-            os.write(fd, '# Enable/Disable FCoE service at the Ethernet port\n')
-            os.write(fd, 'FCOE_ENABLE="yes"\n')
-            os.write(fd, '# Indicate if DCB service is required at the Ethernet port\n')
+            config = '# Created by anaconda\n'
+            config += '# Enable/Disable FCoE service at the Ethernet port\n'
+            config += 'FCOE_ENABLE="yes"\n'
+            config += '# Indicate if DCB service is required at the Ethernet port\n'
+            config += 'Ethernet port\n'
             if dcb:
-                os.write(fd, 'DCB_REQUIRED="yes"\n')
+                config += 'DCB_REQUIRED="yes"\n'
             else:
-                os.write(fd, 'DCB_REQUIRED="no"\n')
-            os.write(fd, '# Indicate if VLAN discovery should be handled by fcoemon\n')
+                config += 'DCB_REQUIRED="no"\n'
+            config += '# Indicate if VLAN discovery should be handled by fcoemon\n'
             if auto_vlan:
-                os.write(fd, 'AUTO_VLAN="yes"\n')
+                config += 'AUTO_VLAN="yes"\n'
             else:
-                os.write(fd, 'AUTO_VLAN="no"\n')
+                config += 'AUTO_VLAN="no"\n'
+            os.write(fd, config.encode('utf-8'))
             os.close(fd)
 
         return

--- a/blivet/formats/__init__.py
+++ b/blivet/formats/__init__.py
@@ -22,6 +22,7 @@
 #
 
 import os
+import importlib
 from gi.repository import BlockDev as blockdev
 from gi.repository import GLib
 
@@ -106,7 +107,7 @@ def collect_device_format_classes():
         (mod_name, ext) = os.path.splitext(module_file)
         if ext == ".py" and mod_name != myfile_name and not mod_name.startswith("."):
             try:
-                globals()[mod_name] = __import__(mod_name, globals(), locals(), [], -1)
+                globals()[mod_name] = importlib.import_module("."+mod_name, package=__package__)
             except ImportError:
                 log.error("import of device format module '%s' failed", mod_name)
                 from traceback import format_exc

--- a/blivet/formats/prepboot.py
+++ b/blivet/formats/prepboot.py
@@ -76,11 +76,11 @@ class PPCPRePBoot(DeviceFormat):
             buf = '\0' * 1024 * 1024
             while length > 0:
                 if length >= len(buf):
-                    os.write(fd, buf)
+                    os.write(fd, buf.encode("utf-8"))
                     length -= len(buf)
                 else:
                     buf = '\0' * length
-                    os.write(fd, buf)
+                    os.write(fd, buf.encode("utf-8"))
                     length = 0
         except OSError as e:
             log.error("error zeroing out %s: %s", self.device, e)

--- a/blivet/iscsi.py
+++ b/blivet/iscsi.py
@@ -215,7 +215,8 @@ class iscsi(object):
         if not os.path.isdir("/etc/iscsi"):
             os.makedirs("/etc/iscsi", 0o755)
         fd = os.open(INITIATOR_FILE, os.O_RDWR | os.O_CREAT)
-        os.write(fd, "InitiatorName=%s\n" %(self.initiator))
+        initiator_name = "InitiatorName=%s\n" % self.initiator
+        os.write(fd, initiator_name.encode("utf-8"))
         os.close(fd)
         self.initiatorSet = True
 
@@ -410,7 +411,8 @@ class iscsi(object):
         if not os.path.isdir(root + "/etc/iscsi"):
             os.makedirs(root + "/etc/iscsi", 0o755)
         fd = os.open(root + INITIATOR_FILE, os.O_RDWR | os.O_CREAT)
-        os.write(fd, "InitiatorName=%s\n" %(self.initiator))
+        initiator_name = "InitiatorName=%s\n" % self.initiator
+        os.write(fd, initiator_name.encode("utf-8"))
         os.close(fd)
 
         # copy "db" files.  *sigh*

--- a/blivet/osinstall.py
+++ b/blivet/osinstall.py
@@ -549,7 +549,7 @@ class FSSet(object):
         devices = list(self.mountpoints.values()) + self.swapDevices
         devices.extend([self.dev, self.devshm, self.devpts, self.sysfs,
                         self.proc, self.selinux, self.usb, self.run])
-        devices.sort(key=lambda d: getattr(d.format, "mountpoint", None))
+        devices.sort(key=lambda d: getattr(d.format, "mountpoint", ""))
 
         for device in devices:
             if not device.format.mountable or not device.format.mountpoint:

--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -32,7 +32,7 @@ from .flags import flags
 from .devices import Device, PartitionDevice, LUKSDevice, devicePathToName
 from .size import Size
 from .i18n import _
-from .util import stringize, unicodeize
+from .util import stringize, unicodeize, compare
 
 import logging
 log = logging.getLogger("blivet")
@@ -61,7 +61,7 @@ def partitionCompare(part1, part2):
     elif part1_start is None and part2_start is not None:
         return 1
     elif part1_start is not None and part2_start is not None:
-        return cmp(part1_start, part2_start)
+        return compare(part1_start, part2_start)
 
     if part1.req_base_weight:
         ret -= part1.req_base_weight
@@ -76,16 +76,16 @@ def partitionCompare(part1, part2):
     elif not part1.req_disks and part2.req_disks:
         ret += 500
     else:
-        ret += cmp(len(part1.req_disks), len(part2.req_disks)) * 500
+        ret += compare(len(part1.req_disks), len(part2.req_disks)) * 500
 
     # primary-only to the front of the list
-    ret -= cmp(part1.req_primary, part2.req_primary) * 200
+    ret -= compare(part1.req_primary, part2.req_primary) * 200
 
     # fixed size requests to the front
-    ret += cmp(part1.req_grow, part2.req_grow) * 100
+    ret += compare(part1.req_grow, part2.req_grow) * 100
 
     # larger requests go to the front of the list
-    ret -= cmp(part1.req_base_size, part2.req_base_size) * 50
+    ret -= compare(part1.req_base_size, part2.req_base_size) * 50
 
     # potentially larger growable requests go to the front
     if part1.req_grow and part2.req_grow:
@@ -94,12 +94,12 @@ def partitionCompare(part1, part2):
         elif part1.req_max_size and not part2.req_max_size:
             ret += 25
         else:
-            ret -= cmp(part1.req_max_size, part2.req_max_size) * 25
+            ret -= compare(part1.req_max_size, part2.req_max_size) * 25
 
     # give a little bump based on mountpoint
     if hasattr(part1.format, "mountpoint") and \
        hasattr(part2.format, "mountpoint"):
-        ret += cmp(part1.format.mountpoint, part2.format.mountpoint) * 10
+        ret += compare(part1.format.mountpoint, part2.format.mountpoint) * 10
 
     if ret > 0:
         ret = 1
@@ -1766,10 +1766,10 @@ def lvCompare(lv1, lv2):
     ret = 0
 
     # larger requests go to the front of the list
-    ret -= cmp(lv1.size, lv2.size) * 100
+    ret -= compare(lv1.size, lv2.size) * 100
 
     # fixed size requests to the front
-    ret += cmp(lv1.req_grow, lv2.req_grow) * 50
+    ret += compare(lv1.req_grow, lv2.req_grow) * 50
 
     # potentially larger growable requests go to the front
     if lv1.req_grow and lv2.req_grow:
@@ -1778,7 +1778,7 @@ def lvCompare(lv1, lv2):
         elif lv1.req_max_size and not lv2.req_max_size:
             ret += 25
         else:
-            ret -= cmp(lv1.req_max_size, lv2.req_max_size) * 25
+            ret -= compare(lv1.req_max_size, lv2.req_max_size) * 25
 
     if ret > 0:
         ret = 1

--- a/blivet/size.py
+++ b/blivet/size.py
@@ -22,6 +22,7 @@
 import re
 import string
 import locale
+import sys
 from collections import namedtuple
 
 from decimal import Decimal
@@ -78,14 +79,18 @@ else:
 def _lowerASCII(s):
     """Convert a string to lowercase using only ASCII character definitions.
 
-       :param str s: string to convert
+       :param s: string instance to convert
+       :type s: str or bytes
        :returns: lower-cased string
        :rtype: str
     """
-    if six.PY2:
-        return string.translate(s, _ASCIIlower_table) # pylint: disable=no-member
-    else:
-        return str.translate(s, _ASCIIlower_table) # pylint: disable=no-member
+
+    # XXX: Python 3 has str.maketrans() and bytes.maketrans() so we should
+    # ideally use one or the other depending on the type of 's'. But it turns
+    # out we expect this function to always return string even if given bytes.
+    if not six.PY2 and isinstance(s, bytes):
+        s = s.decode(sys.getdefaultencoding())
+    return s.translate(_ASCIIlower_table) # pylint: disable=no-member
 
 def _makeSpec(prefix, suffix, xlate, lowercase=True):
     """ Synthesizes a whole word from prefix and suffix.

--- a/blivet/size.py
+++ b/blivet/size.py
@@ -42,29 +42,29 @@ _Prefix = namedtuple("Prefix", ["factor", "prefix", "abbr"])
 _DECIMAL_FACTOR = 10 ** 3
 _BINARY_FACTOR = 2 ** 10
 
-_BYTES_SYMBOL = N_(b"B")
-_BYTES_WORDS = (N_(b"bytes"), N_(b"byte"))
+_BYTES_SYMBOL = N_("B")
+_BYTES_WORDS = (N_("bytes"), N_("byte"))
 
 # Symbolic constants for units
-B = _Prefix(1, b"", b"")
+B = _Prefix(1, "", "")
 
-KB = _Prefix(_DECIMAL_FACTOR ** 1, N_(b"kilo"), N_(b"k"))
-MB = _Prefix(_DECIMAL_FACTOR ** 2, N_(b"mega"), N_(b"M"))
-GB = _Prefix(_DECIMAL_FACTOR ** 3, N_(b"giga"), N_(b"G"))
-TB = _Prefix(_DECIMAL_FACTOR ** 4, N_(b"tera"), N_(b"T"))
-PB = _Prefix(_DECIMAL_FACTOR ** 5, N_(b"peta"), N_(b"P"))
-EB = _Prefix(_DECIMAL_FACTOR ** 6, N_(b"exa"), N_(b"E"))
-ZB = _Prefix(_DECIMAL_FACTOR ** 7, N_(b"zetta"), N_(b"Z"))
-YB = _Prefix(_DECIMAL_FACTOR ** 8, N_(b"yotta"), N_(b"Y"))
+KB = _Prefix(_DECIMAL_FACTOR ** 1, N_("kilo"), N_("k"))
+MB = _Prefix(_DECIMAL_FACTOR ** 2, N_("mega"), N_("M"))
+GB = _Prefix(_DECIMAL_FACTOR ** 3, N_("giga"), N_("G"))
+TB = _Prefix(_DECIMAL_FACTOR ** 4, N_("tera"), N_("T"))
+PB = _Prefix(_DECIMAL_FACTOR ** 5, N_("peta"), N_("P"))
+EB = _Prefix(_DECIMAL_FACTOR ** 6, N_("exa"), N_("E"))
+ZB = _Prefix(_DECIMAL_FACTOR ** 7, N_("zetta"), N_("Z"))
+YB = _Prefix(_DECIMAL_FACTOR ** 8, N_("yotta"), N_("Y"))
 
-KiB = _Prefix(_BINARY_FACTOR ** 1, N_(b"kibi"), N_(b"Ki"))
-MiB = _Prefix(_BINARY_FACTOR ** 2, N_(b"mebi"), N_(b"Mi"))
-GiB = _Prefix(_BINARY_FACTOR ** 3, N_(b"gibi"), N_(b"Gi"))
-TiB = _Prefix(_BINARY_FACTOR ** 4, N_(b"tebi"), N_(b"Ti"))
-PiB = _Prefix(_BINARY_FACTOR ** 5, N_(b"pebi"), N_(b"Pi"))
-EiB = _Prefix(_BINARY_FACTOR ** 6, N_(b"exbi"), N_(b"Ei"))
-ZiB = _Prefix(_BINARY_FACTOR ** 7, N_(b"zebi"), N_(b"Zi"))
-YiB = _Prefix(_BINARY_FACTOR ** 8, N_(b"yobi"), N_(b"Yi"))
+KiB = _Prefix(_BINARY_FACTOR ** 1, N_("kibi"), N_("Ki"))
+MiB = _Prefix(_BINARY_FACTOR ** 2, N_("mebi"), N_("Mi"))
+GiB = _Prefix(_BINARY_FACTOR ** 3, N_("gibi"), N_("Gi"))
+TiB = _Prefix(_BINARY_FACTOR ** 4, N_("tebi"), N_("Ti"))
+PiB = _Prefix(_BINARY_FACTOR ** 5, N_("pebi"), N_("Pi"))
+EiB = _Prefix(_BINARY_FACTOR ** 6, N_("exbi"), N_("Ei"))
+ZiB = _Prefix(_BINARY_FACTOR ** 7, N_("zebi"), N_("Zi"))
+YiB = _Prefix(_BINARY_FACTOR ** 8, N_("yobi"), N_("Yi"))
 
 # Categories of symbolic constants
 _DECIMAL_PREFIXES = [KB, MB, GB, TB, PB, EB, ZB, YB]

--- a/blivet/size.py
+++ b/blivet/size.py
@@ -255,7 +255,7 @@ class Size(Decimal):
 
         # drop any partial byte
         size = size.to_integral_value(rounding=ROUND_DOWN)
-        self = Decimal.__new__(cls, value=size)
+        self = Decimal.__new__(cls, value=size, context=context)
         return self
 
     # Force str and unicode types since the translated sizespec may be unicode
@@ -280,26 +280,26 @@ class Size(Decimal):
         return (self.__class__, (self.convertTo(),))
 
     def __add__(self, other, context=None):
-        return Size(Decimal.__add__(self, other, context=context))
+        return Size(Decimal.__add__(self, other))
 
     # needed to make sum() work with Size arguments
     def __radd__(self, other, context=None):
-        return Size(Decimal.__radd__(self, other, context=context))
+        return Size(Decimal.__radd__(self, other))
 
     def __sub__(self, other, context=None):
         # subtraction is implemented using __add__ and negation, so we'll
         # be getting passed a Size
-        return Decimal.__sub__(self, other, context=context)
+        return Decimal.__sub__(self, other)
 
     def __mul__(self, other, context=None):
-        return Size(Decimal.__mul__(self, other, context=context))
+        return Size(Decimal.__mul__(self, other))
     __rmul__ = __mul__
 
     def __div__(self, other, context=None):
-        return Size(Decimal.__div__(self, other, context=context))
+        return Size(Decimal.__div__(self, other))
 
     def __mod__(self, other, context=None):
-        return Size(Decimal.__mod__(self, other, context=context))
+        return Size(Decimal.__mod__(self, other))
 
     def convertTo(self, spec=None):
         """ Return the size in the units indicated by the specifier.

--- a/blivet/size.py
+++ b/blivet/size.py
@@ -287,9 +287,7 @@ class Size(Decimal):
         return Size(Decimal.__radd__(self, other))
 
     def __sub__(self, other, context=None):
-        # subtraction is implemented using __add__ and negation, so we'll
-        # be getting passed a Size
-        return Decimal.__sub__(self, other)
+        return Size(Decimal.__sub__(self, other))
 
     def __mul__(self, other, context=None):
         return Size(Decimal.__mul__(self, other))

--- a/blivet/size.py
+++ b/blivet/size.py
@@ -296,6 +296,12 @@ class Size(Decimal):
     def __div__(self, other, context=None):
         return Size(Decimal.__div__(self, other))
 
+    def __truediv__(self, other, context=None):
+        return Size(Decimal.__truediv__(self, other))
+
+    def __floordiv__(self, other, context=None):
+        return Size(Decimal.__floordiv__(self, other))
+
     def __mod__(self, other, context=None):
         return Size(Decimal.__mod__(self, other))
 

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -24,7 +24,8 @@ from threading import Lock
 # this will get set to anaconda's program_log_lock in enable_installer_mode
 program_log_lock = Lock()
 
-def _run_program(argv, root='/', stdin=None, env_prune=None, stderr_to_stdout=False):
+
+def _run_program(argv, root='/', stdin=None, env_prune=None, stderr_to_stdout=False, binary_output=False):
     if env_prune is None:
         env_prune = []
 
@@ -54,6 +55,8 @@ def _run_program(argv, root='/', stdin=None, env_prune=None, stderr_to_stdout=Fa
                                     preexec_fn=chroot, cwd=root, env=env)
 
             out, err = proc.communicate()
+            if not binary_output and six.PY3:
+                out = out.decode("utf-8")
             if out:
                 if not stderr_to_stdout:
                     program_log.info("stdout:")
@@ -79,7 +82,15 @@ def run_program(*args, **kwargs):
 def capture_output(*args, **kwargs):
     return _run_program(*args, **kwargs)[1]
 
+def capture_output_binary(*args, **kwargs):
+    kwargs["binary_output"] = True
+    return _run_program(*args, **kwargs)[1]
+
 def run_program_and_capture_output(*args, **kwargs):
+    return _run_program(*args, **kwargs)
+
+def run_program_and_capture_output_binary(*args, **kwargs):
+    kwargs["binary_output"] = True
     return _run_program(*args, **kwargs)
 
 def mount(device, mountpoint, fstype, options=None):

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -448,6 +448,29 @@ def unicodeize(inputstr):
     else:
         return str(inputstr)
 
+def compare(first, second):
+    """ Compare two objects.
+
+        :param first: first object to compare
+        :param second: second object to compare
+        :returns: 0 if first == second, 1 if first > second, -1 if first < second
+        :rtype: int
+
+        This method replaces Python 2 cmp() built-in-function.
+    """
+
+    if first == None and second == None:
+        return 0
+
+    elif first == None:
+        return -1
+
+    elif second == None:
+        return 1
+
+    else:
+        return (first > second) - (first < second)
+
 ##
 ## Convenience functions for examples and tests
 ##

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -382,7 +382,8 @@ class ObjectID(object):
     _newid_gen = functools.partial(next, itertools.count())
 
     def __new__(cls, *args, **kwargs):
-        self = super(ObjectID, cls).__new__(cls, *args, **kwargs)
+        # pylint: disable=unused-argument
+        self = super(ObjectID, cls).__new__(cls)
         self.id = self._newid_gen() # pylint: disable=attribute-defined-outside-init
         return self
 

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -8,6 +8,7 @@ License: LGPLv2+
 Group: System Environment/Libraries
 %define realname blivet
 Source0: http://github.com/dwlehman/blivet/archive/%{realname}-%{version}.tar.gz
+%global with_python3 1
 
 # Versions of required components (done so we make sure the buildrequires
 # match the requires versions of things).
@@ -22,6 +23,10 @@ BuildArch: noarch
 BuildRequires: gettext
 BuildRequires: python-setuptools
 
+%if 0%{with_python3}
+BuildRequires: python3-devel python3-setuptools
+%endif
+
 Requires: python
 Requires: python-six
 Requires: python-kickstart >= %{pykickstartver}
@@ -32,6 +37,7 @@ Requires: pyparted >= %{pypartedver}
 Requires: dosfstools
 Requires: e2fsprogs >= %{e2fsver}
 Requires: lsof
+Requires: libselinux-python
 Requires: libblockdev >= %{libblockdevver}
 Requires: libblockdev-plugins-all >= %{libblockdevver}
 
@@ -39,8 +45,35 @@ Requires: libblockdev-plugins-all >= %{libblockdevver}
 The python-blivet package is a python module for examining and modifying
 storage configuration.
 
+%if 0%{with_python3}
+%package -n python3-%{realname}
+Summary: A python3 package for examining and modifying storage configuration.
+Requires: python3
+Requires: python3-six
+Requires: python3-kickstart
+Requires: python3-pyudev
+Requires: parted >= %{partedver}
+Requires: python3-pyparted >= %{pypartedver}
+Requires: libselinux-python3
+Requires: libblockdev >= %{libblockdevver}
+Requires: libblockdev-plugins-all >= %{libblockdevver}
+Requires: util-linux >= %{utillinuxver}
+Requires: dosfstools
+Requires: e2fsprogs >= %{e2fsver}
+Requires: lsof
+
+%description -n python3-%{realname}
+The python3-%{realname} is a python3 package for examining and modifying storage
+configuration.
+%endif
+
 %prep
 %setup -q -n %{realname}-%{version}
+
+%if 0%{?with_python3}
+rm -rf %{py3dir}
+cp -a . %{py3dir}
+%endif
 
 %build
 make
@@ -50,11 +83,24 @@ rm -rf %{buildroot}
 make DESTDIR=%{buildroot} install
 %find_lang %{realname}
 
+%if 0%{?with_python3}
+pushd %{py3dir}
+make PYTHON=%{__python3} DESTDIR=%{buildroot} install
+popd
+%endif
+
 %files -f %{realname}.lang
 %defattr(-,root,root,-)
 %license COPYING
 %doc README ChangeLog examples
 %{python_sitelib}/*
+
+%if 0%{?with_python3}
+%files -n python3-%{realname}
+%license COPYING
+%doc README ChangeLog examples
+%{python3_sitelib}/*
+%endif
 
 %changelog
 * Fri Mar 27 2015 Brian C. Lane <bcl@redhat.com> - 1.2-1

--- a/tests/formats_test/labeling_test.py
+++ b/tests/formats_test/labeling_test.py
@@ -76,12 +76,12 @@ class MethodsTestCase(unittest.TestCase):
 
         # JFS, XFS use a -L flag
         lflag_classes = [fs.JFS, fs.XFS]
-        for name, klass in [(k, v) for k, v in self.fs.items() if any(isinstance(v, c) for c in lflag_classes)]:
-            self.assertEqual(klass._labelfs.label_app.setLabelCommand(v), [klass._labelfs.label_app.name, "-L", "myfs", "/dev"], msg=name)
+        for name, klass in ((k, v) for k, v in self.fs.items() if any(isinstance(v, c) for c in lflag_classes)):
+            self.assertEqual(klass._labelfs.label_app.setLabelCommand(klass), [klass._labelfs.label_app.name, "-L", "myfs", "/dev"], msg=name)
 
         # Ext2FS and descendants and FATFS do not use a flag
         noflag_classes = [fs.Ext2FS, fs.FATFS]
-        for name, klass in [(k, v) for k, v in self.fs.items() if any(isinstance(v, c) for c in noflag_classes)]:
+        for name, klass in ((k, v) for k, v in self.fs.items() if any(isinstance(v, c) for c in noflag_classes)):
             self.assertEqual(klass._labelfs.label_app.setLabelCommand(klass), [klass._labelfs.label_app.name, "/dev", "myfs"], msg=name)
 
         # all of the remaining are non-labeling so will accept any label

--- a/tests/size_test.py
+++ b/tests/size_test.py
@@ -21,6 +21,9 @@
 #
 # Red Hat Author(s): David Cantrell <dcantrell@redhat.com>
 
+# we need integer division to work the same with both Python 2 and 3
+from __future__ import division
+
 import locale
 import os
 import unittest
@@ -149,10 +152,10 @@ class SizeTestCase(unittest.TestCase):
         self.assertEquals(s.humanReadable(max_places=None), "63.9990234375 KiB")
 
         # deviation is less than 1/2 of 1% of 1024
-        s = Size(16384 - (1024/100/2))
+        s = Size(16384 - (1024/100//2))
         self.assertEquals(s.humanReadable(max_places=2), "16 KiB")
         # deviation is greater than 1/2 of 1% of 1024
-        s = Size(16384 - ((1024/100/2) + 1))
+        s = Size(16384 - ((1024/100//2) + 1))
         self.assertEquals(s.humanReadable(max_places=2), "15.99 KiB")
 
         s = Size(0x10000000000000)
@@ -383,6 +386,7 @@ class UtilityMethodsTestCase(unittest.TestCase):
         self.assertIsInstance(s-2, Size)
         self.assertIsInstance(s*2, Size)
         self.assertIsInstance(s/2, Size)
+        self.assertIsInstance(s//2, Size)
         self.assertIsInstance(s**2, Decimal)
         self.assertIsInstance(s % 127, Size)
 

--- a/tests/size_test.py
+++ b/tests/size_test.py
@@ -226,19 +226,19 @@ class TranslationTestCase(unittest.TestCase):
             locale.setlocale(locale.LC_ALL, '')
 
             # untranslated specs
-            self.assertEqual(size._makeSpec(b"", b"BYTES", False), b"bytes")
-            self.assertEqual(size._makeSpec(b"Mi", b"b", False), b"mib")
+            self.assertEqual(size._makeSpec("", "BYTES", False), "bytes")
+            self.assertEqual(size._makeSpec("Mi", "b", False), "mib")
 
             # un-lower-cased specs
-            self.assertEqual(size._makeSpec(b"", b"BYTES", False, False), b"BYTES")
-            self.assertEqual(size._makeSpec(b"Mi", b"b", False, False), b"Mib")
-            self.assertEqual(size._makeSpec(b"Mi", b"B", False, False), b"MiB")
+            self.assertEqual(size._makeSpec("", "BYTES", False, False), "BYTES")
+            self.assertEqual(size._makeSpec("Mi", "b", False, False), "Mib")
+            self.assertEqual(size._makeSpec("Mi", "B", False, False), "MiB")
 
             # translated specs
-            res = size._makeSpec(b"", b"bytes", True)
+            res = size._makeSpec("", "bytes", True)
 
-            # Note that exp != _(b"bytes").lower() as one might expect
-            exp = (_(b"") + _(b"bytes")).lower()
+            # Note that exp != _("bytes").lower() as one might expect
+            exp = (_("") + _("bytes")).lower()
             self.assertEqual(res, exp)
 
     def testParseSpec(self):
@@ -363,8 +363,8 @@ class UtilityMethodsTestCase(unittest.TestCase):
 
     def testLowerASCII(self):
         """ Tests for _lowerASCII. """
-        self.assertEqual(size._lowerASCII(b""), b"")
-        self.assertEqual(size._lowerASCII(b"B"), b"b")
+        self.assertEqual(size._lowerASCII(""), "")
+        self.assertEqual(size._lowerASCII("B"), "b")
 
     def testArithmetic(self):
         s = Size("2GiB")


### PR DESCRIPTION
Fixes for Python 3 compatibility issues discovered while running tests with Python 3 including hundreds of installations with Python 3 Anaconda. With all that passing in the end, I decided to add the pieces that make sure the python3 subpackage is built too (tested in [Copr builds] (https://copr.fedoraproject.org/coprs/bkabrda/py3anaconda/builds/)).

**Disclaimer:** 
These patches don't try to fix anything else than Python 3 incompatibilities in the most straightforward way. Many changes are subject for future improvements and nicer solutions.