### PR TITLE
Master btrfs

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -40,6 +40,7 @@ from ..size import B, KiB, MiB, GiB, KB, MB, GB
 from ..i18n import _, N_
 from .. import udev
 from ..mounts import mountsCache
+from ..devicelibs import btrfs
 
 import logging
 log = logging.getLogger("blivet")
@@ -1157,7 +1158,7 @@ class BTRFS(FS):
     def __init__(self, **kwargs):
         super(BTRFS, self).__init__(**kwargs)
         self.volUUID = kwargs.pop("volUUID", None)
-        self.subvolspec = kwargs.pop("subvolspec", None)
+        self.subvolspec = kwargs.pop("subvolspec", btrfs.MAIN_VOLUME_ID)
 
     def create(self, **kwargs):
         # filesystem creation is done in blockdev.btrfs.create_volume

--- a/blivet/mounts.py
+++ b/blivet/mounts.py
@@ -21,6 +21,7 @@
 #
 from collections import defaultdict
 from . import util
+from .devicelibs import btrfs
 
 import logging
 log = logging.getLogger("blivet")
@@ -40,7 +41,7 @@ class MountsCache(object):
             :param devscpec: device specification, eg. "/dev/vda1"
             :type devspec: str
             :param subvolspec: btrfs subvolume specification, eg. ID or name
-            :type subvolspec: str
+            :type subvolspec: object (may be NoneType)
             :returns: list of mountpoints (path)
             :rtype: list of str or empty list
 
@@ -49,6 +50,9 @@ class MountsCache(object):
                 devices mounted to them (hiding previous mounts). Callers should take this into account.
         """
         self._cacheCheck()
+
+        if subvolspec is not None:
+            subvolspec = str(subvolspec)
 
         return self.mountpoints[(devspec, subvolspec)]
 
@@ -61,6 +65,23 @@ class MountsCache(object):
 
         return any(path in p for p in self.mountpoints.values())
 
+    def _getSubvolSpec(self, devspec, mountpoint):
+        """ Get the subvolume specification for this btrfs volume.
+
+            :param str devspec: the device specification
+            :param str mountpoint: the mountpoint
+
+            :returns: the subvolume specification, 5 for a top-level volume
+            :rtype: str or NoneType
+        """
+        for line in open("/proc/self/mountinfo").readlines():
+            fields = line.split()
+            if fields[4] == mountpoint and fields[9] == devspec:
+                # empty _subvol[1:] means it is a top-level volume
+                subvolspec = fields[3]
+                return subvolspec[1:] or str(btrfs.MAIN_VOLUME_ID)
+        return None
+
     def _getActiveMounts(self):
         """ Get information about mounted devices from /proc/mounts and
             /proc/self/mountinfo
@@ -70,24 +91,17 @@ class MountsCache(object):
         self.mountpoints = defaultdict(list)
         for line in open("/proc/mounts").readlines():
             try:
-                (devspec, mountpoint, fstype, _options, _rest) = line.split(None, 4)
+                (devspec, mountpoint, fstype, _rest) = line.split(None, 3)
             except ValueError:
                 log.error("failed to parse /proc/mounts line: %s", line)
                 continue
 
             if fstype == "btrfs":
-                # get the subvol name from /proc/self/mountinfo
-                for line in open("/proc/self/mountinfo").readlines():
-                    fields = line.split()
-                    _subvol = fields[3]
-                    _mountpoint = fields[4]
-                    _devspec = fields[9]
-                    if _mountpoint == mountpoint and _devspec == devspec:
-                        # empty _subvol[1:] means it is a top-level volume
-                        subvolspec = _subvol[1:] or 5
-
-                        self.mountpoints[(devspec, subvolspec)].append(mountpoint)
-
+                subvolspec = self._getSubvolSpec(devspec, mountpoint)
+                if subvolspec is not None:
+                    self.mountpoints[(devspec, subvolspec)].append(mountpoint)
+                else:
+                    log.error("failed to obtain subvolspec for btrfs device %s", devspec)
             else:
                 self.mountpoints[(devspec, None)].append(mountpoint)
 


### PR DESCRIPTION
Fixes a bug where mountpoint of btrfs top-level volume was not found in mountsCache.

Two parts of fix are:
* Make MAIN_VOLUME_ID default subvolspec for btrfs format. If making a subvol it should always be
overridden with subvol's subvolspec.
* Make mountsCache use consistent types for subvolspec in keys.

Symptom of bug was uncaught RuntimeError "btrfs subvol create requires mounted volume" while executing storage actions.