### PR TITLE
Store vendor/model information for DiskDevice instances.

### DIFF
--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -105,7 +105,7 @@ class DiskDevice(StorageDevice):
 
     @property
     def description(self):
-        return self.model
+        return " ".join(s for s in (self.vendor, self.model) if s)
 
     def _preDestroy(self):
         """ Destroy the device. """

--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -113,8 +113,8 @@ class StorageDevice(Device):
         self.major = util.numeric_type(major)
         self.minor = util.numeric_type(minor)
         self._serial = serial
-        self._vendor = vendor
-        self._model = model
+        self._vendor = vendor or ""
+        self._model = model or ""
         self.bus = bus
 
         self._readonly = False

--- a/blivet/populator.py
+++ b/blivet/populator.py
@@ -476,12 +476,10 @@ class Populator(object):
         serial = udev.device_get_serial(info)
         bus = udev.device_get_bus(info)
 
-        # udev doesn't always provide a vendor.
-        vendor = udev.device_get_vendor(info)
-        if not vendor:
-            vendor = ""
+        vendor = util.get_sysfs_attr(sysfs_path, "device/vendor")
+        model = util.get_sysfs_attr(sysfs_path, "device/model")
 
-        kwargs = { "serial": serial, "vendor": vendor, "bus": bus }
+        kwargs = { "serial": serial, "vendor": vendor, "model": model, "bus": bus }
         if udev.device_is_iscsi(info):
             diskType = iScsiDiskDevice
             initiator = udev.device_get_iscsi_initiator(info)
@@ -561,7 +559,6 @@ class Populator(object):
         device = diskType(name,
                           major=udev.device_get_major(info),
                           minor=udev.device_get_minor(info),
-                          model=udev.device_get_model(info),
                           sysfsPath=sysfs_path, **kwargs)
 
         if diskType == DASDDevice:


### PR DESCRIPTION
Also make sure _model and _vendor attrs are never set to None in the
StorageDevice constructor.

Fixes #84