### PR TITLE
Use COW device to get actual size of LVM snapshots

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -24,6 +24,7 @@ from six import add_metaclass
 import abc
 import pprint
 import re
+import os
 from gi.repository import BlockDev as blockdev
 
 # device backend modules
@@ -39,6 +40,7 @@ from ..size import Size, KiB, MiB, ROUND_UP, ROUND_DOWN
 import logging
 log = logging.getLogger("blivet")
 
+from .lib import LINUX_SECTOR_SIZE
 from .device import Device
 from .storage import StorageDevice
 from .container import ContainerDevice
@@ -965,6 +967,19 @@ class LVMSnapShotDevice(LVMSnapShotBase, LVMLogicalVolumeDevice):
         # pylint: disable=bad-super-call
         return (self.origin == dep or
                 super(LVMSnapShotBase, self).dependsOn(dep))
+
+    def readCurrentSize(self):
+        log_method_call(self, exists=self.exists, path=self.path,
+                        sysfsPath=self.sysfsPath)
+        size = Size(0)
+        if self.exists and os.path.isdir(self.sysfsPath):
+            cowSysfsPath = util.get_cow_sysfs_path(self.path, self.sysfsPath)
+
+            if os.path.exists(cowSysfsPath) and os.path.isdir(cowSysfsPath):
+                blocks = int(util.get_sysfs_attr(cowSysfsPath, "size"))
+                size = Size(blocks * LINUX_SECTOR_SIZE)
+
+        return size
 
 class LVMThinPoolDevice(LVMLogicalVolumeDevice):
     """ An LVM Thin Pool """

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -226,6 +226,23 @@ def get_sysfs_path_by_name(dev_node, class_name="block"):
         raise RuntimeError("get_sysfs_path_by_name: Could not find sysfs path "
                            "for '%s' (it is not at '%s')" % (dev_node, dev_path))
 
+def get_cow_sysfs_path(dev_path, dev_sysfsPath):
+    """ Return sysfs path of cow device for a given device.
+    """
+
+    cow_path = dev_path + "-cow"
+    if not os.path.islink(cow_path):
+        raise RuntimeError("get_cow_sysfs_path: Could not find cow device for" %
+                            (dev_path))
+
+    # dev path for cow devices is actually a link to a dm device (e.g. /dev/dm-X)
+    # we need the 'dm-X' name for sysfsPath (e.g. /sys/devices/virtual/block/dm-X)
+    # where first part is the same as in sysfsPath of the original device
+    dm_name = os.path.basename(os.path.realpath(cow_path))
+    cow_sysfsPath = os.path.join(os.path.split(dev_sysfsPath)[0], dm_name)
+
+    return cow_sysfsPath
+
 ##
 ## SELinux functions
 ##


### PR DESCRIPTION
New version of #99 

-----
Override readCurrentSize of LVM old-style snapshots to check size
on COW device instead of snapshot device. (The latter one reports
snapshot to be same size as the LV.)

Signed-off-by: Vojtech Trefny <vtrefny@redhat.com>