### PR TITLE
Use the return of findActiveDevicesOnActionDisks() properly

### DIFF
--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -255,7 +255,7 @@ class DeviceTree(object):
             else:
                 raise RuntimeError("partitions in use on disks with changes "
                                    "pending: %s" %
-                                   ",".join(p.name for p in problematic))
+                                   ",".join(problematic))
 
         log.info("resetting parted disks...")
         for device in self.devices:


### PR DESCRIPTION
The function findActiveDevicesOnActionDisks() does return a list of
device names, i.e. a list of strings, not a list of devices.

Without this fix, an AttributeError is throwned before the RuntimeError,
see:

  File "/usr/lib/python2.7/site-packages/blivet/devicetree.py", line 354, in processActions
    self._preProcessActions()
  File "/usr/lib/python2.7/site-packages/blivet/devicetree.py", line 258, in _preProcessActions
    ",".join(p.name for p in problematic))
  File "/usr/lib/python2.7/site-packages/blivet/devicetree.py", line 258, in <genexpr>
    ",".join(p.name for p in problematic))
AttributeError: 'str' object has no attribute 'name'