### PR TITLE
Make use of the new libblockdev error reporting

### DIFF
--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -79,7 +79,7 @@ def _set_global_config():
     if not flags.lvm_metadata_backup:
         config_string += "backup {backup=0 archive=0} "
 
-    blockdev.lvm_set_global_config(config_string)
+    blockdev.lvm.set_global_config(config_string)
 
 def needs_config_refresh(fn):
     def fn_with_refresh(*args, **kwargs):

--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -204,13 +204,13 @@ class DMRaidArrayDevice(DMDevice, ContainerDevice):
         """ Deactivate the raid set. """
         log_method_call(self, self.name, status=self.status)
         # This call already checks if the set is not active.
-        blockdev.dm_deactivate_raid_set(self.name)
+        blockdev.dm.deactivate_raid_set(self.name)
 
     def activate(self):
         """ Activate the raid set. """
         log_method_call(self, self.name, status=self.status)
         # This call already checks if the set is active.
-        blockdev.dm_activate_raid_set(self.name)
+        blockdev.dm.activate_raid_set(self.name)
         udev.settle()
 
     def _setup(self, orig=False):
@@ -236,7 +236,7 @@ class DMRaidArrayDevice(DMDevice, ContainerDevice):
 
     @property
     def description(self):
-        return "BIOS RAID set (%s)" % blockdev.dm_get_raid_set_type(self.name)
+        return "BIOS RAID set (%s)" % blockdev.dm.get_raid_set_type(self.name)
 
     @property
     def model(self):

--- a/blivet/devices/dm.py
+++ b/blivet/devices/dm.py
@@ -22,7 +22,6 @@
 
 import os
 from gi.repository import BlockDev as blockdev
-from gi.repository import GLib
 
 from .. import errors
 from .. import util
@@ -97,8 +96,8 @@ class DMDevice(StorageDevice):
     @property
     def status(self):
         try:
-            return blockdev.dm_map_exists(self.mapName, True, True)
-        except GLib.GError as e:
+            return blockdev.dm.map_exists(self.mapName, True, True)
+        except blockdev.DMError as e:
             if "Not running as root" in e.message:
                 return False
             else:
@@ -113,7 +112,7 @@ class DMDevice(StorageDevice):
         if not self.exists:
             raise errors.DeviceError("device has not been created", self.name)
 
-        return blockdev.dm_node_from_name(self.name)
+        return blockdev.dm.node_from_name(self.name)
 
     def setupPartitions(self):
         log_method_call(self, name=self.name, kids=self.kids)
@@ -131,7 +130,7 @@ class DMDevice(StorageDevice):
         for dev in os.listdir("/dev/mapper/"):
             prefix = self.name + "p"
             if dev.startswith(prefix) and dev[len(prefix):].isdigit():
-                blockdev.dm_remove(dev)
+                blockdev.dm.remove(dev)
 
     def _setName(self, value):
         """ Set the device's map name. """
@@ -186,7 +185,7 @@ class DMLinearDevice(DMDevice):
         log_method_call(self, self.name, orig=orig, status=self.status,
                         controllable=self.controllable)
         slave_length = self.slave.partedDevice.length
-        blockdev.dm_create_linear(self.name, self.slave.path, slave_length,
+        blockdev.dm.create_linear(self.name, self.slave.path, slave_length,
                                   self.dmUuid)
 
     def _postSetup(self):
@@ -197,7 +196,7 @@ class DMLinearDevice(DMDevice):
     def _teardown(self, recursive=False):
         self.teardownPartitions()
         udev.settle()
-        blockdev.dm_remove(self.name)
+        blockdev.dm.remove(self.name)
         udev.settle()
 
     def deactivate(self, recursive=False):

--- a/blivet/devices/loop.py
+++ b/blivet/devices/loop.py
@@ -73,7 +73,7 @@ class LoopDevice(StorageDevice):
             # if our name is loopN we must already be active
             return self.name
 
-        name = blockdev.loop_get_loop_name(self.slave.path)
+        name = blockdev.loop.get_loop_name(self.slave.path)
         if name.startswith("loop"):
             self.name = name
 
@@ -83,7 +83,7 @@ class LoopDevice(StorageDevice):
     def status(self):
         return (self.slave.status and
                 self.name.startswith("loop") and
-                blockdev.loop_get_loop_name(self.slave.path) == self.name)
+                blockdev.loop.get_loop_name(self.slave.path) == self.name)
 
     @property
     def size(self):
