### PR TITLE
Add libselinux-python to package dependencies (#1211834)

### DIFF
--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -34,6 +34,7 @@ Requires: e2fsprogs >= %{e2fsver}
 Requires: lsof
 Requires: libblockdev >= %{libblockdevver}
 Requires: libblockdev-plugins-all >= %{libblockdevver}
+Requires: libselinux-python
 
 %description
 The python-blivet package is a python module for examining and modifying


### PR DESCRIPTION
Blivet imports selinux module but doen't depend on libselinux-python (only anaconda-core depends on that). Resolves https://bugzilla.redhat.com/show_bug.cgi?id=1211834