### PR TITLE
Fix adding new partitions on disks with active devices

### DIFF
--- a/blivet/actionlist.py
+++ b/blivet/actionlist.py
@@ -247,18 +247,21 @@ class ActionList(object):
         disks = []
         for action in self._actions:
             disk = None
-            if action.isDevice and isinstance(action.device, PartitionDevice):
-                disk = action.device.disk
-            elif action.isFormat and action.format.type == "disklabel":
+            if action.isFormat and action.format.type == "disklabel":
                 disk = action.device
 
             if disk is not None and disk not in disks:
                 disks.append(disk)
 
-        active = (dev for dev in devices
-                        if (dev.status and
-                            (not dev.isDisk and
-                             not isinstance(dev, PartitionDevice))))
+        active = []
+        for dev in devices:
+            if dev.status and not dev.isDisk and \
+               not isinstance(dev, PartitionDevice):
+                active.append(dev)
+
+            elif dev.format.status and not dev.isDisk:
+                active.append(dev)
+
         devices = [a.name for a in active if any(d in disks for d in a.disks)]
         return devices
 

--- a/blivet/formats/lvmpv.py
+++ b/blivet/formats/lvmpv.py
@@ -125,7 +125,7 @@ class LVMPhysicalVolume(DeviceFormat):
     def status(self):
         # XXX hack
         return (self.exists and self.vgName and
-                os.path.isdir("/dev/mapper/%s" % self.vgName))
+                os.path.isdir("/dev/%s" % self.vgName))
 
 register_device_format(LVMPhysicalVolume)
 


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1212841

Currently is not possible to add new partitions to disk with an existing LVM VG. 'findActiveDevicesOnActionDisks' should disallow only actions involving changes on the disklabel not adding new partitions.