### PR TITLE
Do not continue when presented with unusable storage configurations

### DIFF
--- a/blivet/errors.py
+++ b/blivet/errors.py
@@ -20,6 +20,8 @@
 # Red Hat Author(s): Dave Lehman <dlehman@redhat.com>
 #
 
+from .i18n import N_
+
 class StorageError(Exception):
     def __init__(self, *args, **kwargs):
         self.hardware_fault = kwargs.pop("hardware_fault", False)
@@ -129,7 +131,25 @@ class DeviceNotFoundError(StorageError):
 
 class UnusableConfigurationError(StorageError):
     """ User has an unusable initial storage configuration. """
-    pass
+    suggestion = ""
+
+class DiskLabelScanError(UnusableConfigurationError):
+    suggestion = N_("For some reason we were unable to locate a disklabel on a "
+                    "disk that the kernel is reporting partitions on. It is "
+                    "unclear what the exact problem is. Please file a bug at "
+                    "http://bugzilla.redhat.com")
+
+class CorruptGPTError(UnusableConfigurationError):
+    suggestion = N_("Either restore the disklabel to a completely working "
+                    "state or remove it completely.\n"
+                    "Hint: parted can restore it or wipefs can remove it.")
+
+class DuplicateVGError(UnusableConfigurationError):
+    suggestion = N_("Rename one of the volume groups so the names are "
+                    "distinct.\n"
+                    "Hint 1: vgrename accepts UUID in place of the old name.\n"
+                    "Hint 2: You can get the VG UUIDs by running "
+                    "'pvs -o +vg_uuid'.")
 
 # DeviceAction
 class DeviceActionError(StorageError):

--- a/blivet/osinstall.py
+++ b/blivet/osinstall.py
@@ -1114,7 +1114,16 @@ def storageInitialize(storage, ksdata, protected):
     if protected:
         storage.config.protectedDevSpecs.extend(protected)
 
-    storage.reset()
+    while True:
+        try:
+            storage.reset()
+        except StorageError as e:
+            if errorHandler.cb(e) == ERROR_RAISE:
+                raise
+            else:
+                continue
+        else:
+            break
 
     if protected and not flags.live_install and \
        not any(d.protected for d in storage.devices):

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -13,7 +13,7 @@ Source0: http://github.com/dwlehman/blivet/archive/%{realname}-%{version}.tar.gz
 # match the requires versions of things).
 %define pykickstartver 1.99.22
 %define partedver 1.8.1
-%define pypartedver 2.5-2
+%define pypartedver 3.10.3
 %define e2fsver 1.41.0
 %define utillinuxver 2.15.1
 %define libblockdevver 0.6


### PR DESCRIPTION
There are some issues that must be resolved before blivet can do anything useful. The two that this PR addresses are multiple LVM VGs with the same name and disklabel corruption that prevents parted from acknowledging a disklabel when partitions are present on the disk.

Until the lvm tools accept UUID in place of VG name for at least lvremove, vgchange, and vgremove we have no way to work with multiple VGs with the same name. This related bug has been sitting since 2008: https://bugzilla.redhat.com/show_bug.cgi?id=449832

The first patch enables parted to proceed with a partially-corrupt GPT disklabel, but I suspect it will not cover all such cases, hence the exception handling.

There will soon be an accompanying anaconda PR that handles these exceptions by showing the error and the suggested course of action to the user.