### PR TITLE
Move definition of _level attribute above super-constructor call.

### DIFF
--- a/blivet/devices/md.py
+++ b/blivet/devices/md.py
@@ -84,13 +84,13 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
         self._memberDevices = 0     # the number of active (non-spare) members
         self._totalDevices = 0      # the total number of members
 
+        # avoid attribute-defined-outside-init pylint warning
+        self._level = None
+
         super(MDRaidArrayDevice, self).__init__(name, fmt=fmt, uuid=uuid,
                                                 exists=exists, size=size,
                                                 parents=parents,
                                                 sysfsPath=sysfsPath)
-
-        # avoid attribute-defined-outside-init pylint warning
-        self._level = None
 
         try:
             self.level = level


### PR DESCRIPTION
The basic problem is that level is a very important concept for md
so a lot of log messages log this information. Some of these
log messages are executed as a result of running the parent constructor.
The particular problem I saw is that self.updateSize() is called by
StorageDevice.__init__, which understandably logs the size,
and the size() methods logs its result, along with the level, leading to
an AttributeError. Now there will be no AttributeError, but the RAID
level will be displayed as None when this happens.

Signed-off-by: mulhern <amulhern@redhat.com>