@@ -98,7 +98,7 @@ class LoopDevice(StorageDevice):
         """ Open, or set up, a device. """
         log_method_call(self, self.name, orig=orig, status=self.status,
                         controllable=self.controllable)
-        blockdev.loop_setup(self.slave.path)
+        blockdev.loop.setup(self.slave.path)
 
     def _postSetup(self):
         StorageDevice._postSetup(self)
@@ -109,7 +109,7 @@ class LoopDevice(StorageDevice):
         """ Close, or tear down, a device. """
         log_method_call(self, self.name, status=self.status,
                         controllable=self.controllable)
-        blockdev.loop_teardown(self.path)
+        blockdev.loop.teardown(self.path)
 
     def _postTeardown(self, recursive=False):
         StorageDevice._postTeardown(self, recursive=recursive)

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -25,7 +25,6 @@ import abc
 import pprint
 import re
 from gi.repository import BlockDev as blockdev
-from gi.repository import GLib
 
 # device backend modules
 from ..devicelibs import lvm
@@ -55,7 +54,7 @@ class LVMVolumeGroupDevice(ContainerDevice):
 
     @staticmethod
     def get_supported_pe_sizes():
-        return [Size(pe_size) for pe_size in blockdev.lvm_get_supported_pe_sizes()]
+        return [Size(pe_size) for pe_size in blockdev.lvm.get_supported_pe_sizes()]
 
     def __init__(self, name, parents=None, size=None, free=None,
                  peSize=None, peCount=None, peFree=None, pvCount=None,
@@ -200,13 +199,13 @@ class LVMVolumeGroupDevice(ContainerDevice):
         """ Close, or tear down, a device. """
         log_method_call(self, self.name, status=self.status,
                         controllable=self.controllable)
-        blockdev.lvm_vgdeactivate(self.name)
+        blockdev.lvm.vgdeactivate(self.name)
 
     def _create(self):
         """ Create the device. """
         log_method_call(self, self.name, status=self.status)
         pv_list = [pv.path for pv in self.parents]
-        blockdev.lvm_vgcreate(self.name, pv_list, self.peSize)
+        blockdev.lvm.vgcreate(self.name, pv_list, self.peSize)
 
     def _postCreate(self):
         self._complete = True
@@ -229,9 +228,9 @@ class LVMVolumeGroupDevice(ContainerDevice):
             # the same name that we want to keep/use.
             return
 
-        blockdev.lvm_vgreduce(self.name, None)
-        blockdev.lvm_vgdeactivate(self.name)
-        blockdev.lvm_vgremove(self.name)
+        blockdev.lvm.vgreduce(self.name, None)
+        blockdev.lvm.vgdeactivate(self.name)
+        blockdev.lvm.vgremove(self.name)
 
     def _remove(self, member):
         status = []
@@ -240,15 +239,15 @@ class LVMVolumeGroupDevice(ContainerDevice):
             if lv.exists:
                 lv.setup()
 
-        blockdev.lvm_pvmove(member.path)
-        blockdev.lvm_vgreduce(self.name, member.path)
+        blockdev.lvm.pvmove(member.path)
+        blockdev.lvm.vgreduce(self.name, member.path)
 
         for (lv, status) in zip(self.lvs, status):
             if lv.status and not status:
                 lv.teardown()
 
     def _add(self, member):
-        blockdev.lvm_vgextend(self.name, member.path)
+        blockdev.lvm.vgextend(self.name, member.path)
 
     def _addLogVol(self, lv):
         """ Add an LV to this VG. """
@@ -602,7 +601,7 @@ class LVMLogicalVolumeDevice(DMDevice):
         if not self.exists:
             raise errors.DeviceError("device has not been created", self.name)
 
-        return blockdev.dm_node_from_name(self.mapName)
+        return blockdev.dm.node_from_name(self.mapName)
 
     def _getName(self):
         """ This device's name. """
@@ -626,13 +625,13 @@ class LVMLogicalVolumeDevice(DMDevice):
         """ Open, or set up, a device. """
         log_method_call(self, self.name, orig=orig, status=self.status,
                         controllable=self.controllable)
-        blockdev.lvm_lvactivate(self.vg.name, self._name)
+        blockdev.lvm.lvactivate(self.vg.name, self._name)
 
     def _teardown(self, recursive=None):
         """ Close, or tear down, a device. """
         log_method_call(self, self.name, status=self.status,
                         controllable=self.controllable)
-        blockdev.lvm_lvdeactivate(self.vg.name, self._name)
+        blockdev.lvm.lvdeactivate(self.vg.name, self._name)
 
     def _postTeardown(self, recursive=False):
         try:
@@ -650,8 +649,8 @@ class LVMLogicalVolumeDevice(DMDevice):
         super(LVMLogicalVolumeDevice, self)._preCreate()
 
         try:
-            vg_info = blockdev.lvm_vginfo(self.vg.name)
-        except GLib.GError as lvmerr:
+            vg_info = blockdev.lvm.vginfo(self.vg.name)
+        except blockdev.LVMError as lvmerr:
             log.error("Failed to get free space for the %s VG: %s", self.vg.name, lvmerr)
             # nothing more can be done, we don't know the VG's free space
             return
@@ -670,7 +669,7 @@ class LVMLogicalVolumeDevice(DMDevice):
         """ Create the device. """
         log_method_call(self, self.name, status=self.status)
         # should we use --zero for safety's sake?
-        blockdev.lvm_lvcreate(self.vg.name, self._name, self.size)
+        blockdev.lvm.lvcreate(self.vg.name, self._name, self.size)
 
     def _preDestroy(self):
         StorageDevice._preDestroy(self)
@@ -680,7 +679,7 @@ class LVMLogicalVolumeDevice(DMDevice):
     def _destroy(self):
         """ Destroy the device. """
         log_method_call(self, self.name, status=self.status)
-        blockdev.lvm_lvremove(self.vg.name, self._name)
+        blockdev.lvm.lvremove(self.vg.name, self._name)
 
     def resize(self):
         log_method_call(self, self.name, status=self.status)
@@ -694,7 +693,7 @@ class LVMLogicalVolumeDevice(DMDevice):
             self.format.teardown()
 
         udev.settle()
-        blockdev.lvm_lvresize(self.vg.name, self._name, self.size)
+        blockdev.lvm.lvresize(self.vg.name, self._name, self.size)
 
     @property
     def isleaf(self):
@@ -883,7 +882,7 @@ class LVMSnapShotBase(object):
             pass
 
         udev.settle()
-        blockdev.lvm_lvsnapshotmerge(self.vg.name, self.lvname) # pylint: disable=no-member
+        blockdev.lvm.lvsnapshotmerge(self.vg.name, self.lvname) # pylint: disable=no-member
 
 
 class LVMSnapShotDevice(LVMSnapShotBase, LVMLogicalVolumeDevice):
@@ -948,7 +947,7 @@ class LVMSnapShotDevice(LVMSnapShotBase, LVMLogicalVolumeDevice):
     def _create(self):
         """ Create the device. """
         log_method_call(self, self.name, status=self.status)
-        blockdev.lvm_lvsnapshotcreate(self.vg.name, self.origin.lvname, self._name, self.size)
+        blockdev.lvm.lvsnapshotcreate(self.vg.name, self.origin.lvname, self._name, self.size)
 
     def _destroy(self):
         """ Destroy the device. """
@@ -956,7 +955,7 @@ class LVMSnapShotDevice(LVMSnapShotBase, LVMLogicalVolumeDevice):
         # old-style snapshots' status is tied to the origin's so we never
         # explicitly activate or deactivate them and we have to tell lvremove
         # that it is okay to remove the active snapshot
-        blockdev.lvm_lvremove(self.vg.name, self._name, force=True)
+        blockdev.lvm.lvremove(self.vg.name, self._name, force=True)
 
     def _getPartedDevicePath(self):
         return "%s-cow" % self.path
@@ -1010,11 +1009,11 @@ class LVMThinPoolDevice(LVMLogicalVolumeDevice):
 
         """
         if metadatasize is not None and \
-           not blockdev.lvm_is_valid_thpool_md_size(metadatasize):
+           not blockdev.lvm.is_valid_thpool_md_size(metadatasize):
             raise ValueError("invalid metadatasize value")
 
         if chunksize is not None and \
-           not blockdev.lvm_is_valid_thpool_chunk_size(chunksize):
+           not blockdev.lvm.is_valid_thpool_chunk_size(chunksize):
             raise ValueError("invalid chunksize value")
 
         super(LVMThinPoolDevice, self).__init__(name, parents=parents,
@@ -1056,7 +1055,7 @@ class LVMThinPoolDevice(LVMLogicalVolumeDevice):
     @property
     def vgSpaceUsed(self):
         space = super(LVMThinPoolDevice, self).vgSpaceUsed
-        space += Size(blockdev.lvm_get_thpool_padding(space, self.vg.peSize))
+        space += Size(blockdev.lvm.get_thpool_padding(space, self.vg.peSize))
         return space
 
     @property
@@ -1075,7 +1074,7 @@ class LVMThinPoolDevice(LVMLogicalVolumeDevice):
         else:
             profile_name = None
         # TODO: chunk size, data/metadata split --> profile
-        blockdev.lvm_thpoolcreate(self.vg.name, self.lvname, self.size,
+        blockdev.lvm.thpoolcreate(self.vg.name, self.lvname, self.size,
                                   md_size=self.metaDataSize,
                                   chunk_size=self.chunkSize,
                                   profile=profile_name)
@@ -1144,7 +1143,7 @@ class LVMThinLogicalVolumeDevice(LVMLogicalVolumeDevice):
     def _create(self):
         """ Create the device. """
         log_method_call(self, self.name, status=self.status)
-        blockdev.lvm_thlvcreate(self.vg.name, self.pool.lvname, self.lvname,
+        blockdev.lvm.thlvcreate(self.vg.name, self.pool.lvname, self.lvname,
                                 self.size)
 
     def removeHook(self, modparent=True):
@@ -1215,7 +1214,7 @@ class LVMThinSnapShotDevice(LVMSnapShotBase, LVMThinLogicalVolumeDevice):
         """ Open, or set up, a device. """
         log_method_call(self, self.name, orig=orig, status=self.status,
                         controllable=self.controllable)
-        blockdev.lvm_lvactivate(self.vg.name, self._name, ignore_skip=True)
+        blockdev.lvm.lvactivate(self.vg.name, self._name, ignore_skip=True)
 
     def _create(self):
         """ Create the device. """
@@ -1226,7 +1225,7 @@ class LVMThinSnapShotDevice(LVMSnapShotBase, LVMThinLogicalVolumeDevice):
             # to use
             pool_name = self.pool.lvname
 
-        blockdev.lvm_thsnapshotcreate(self.vg.name, self._name, self.origin.lvname,
+        blockdev.lvm.thsnapshotcreate(self.vg.name, self._name, self.origin.lvname,
                                       pool_name=pool_name)
 
     def dependsOn(self, dep):

--- a/blivet/devices/md.py
+++ b/blivet/devices/md.py
@@ -23,7 +23,6 @@ import os
 import six
 
 from gi.repository import BlockDev as blockdev
-from gi.repository import GLib
 
 from ..devicelibs import mdraid, raid
 
@@ -133,8 +132,8 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
 
         if self.uuid is not None:
             try:
-                formatted_uuid = blockdev.md_get_md_uuid(self.uuid)
-            except GLib.GError:
+                formatted_uuid = blockdev.md.get_md_uuid(self.uuid)
+            except blockdev.MDRaidError:
                 pass
 
         return formatted_uuid
@@ -196,7 +195,7 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
            :returns: estimated superblock size
            :rtype: :class:`~.size.Size`
         """
-        return blockdev.md_get_superblock_size(raw_array_size,
+        return blockdev.md.get_superblock_size(raw_array_size,
                                                version=self.metadataVersion)
 
     @property
@@ -210,7 +209,7 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
                     self.memberDevices,
                     self.chunkSize,
                     self.getSuperBlockSize)
-            except (GLib.GError, errors.RaidError) as e:
+            except (blockdev.MDRaidError, errors.RaidError) as e:
                 log.info("could not calculate size of device %s for raid level %s: %s", self.name, self.level, e)
                 size = Size(0)
             log.debug("non-existent RAID %s size == %s", self.level, size)
@@ -425,7 +424,7 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
             member.setup(orig=orig)
             disks.append(member.path)
 
-        blockdev.md_activate(self.path, members=disks, uuid=self.mdadmFormatUUID)
+        blockdev.md.activate(self.path, members=disks, uuid=self.mdadmFormatUUID)
 
     def _postTeardown(self, recursive=False):
         super(MDRaidArrayDevice, self)._postTeardown(recursive=recursive)
@@ -446,7 +445,7 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
         # file exists, we want to deactivate it. mdraid has too many
         # states.
         if self.exists and os.path.exists(self.path):
-            blockdev.md_deactivate(self.path)
+            blockdev.md.deactivate(self.path)
 
         self._postTeardown(recursive=recursive)
 
@@ -474,7 +473,7 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
 
         # update our uuid attribute with the new array's UUID
         # XXX this won't work for containers since no UUID is reported for them
-        info = blockdev.md_detail(self.path)
+        info = blockdev.md.detail(self.path)
         self.uuid = info.uuid
         for member in self.devices:
             member.format.mdUuid = self.uuid
@@ -487,7 +486,7 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
         level = None
         if self.level:
             level = str(self.level)
-        blockdev.md_create(self.path, level, disks, spares,
+        blockdev.md.create(self.path, level, disks, spares,
                            version=self.metadataVersion,
                            bitmap=self.createBitmap)
         udev.settle()
@@ -496,14 +495,14 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
         self.setup()
         # see if the device must be marked as failed before it can be removed
         fail = (self.memberStatus(member) == "in_sync")
-        blockdev.md_remove(self.path, member.path, fail)
+        blockdev.md.remove(self.path, member.path, fail)
 
     def _add(self, member):
         """ Add a member device to an array.
 
            :param str member: the member's path
 
-           :raises: GLib.GError
+           :raises: blockdev.MDRaidError
         """
         self.setup()
 
@@ -511,11 +510,11 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
         try:
             if not self.level.has_redundancy():
                 if self.level is not raid.Linear:
-                    raid_devices = int(blockdev.md_detail(self.name).raid_devices) + 1
+                    raid_devices = int(blockdev.md.detail(self.name).raid_devices) + 1
         except errors.RaidError:
             pass
 
-        blockdev.md_add(self.path, member.path, raid_devs=raid_devices)
+        blockdev.md.add(self.path, member.path, raid_devs=raid_devices)
 
     @property
     def formatArgs(self):

--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -23,7 +23,6 @@ import os
 import parted
 import _ped
 from gi.repository import BlockDev as blockdev
-from gi.repository import GLib
 
 from .. import errors
 from .. import util
@@ -692,8 +691,8 @@ class PartitionDevice(StorageDevice):
             # self.exists has been unset, so don't use self.status
             if os.path.exists(self.path):
                 try:
-                    blockdev.dm_remove(self.name)
-                except GLib.GError:
+                    blockdev.dm.remove(self.name)
+                except blockdev.DMError:
                     pass
 
     def _getSize(self):

--- a/blivet/formats/__init__.py
+++ b/blivet/formats/__init__.py
@@ -23,7 +23,6 @@
 
 import os
 from gi.repository import BlockDev as blockdev
-from gi.repository import GLib
 
 from ..util import notify_kernel
 from ..util import get_sysfs_path_by_name
@@ -345,14 +344,14 @@ class DeviceFormat(ObjectID):
 
         if self.device.startswith("/dev/mapper/"):
             try:
-                name = blockdev.dm_node_from_name(os.path.basename(self.device))
-            except GLib.GError:
+                name = blockdev.dm.node_from_name(os.path.basename(self.device))
+            except blockdev.DMError:
                 log.warning("failed to get dm node for %s", self.device)
                 return
         elif self.device.startswith("/dev/md/"):
             try:
-                name = blockdev.md_node_from_name(os.path.basename(self.device))
-            except GLib.GError:
+                name = blockdev.md.node_from_name(os.path.basename(self.device))
+            except blockdev.MDRaidError:
                 log.warning("failed to get md node for %s", self.device)
                 return
         else:

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -1125,11 +1125,11 @@ class BTRFS(FS):
         self.volUUID = kwargs.pop("volUUID", None)
 
     def create(self, **kwargs):
-        # filesystem creation is done in blockdev.btrfs_create_volume
+        # filesystem creation is done in blockdev.btrfs.create_volume
         self.exists = True
 
     def destroy(self, **kwargs):
-        # filesystem deletion is done in blockdev.btrfs_delete_volume
+        # filesystem deletion is done in blockdev.btrfs.delete_volume
         self.exists = False
 
     def setup(self, **kwargs):

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -182,7 +182,7 @@ class LUKS(DeviceFormat):
             return
 
         DeviceFormat.setup(self, **kwargs)
-        blockdev.crypto_luks_open(self.device, self.mapName,
+        blockdev.crypto.luks_open(self.device, self.mapName,
                                   passphrase=self.__passphrase,
                                   key_file=self._key_file)
 
@@ -195,7 +195,7 @@ class LUKS(DeviceFormat):
 
         if self.status:
             log.debug("unmapping %s", self.mapName)
-            blockdev.crypto_luks_close(self.mapName)
+            blockdev.crypto.luks_close(self.mapName)
 
     def create(self, **kwargs):
         """ Write the formatting to the specified block device.
@@ -217,7 +217,7 @@ class LUKS(DeviceFormat):
 
         try:
             DeviceFormat.create(self, **kwargs)
-            blockdev.crypto_luks_format(self.device,
+            blockdev.crypto.luks_format(self.device,
                                         passphrase=self.__passphrase,
                                         key_file=self._key_file,
                                         cipher=self.cipher,
@@ -227,7 +227,7 @@ class LUKS(DeviceFormat):
         except Exception:
             raise
         else:
-            self.uuid = blockdev.crypto_luks_uuid(self.device)
+            self.uuid = blockdev.crypto.luks_uuid(self.device)
             self.exists = True
             if flags.installer_mode:
                 self.mapName = "luks-%s" % self.uuid
@@ -261,7 +261,7 @@ class LUKS(DeviceFormat):
         if not self.exists:
             raise LUKSError("format has not been created")
 
-        blockdev.crypto_luks_add_key(self.device,
+        blockdev.crypto.luks_add_key(self.device,
                                      pass_=self.__passphrase,
                                      key_file=self._key_file,
                                      new_passphrase=passphrase)
@@ -278,13 +278,13 @@ class LUKS(DeviceFormat):
         if not self.exists:
             raise LUKSError("format has not been created")
 
-        blockdev.crypto_luks_remove_key(self.device,
+        blockdev.crypto.luks_remove_key(self.device,
                                         passphrase=self.__passphrase,
                                         key_file=self._key_file)
 
     def escrow(self, directory, backupPassphrase):
         log.debug("escrow: escrowVolume start for %s", self.device)
-        blockdev.crypto_escrow_device(self.device, self.__passphrase, self.escrow_cert,
+        blockdev.crypto.escrow_device(self.device, self.__passphrase, self.escrow_cert,
                                       directory, backupPassphrase)
         log.debug("escrow: escrowVolume done for %s", repr(self.device))
 

--- a/blivet/formats/lvmpv.py
+++ b/blivet/formats/lvmpv.py
@@ -22,7 +22,6 @@
 
 import os
 from gi.repository import BlockDev as blockdev
-from gi.repository import GLib
 
 from ..storage_log import log_method_call
 from parted import PARTITION_LVM
@@ -120,12 +119,12 @@ class LVMPhysicalVolume(DeviceFormat):
             # lvm has issues with persistence of metadata, so here comes the
             # hammer...
             DeviceFormat.destroy(self, **kwargs)
-            blockdev.lvm_pvscan(self.device)
-            blockdev.lvm_pvcreate(self.device, data_alignment=self.dataAlignment)
+            blockdev.lvm.pvscan(self.device)
+            blockdev.lvm.pvcreate(self.device, data_alignment=self.dataAlignment)
         except Exception:
             raise
         finally:
-            blockdev.lvm_pvscan(self.device)
+            blockdev.lvm.pvscan(self.device)
 
         self.exists = True
         self.notifyKernel()
@@ -146,11 +145,11 @@ class LVMPhysicalVolume(DeviceFormat):
 
         # FIXME: verify path exists?
         try:
-            blockdev.lvm_pvremove(self.device)
-        except GLib.GError:
+            blockdev.lvm.pvremove(self.device)
+        except blockdev.LVMError:
             DeviceFormat.destroy(self, **kwargs)
         finally:
-            blockdev.lvm_pvscan(self.device)
+            blockdev.lvm.pvscan(self.device)
 
         self.exists = False
         self.notifyKernel()

--- a/blivet/formats/mdraid.py
+++ b/blivet/formats/mdraid.py
@@ -89,7 +89,7 @@ class MDRaidMember(DeviceFormat):
         if not os.access(self.device, os.W_OK):
             raise MDMemberError("device path does not exist")
 
-        blockdev.md_destroy(self.device)
+        blockdev.md.destroy(self.device)
         self.exists = False
 
     @property

--- a/blivet/formats/swap.py
+++ b/blivet/formats/swap.py
@@ -135,7 +135,7 @@ class SwapSpace(DeviceFormat):
     @property
     def status(self):
         """ Device status. """
-        return self.exists and blockdev.swap_swapstatus(self.device)
+        return self.exists and blockdev.swap.swapstatus(self.device)
 
     def setup(self, **kwargs):
         """ Activate the formatting.
@@ -159,7 +159,7 @@ class SwapSpace(DeviceFormat):
             return
 
         DeviceFormat.setup(self, **kwargs)
-        blockdev.swap_swapon(self.device, priority=self.priority)
+        blockdev.swap.swapon(self.device, priority=self.priority)
 
     def teardown(self):
         """ Close, or tear down, a device. """
@@ -169,7 +169,7 @@ class SwapSpace(DeviceFormat):
             raise SwapSpaceError("format has not been created")
 
         if self.status:
-            blockdev.swap_swapoff(self.device)
+            blockdev.swap.swapoff(self.device)
 
     def create(self, **kwargs):
         """ Write the formatting to the specified block device.
@@ -191,7 +191,7 @@ class SwapSpace(DeviceFormat):
 
         try:
             DeviceFormat.create(self, **kwargs)
-            blockdev.swap_mkswap(self.device, label=self.label)
+            blockdev.swap.mkswap(self.device, label=self.label)
         except Exception:
             raise
         else:

--- a/blivet/osinstall.py
+++ b/blivet/osinstall.py
@@ -24,7 +24,6 @@ import shlex
 import os
 import stat
 import time
-from gi.repository import GLib
 from gi.repository import BlockDev as blockdev
 
 from . import util
@@ -529,7 +528,7 @@ class FSSet(object):
                 try:
                     device.setup()
                     device.format.setup()
-                except (StorageError, GLib.GError) as e:
+                except (StorageError, blockdev.BlockDevError) as e:
                     if errorHandler.cb(e) == ERROR_RAISE:
                         raise
                 else:
@@ -1031,7 +1030,7 @@ def get_containing_device(path, devicetree):
 
     if device_name.startswith("dm-"):
         # have I told you lately that I love you, device-mapper?
-        device_name = blockdev.dm_name_from_node(device_name)
+        device_name = blockdev.dm.name_from_node(device_name)
 
     return devicetree.getDeviceByName(device_name)
 
@@ -1078,7 +1077,7 @@ def writeEscrowPackets(storage):
 
     log.debug("escrow: writeEscrowPackets start")
 
-    backupPassphrase = blockdev.crypto_generate_backup_passphrase()
+    backupPassphrase = blockdev.crypto.generate_backup_passphrase()
 
     try:
         escrowDir = getSysroot() + "/root"

--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -1789,7 +1789,7 @@ def _apply_chunk_growth(chunk):
 
         # reduce the size of thin pools by the pad size
         if hasattr(req.device, "lvs"):
-            size -= Size(blockdev.lvm_get_thpool_padding(size, req.device.vg.peSize, included=True))
+            size -= Size(blockdev.lvm.get_thpool_padding(size, req.device.vg.peSize, included=True))
 
         # Base is pe, which means potentially rounded up by as much as
         # pesize-1. As a result, you can't just add the growth to the
@@ -1829,7 +1829,7 @@ def growLVM(storage):
                 lv.req_size = max(lv.req_size, lv.usedSpace)
 
                 # add the required padding to the requested pool size
-                lv.req_size += Size(blockdev.lvm_get_thpool_padding(lv.req_size, vg.peSize))
+                lv.req_size += Size(blockdev.lvm.get_thpool_padding(lv.req_size, vg.peSize))
 
         # establish sizes for the percentage-based requests (which are fixed)
         percentage_based_lvs = [lv for lv in vg.lvs if lv.req_percent]

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -139,7 +139,7 @@ def get_mount_device(mountpoint):
 
     if mount_device and re.match(r'/dev/loop\d+$', mount_device):
         loop_name = os.path.basename(mount_device)
-        mount_device = blockdev.loop_get_backing_file(loop_name)
+        mount_device = blockdev.loop.get_backing_file(loop_name)
         log.debug("found backing file %s for loop device %s", mount_device,
                                                               loop_name)
 

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -16,7 +16,7 @@ Source0: http://github.com/dwlehman/blivet/archive/%{realname}-%{version}.tar.gz
 %define pypartedver 2.5-2
 %define e2fsver 1.41.0
 %define utillinuxver 2.15.1
-%define libblockdevver 0.6
+%define libblockdevver 0.10
 
 BuildArch: noarch
 BuildRequires: gettext

--- a/tests/devices_test.py
+++ b/tests/devices_test.py
@@ -520,7 +520,7 @@ class MDRaidArrayDeviceTestCase(DeviceStateTestCase):
         self.stateCheck(self.dev19,
                         devices=xform(lambda x, m: self.assertEqual(len(x), 2, m)),
                         level=xform(lambda x, m: self.assertEqual(x.number, 1, m)),
-                        mdadmFormatUUID=xform(lambda x, m: self.assertEqual(x, blockdev.md_get_md_uuid(self.dev19.uuid), m)),
+                        mdadmFormatUUID=xform(lambda x, m: self.assertEqual(x, blockdev.md.get_md_uuid(self.dev19.uuid), m)),
                         parents=xform(lambda x, m: self.assertEqual(len(x), 2, m)),
                         uuid=xform(lambda x, m: self.assertEqual(x, self.dev19.uuid, m)))
 


### PR DESCRIPTION
As of version 0.10 libblockdev provides better error reporting if its ErrorProxy
instances are used (e.g. blockdev.lvm.lvcreate instead of lvm.lvm_lvcreate where
blockdev.lvm is an ErrorProxy instance). Let's make use of this feature and
catch native python exceptions defined in libblockdev's python GI overrides
instead of GLib.GError.