### PR TITLE
Filter GLib.GError instead of GLib.Error in pylint false positives.

### DIFF
--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -9,7 +9,7 @@ class BlivetLintConfig(PocketLintConfig):
         PocketLintConfig.__init__(self)
 
         self.falsePositives = [ FalsePositive(r"BTRFSVolumeDevice._create: Instance of 'DeviceFormat' has no 'label' member"),
-                                FalsePositive(r"Catching an exception which doesn't inherit from BaseException: (BlockDev|DM|Crypto|Swap|LVM|Btrfs|MDRaid|)Error$"),
+                                FalsePositive(r"Catching an exception which doesn't inherit from BaseException: (BlockDev|DM|Crypto|Swap|LVM|Btrfs|MDRaid|G)Error$"),
                                 FalsePositive(r"Function 'run_program' has no 'called' member"),
                                 FalsePositive(r"(PartitioningTestCase|PartitionDeviceTestCase).*: Instance of 'DeviceFormat' has no .* member"),
                                 FalsePositive(r"Instance of 'int' has no .* member"),


### PR DESCRIPTION
GError and Error are just aliases of each other, and GError is more
distinctive, thus a better choice for filtering so long as it is
used always in place of Error.

Should have gone in with commit 3f0aa449e42bc64da78e2ff8c0553b4526deed00.

Signed-off-by: mulhern <amulhern@redhat.com>