### PR TITLE
Do not update size information on LVM snapshots

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -966,6 +966,11 @@ class LVMSnapShotDevice(LVMSnapShotBase, LVMLogicalVolumeDevice):
         return (self.origin == dep or
                 super(LVMSnapShotBase, self).dependsOn(dep))
 
+    def readCurrentSize(self):
+        # override StorageDevice.readCurrentSize because /sys reports wrong size
+        # for snapshots
+        return self._size
+
 class LVMThinPoolDevice(LVMLogicalVolumeDevice):
     """ An LVM Thin Pool """
     _type = "lvmthinpool"


### PR DESCRIPTION
Current updateSize method implementation checks the size of devices in /sys where the size of LVM snapshots is incorrect (it reports the size of the LV instead of the actual size of the snapshot).

My fix actually prevents blivet from updating size of the snapshot. The question is if we want to update the size because it would require to run the devicetree.lvInfo() function again (because only "lvs" reports the correct size for snapshots).
