### PR TITLE
Include automatic and manual test documentation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ doc/blivet.devicelibs.rst
 doc/blivet.formats.rst
 doc/blivet.rst
 doc/modules.rst
+doc/tests*.rst
 doc/_build
 po/*.gmo
 po/*.po

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -43,8 +43,12 @@ help:
 
 clean:
 	-rm -rf $(BUILDDIR)/*
+	-rm -f $(addprefix ./, tests.*)
 
 apidoc:
+	-rm -f $(addprefix ./, tests.* modules.rst)
+	$(SPHINXAPIDOC) -o . ../tests/
+	-cp modules.rst tests.modules.rst
 	-rm $(addprefix ./, $(MODULE_NAMES))
 	$(SPHINXAPIDOC) -o . $(SOURCEDIR)
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -13,6 +13,7 @@ Contents:
 
    intro
    modules
+   tests.modules
 
 Indices and tables
 ==================

--- a/doc/inheritance.rst
+++ b/doc/inheritance.rst
@@ -1,0 +1,28 @@
+Test Suite Inheritance Diagram
+------------------------------
+
+Blivet's test suite relies on the base classes shown below. These classes
+take care of working with fake block or loop devices.
+
+.. inheritance-diagram::
+    tests.imagebackedtestcase
+    tests.loopbackedtestcase
+    tests.storagetestcase
+    tests.devicetree_test.BlivetResetTestCase
+
+Actual test cases inherit either :class:`unittest.TestCase` or one of
+these base classes. Some use cases require more levels of abstraction
+which is shown on the following diagram.
+
+.. inheritance-diagram::
+    tests.devicetree_test
+    tests.formats_test.fs_test
+    tests.formats_test.fslabeling
+
+Note: with :class:`sphinx.ext.inheritance_diagram` it is not possible to
+generate an inheritance diagram of all available classes. The ones shown above
+are considered a bit more important. If you want to see the inheritance diagram
+for other classes add the following markup to this document and rebuild it::
+
+    .. inheritance-diagram::
+        tests.module_name.className

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -197,3 +197,5 @@ from which to allocate the partition::
     new_part = b.newPartition(start=2048, end=204802048, parents=[sdb])
 
 All the rest is the same as the previous partitioning example.
+
+.. include:: ../tests/README.rst

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -1,0 +1,88 @@
+Testing Blivet
+==============
+
+Note: The test suite documented here is available only from the git repository
+not as part of any installable packages.
+
+In order to execute blivet's test suite from inside the source directory execute
+the command::
+
+    make test
+
+Tests descending from :class:`~.imagebackedtestcase.ImageBackedTestCase` or
+:class:`~.loopbackedtestcase.LoopBackedTestCase` require root access on the
+system and will be skipped if you're running as non-root user.
+Tests descending from :class:`~.imagebackedtestcase.ImageBackedTestCase` will
+also be skipped if the environment variable JENKINS_HOME is not defined. If
+you'd like to execute them use the following commands (as root)::
+
+    # export JENKINS_HOME=`pwd`
+    # make test
+
+To execute the Pylint code analysis tool run::
+
+    make check
+
+Running Pylint doesn't require root privileges but requires Python3 due to usage
+of pocket-lint.
+
+It is also possible to generate test coverage reports using the Python coverage
+tool. To do that execute::
+
+    make coverage
+
+It is also possible to check all external links in the documentation for
+integrity. To do this::
+
+    cd doc/
+    make linkcheck
+
+Test Suite Architecture
+------------------------
+
+Blivet's test suite relies on several base classes listed below. All test cases
+inherit from them.
+
+- :class:`unittest.TestCase` - the standard unit test class in Python.
+  Used for tests which don't touch disk space;
+
+
+- :class:`~tests.storagetestcase.StorageTestCase` - intended as a base class for
+  higher-level tests. Most of what it does is stub out operations that touch
+  disks. Currently it is only used in
+  :class:`~tests.action_test.DeviceActionTestCase`;
+
+
+- :class:`~tests.loopbackedtestcase.LoopBackedTestCase` and
+  :class:`~tests.imagebackedtestcase.ImageBackedTestCase` - both classes
+  represent actual storage space.
+  :class:`~tests.imagebackedtestcase.ImageBackedTestCase` uses the same stacks
+  as anaconda disk image installations. These mimic normal disks more closely
+  than using loop devices directly. Usually
+  :class:`~tests.loopbackedtestcase.LoopBackedTestCase` is used for stacks of
+  limited depth (eg: md array with two loop members) and
+  :class:`~tests.imagebackedtestcase.ImageBackedTestCase` for stacks of greater
+  or arbitrary depth.
+
+
+In order to get a high level view of how test classes inherit from each other
+you can generate an inheritance diagram::
+
+    PYTHONPATH=.:tests/ python3-pyreverse -p "Blivet_Tests" -o svg -SkAmy tests/
+
+
+Alternatively you may try::
+
+    cd doc/
+    make clean html \
+    SPHINXOPTS="                                                         \
+        -D extensions=sphinx.ext.inheritance_diagram,sphinx.ext.graphviz \
+        -D inheritance_graph_attrs.rankdir=LR                            \
+        -D inheritance_graph_attrs.size=''"
+
+
+and view the `_build/html/inheritance.html` document.
+
+Note: pyreverse is part of pylint while sphinx.ext.inheritance_diagram is part
+of Sphinx itself. Both should be installed on your system if you're building
+Blivet from source.


### PR DESCRIPTION
This is my first attempt to bring some test documentation to blivet before actually trying to write any more tests. Summary of changes:

- modify existing Makefile target to include test documentation in the main document
- add dependency on Graphviz which is used to create inheritance graphs for test cases (used to outline which are the base test classes in Blivet). WARNING: may break Red The Docs if they don't have graphviz installed. Possibly needs a BuildRequires change for the spec file as well.
- update .gitignore
- add tests/README.rst with basic description of blivet's test suite. 