### PR TITLE
If the parent volume has a label, use it in subvol's kickstart (#1072060...

### DIFF
--- a/blivet/devices.py
+++ b/blivet/devices.py
@@ -5710,6 +5710,14 @@ class BTRFSSubVolumeDevice(BTRFSDevice):
         data.name = self.name
         data.preexist = self.exists
 
+        # Identify the volume this subvolume belongs to by means of its
+        # label. If the volume has no label, do nothing.
+        # Note that doing nothing will create an invalid kickstart.
+        # See rhbz#1072060
+        label = self.parents[0].format.label
+        if label:
+            data.devices = ["LABEL=%s" % label]
+
     @classmethod
     def isNameValid(cls, name):
         # Override StorageDevice.isNameValid to allow /


### PR DESCRIPTION
...)

Resolves: rhbz#1072060

The LABEL= entry identifies the parent of the specified subvolume by its
label. If the parent volume does not have a label, then no entry is made
that identifies the parent volume and the generated kickstart
file will be rejected by ksvalidator.

Signed-off-by: mulhern <amulhern@redhat.com>