### PR TITLE
Allow passing KiB values to vgcreate -s option

### DIFF
--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -339,7 +339,7 @@ def pvinfo(device=None):
 def vgcreate(vg_name, pv_list, pe_size):
     argv = ["vgcreate"]
     if pe_size:
-        argv.extend(["-s", "%dm" % pe_size.convertTo(spec="mib")])
+        argv.extend(["-s", "%sk" % pe_size.convertTo(spec="KiB")])
     argv.append(vg_name)
     argv.extend(pv_list)
 


### PR DESCRIPTION
Resolves: rhbz#1206526

Currently blivet exepects pesize parm of the vgcreate function
should be in MiB. Any given value will be converted to MiB format
and omits any fractional part. That means, if any KiB values are
passed to pesize parm, it becomes 0 and the actual lvm lvcreate
faild to create the vg and returns an error.
This limits passing any KiB values for pesize to create a vg.
This patch fixes the issue by accepting the given value in KiB.

Submitted-by: Timothy Asir Jeyasingh <tjeyasin@redhat.com>
Signed-off-by: mulhern <amulhern@redhat.com>