### PR TITLE
Beware of Python 3's version of the map() built-in function

### DIFF
--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -719,7 +719,8 @@ class StorageDevice(Device):
             False that are normally performed as part of the device constructor.
         """
         if not new:
-            map(lambda p: p.addChild(), self.parents)
+            for p in self.parents:
+                p.addChild()
 
     def populateKSData(self, data):
         # the common pieces are basically the formatting

--- a/tests/devicelibs_test/edd_test.py
+++ b/tests/devicelibs_test/edd_test.py
@@ -168,7 +168,8 @@ class EddTestFS(object):
     def sda_vda_no_pcidev(self):
         self.sda_vda()
         entries = [e for e in self.fs.fs if e.startswith("/sys/devices/pci")]
-        map(self.fs.os_remove, entries)
+        for e in entries:
+            self.fs.os_remove(e)
         return self.fs
 
     def sda_vda_no_host_bus(self):


### PR DESCRIPTION
It not only returns an iterator in Python 3, it actually works in the lazy
evaluation fashion. So if its returned value is not iterated over, the passed
function is not called on the iterable's items. Let's use a for cycle in these
places to make the iteration and function calls explicit.