### PR TITLE
Pickling support for Size

### DIFF
--- a/blivet/size.py
+++ b/blivet/size.py
@@ -269,6 +269,11 @@ class Size(Decimal):
     def __deepcopy__(self, memo):
         return Size(self.convertTo())
 
+    # pickling support for Size
+    # see https://docs.python.org/3/library/pickle.html#object.__reduce__
+    def __reduce__(self):
+        return (self.__class__, (self.convertTo(),))
+
     def __add__(self, other, context=None):
         return Size(Decimal.__add__(self, other, context=context))
 

--- a/tests/size_test.py
+++ b/tests/size_test.py
@@ -25,6 +25,8 @@ import locale
 import os
 import unittest
 
+from six.moves import cPickle
+
 from decimal import Decimal
 
 from blivet.i18n import _
@@ -193,6 +195,10 @@ class SizeTestCase(unittest.TestCase):
         self.assertEqual(size.parseSpec("1e-1 KB"), Decimal(100))
         self.assertEqual(size.parseSpec("1E-4KB"), Decimal("0.1"))
         self.assertEqual(Size("1E-10KB"), Size(0))
+
+    def testPickling(self):
+        s = Size("10 MiB")
+        self.assertEqual(s, cPickle.loads(cPickle.dumps(s)))
 
 class TranslationTestCase(unittest.TestCase):
 


### PR DESCRIPTION
I need to pickle size instances in blivet-gui for multiprocess communication and \__reduce__ function inherited from decimal causes precision loss and other problems.