### PR TITLE
lvm: Add missing argument to libblockdev API for thinpool

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -1016,7 +1016,7 @@ class LVMThinPoolDevice(LVMLogicalVolumeDevice):
             raise ValueError("invalid metadatasize value")
 
         if chunksize is not None and \
-           not blockdev.lvm.is_valid_thpool_chunk_size(chunksize):
+           not blockdev.lvm.is_valid_thpool_chunk_size(chunksize, False):
             raise ValueError("invalid chunksize value")
 
         super(LVMThinPoolDevice, self).__init__(name, parents=parents,


### PR DESCRIPTION
It takes a boolean:
```
 * @discard: whether discard/TRIM is required to be supported or not
```

So I don't know offhand whether anything in anaconda has support for
forcing TRIM support on or not.  `git grep -i trim` in both blivet and
anaconda has no obvious hits, so I'm going to go ahead and assume no.
In that case, let's pass `False` here to avoid blowing chunks.

NOTE: Not actually tested, but I was trying to do thinp via kickstart
with a rawhide installer and saw a traceback for this, and it looks
right to me.