### PR TITLE
Master keepers c

### DIFF
--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -534,7 +534,7 @@ def device_get_dm_partition_disk(info):
         return None
 
     disk = None
-    majorminor = info["ID_PART_ENTRY_DISK"]
+    majorminor = info.get("ID_PART_ENTRY_DISK")
     if majorminor:
         major, minor = majorminor.split(":")
         for device in get_devices():

--- a/tests/loopbackedtestcase.py
+++ b/tests/loopbackedtestcase.py
@@ -1,13 +1,13 @@
 import unittest
 import os
 import subprocess
+import tempfile
 
 from blivet.size import Size
 
-def makeLoopDev(device_name, file_name, num_blocks=102400, block_size=1024):
-    """ Set up a loop device with a backing store.
+def makeStore(file_name, num_blocks=102400, block_size=1024):
+    """ Set up the backing store for a loop device.
 
-        :param str device_name: the path of the loop device
         :param str file_name: the path of the backing file
         :param int num_blocks: the size of file_name in number of blocks
         :param int block_size: the number of bytes in a block
@@ -23,6 +23,13 @@ def makeLoopDev(device_name, file_name, num_blocks=102400, block_size=1024):
     if rc:
         raise OSError("dd failed creating the file %s" % file_name)
 
+def makeLoopDev(device_name, file_name):
+    """ Set up a loop device with a backing store.
+
+        :param str device_name: the path of the loop device
+        :param str file_name: the path of the backing file
+    """
+
     proc = subprocess.Popen(["losetup", device_name, file_name],
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     while True:
@@ -33,7 +40,7 @@ def makeLoopDev(device_name, file_name, num_blocks=102400, block_size=1024):
     if rc:
         raise OSError("losetup failed setting up the loop device %s" % device_name)
 
-def removeLoopDev(device_name, file_name):
+def removeLoopDev(device_name):
     proc = subprocess.Popen(["losetup", "-d", device_name],
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     while True:
@@ -43,8 +50,6 @@ def removeLoopDev(device_name, file_name):
             break
     if rc:
         raise OSError("losetup failed removing the loop device %s" % device_name)
-
-    os.unlink(file_name)
 
 def getFreeLoopDev():
     # There's a race condition here where another process could grab the loop
@@ -72,8 +77,6 @@ class LoopBackedTestCase(unittest.TestCase):
     DEFAULT_BLOCK_SIZE = Size("1 KiB")
     DEFAULT_STORE_SIZE = Size("100 MiB")
     _DEFAULT_DEVICE_SPEC = [DEFAULT_STORE_SIZE, DEFAULT_STORE_SIZE]
-    _STORE_FILE_TEMPLATE = 'test-virtdev%d'
-    _STORE_FILE_PATH = '/var/tmp'
 
     def __init__(self, methodName='runTest', deviceSpec=None, block_size=None):
         """ DevicelibsTestCase manages loop devices.
@@ -88,7 +91,7 @@ class LoopBackedTestCase(unittest.TestCase):
         """
         unittest.TestCase.__init__(self, methodName=methodName)
         self._deviceSpec = deviceSpec or self._DEFAULT_DEVICE_SPEC
-        self._loopMap = {}
+        self._loopMap = []
         self.loopDevices = []
         self.block_size = block_size or self.DEFAULT_BLOCK_SIZE
 
@@ -97,13 +100,45 @@ class LoopBackedTestCase(unittest.TestCase):
 
     def setUp(self):
         for index, size in enumerate(self._deviceSpec):
-            store = os.path.join(self._STORE_FILE_PATH, self._STORE_FILE_TEMPLATE % index)
-            dev = getFreeLoopDev()
             num_blocks = int(size / self.block_size)
-            makeLoopDev(dev, store, num_blocks=num_blocks, block_size=int(self.block_size))
-            self._loopMap[dev] = store
+            tmpfile = tempfile.NamedTemporaryFile(suffix="-%d" % index, prefix="test-virtdev-", dir="/var/tmp", delete=False)
+            tmpfile.close()
+
+            store = tmpfile.name
+            makeStore(store, num_blocks, int(self.block_size))
+
+            dev = None
+            try:
+                dev = getFreeLoopDev()
+                makeLoopDev(dev, store)
+            except OSError:
+                os.unlink(store)
+                raise
+
+            self._loopMap.append((dev, store))
             self.loopDevices.append(dev)
 
     def tearDown(self):
-        for (dev, store) in iter(self._loopMap.items()):
-            removeLoopDev(dev, store)
+        # Guarantees that every item in _loopMap receives a minimum of
+        # three chances to be removed or deleted as appropriate.
+        num_tries = 3 * len(self._loopMap)
+        for _ in range(num_tries):
+            # If worklist is empty, quit
+            if not self._loopMap:
+                break
+
+            # get worklist item from front
+            dev, store = self._loopMap.pop(0)
+
+            # try to clean up dev, store pair
+            # if cleanup fails, push pair onto back
+            # dev is None if removal has already succeeded
+            if dev is not None:
+                try:
+                    removeLoopDev(dev)
+                    try:
+                        os.unlink(store)
+                    except OSError:
+                        self._loopMap.append((None, store))
+                except OSError:
+                    self._loopMap.append((dev, store))

--- a/tests/size_test.py
+++ b/tests/size_test.py
@@ -200,6 +200,57 @@ class SizeTestCase(unittest.TestCase):
         self.assertEqual(size.parseSpec("1E-4KB"), Decimal("0.1"))
         self.assertEqual(Size("1E-10KB"), Size(0))
 
+        with self.assertRaises(ValueError):
+            # this is an exponent w/out a base
+            size.parseSpec("e+0")
+
+    def testFloatingPointStr(self):
+        self.assertEqual(size.parseSpec("1.5e+0 KiB"), Decimal(1536))
+        self.assertEqual(size.parseSpec("0.0"), Decimal(0))
+        self.assertEqual(size.parseSpec("0.9 KiB"), Decimal("921.6"))
+        self.assertEqual(size.parseSpec("1.5 KiB"), Decimal(1536))
+        self.assertEqual(size.parseSpec("0.5 KiB"), Decimal(512))
+        self.assertEqual(size.parseSpec(".5 KiB"), Decimal(512))
+        self.assertEqual(size.parseSpec("1. KiB"), Decimal(1024))
+        self.assertEqual(size.parseSpec("-1. KiB"), Decimal(-1024))
+        self.assertEqual(size.parseSpec("+1. KiB"), Decimal(1024))
+        self.assertEqual(size.parseSpec("+1.0000000e+0 KiB"), Decimal(1024))
+        self.assertEqual(size.parseSpec("+.5 KiB"), Decimal(512))
+
+        with self.assertRaises(ValueError):
+            # this is a fragment of an arithmetic expression
+            size.parseSpec("+ 1 KiB")
+
+        with self.assertRaises(ValueError):
+            # this is a fragment of an arithmetic expression
+            size.parseSpec("- 1 KiB")
+
+        with self.assertRaises(ValueError):
+            # this is a lonely .
+            size.parseSpec(". KiB")
+
+        with self.assertRaises(ValueError):
+            # this has a fragmentary exponent
+            size.parseSpec("1.0e+ KiB")
+
+        with self.assertRaises(ValueError):
+            # this is a version string, not a number
+            size.parseSpec("1.0.0")
+
+    def testWhiteSpace(self):
+        self.assertEqual(size.parseSpec("1 KiB "), Decimal(1024))
+        self.assertEqual(size.parseSpec(" 1 KiB"), Decimal(1024))
+        self.assertEqual(size.parseSpec(" 1KiB"), Decimal(1024))
+        self.assertEqual(size.parseSpec(" 1e+0KiB"), Decimal(1024))
+        with self.assertRaises(ValueError):
+            size.parseSpec("1 KiB just a lot of stray characters")
+        with self.assertRaises(ValueError):
+            size.parseSpec("just 1 KiB")
+
+    def testLeadingZero(self):
+        self.assertEqual(size.parseSpec("001 KiB"), Decimal(1024))
+        self.assertEqual(size.parseSpec("1e+01"), Decimal(10))
+
     def testPickling(self):
         s = Size("10 MiB")
         self.assertEqual(s, cPickle.loads(cPickle.dumps(s)))

--- a/tests/size_test.py
+++ b/tests/size_test.py
@@ -43,7 +43,7 @@ class SizeTestCase(unittest.TestCase):
 
     def testExceptions(self):
         zero = Size(0)
-        self.assertEqual(zero, Size(0.0))
+        self.assertEqual(zero, Size("0.0"))
 
         s = Size(500)
         with self.assertRaises(SizePlacesError):
@@ -170,7 +170,7 @@ class SizeTestCase(unittest.TestCase):
 
         s = Size("0.5 GiB")
         self.assertEquals(s.humanReadable(max_places=2, min_value=1), "512 MiB")
-        self.assertEquals(s.humanReadable(max_places=2, min_value=Decimal(0.1)), "0.5 GiB")
+        self.assertEquals(s.humanReadable(max_places=2, min_value=Decimal("0.1")), "0.5 GiB")
         self.assertEquals(s.humanReadable(max_places=2, min_value=Decimal(1)), "512 MiB")
 
     def testConvertToPrecision(self):
@@ -178,7 +178,7 @@ class SizeTestCase(unittest.TestCase):
         self.assertEquals(s.convertTo(None), 1835008)
         self.assertEquals(s.convertTo(B), 1835008)
         self.assertEquals(s.convertTo(KiB), 1792)
-        self.assertEquals(s.convertTo(MiB), 1.75)
+        self.assertEquals(s.convertTo(MiB), Decimal("1.75"))
 
     def testNegative(self):
         s = Size("-500MiB")
@@ -186,7 +186,7 @@ class SizeTestCase(unittest.TestCase):
         self.assertEquals(s.convertTo(B), -524288000)
 
     def testPartialBytes(self):
-        self.assertEquals(Size(1024.6), Size(1024))
+        self.assertEquals(Size("1024.6"), Size(1024))
         self.assertEquals(Size("%s KiB" % (1/1025.0,)), Size(0))
         self.assertEquals(Size("%s KiB" % (1/1023.0,)), Size(1))
 

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -14,7 +14,7 @@ class MiscTest(unittest.TestCase):
     def test_power_of_two(self):
         self.assertFalse(util.power_of_two(None))
         self.assertFalse(util.power_of_two("not a number"))
-        self.assertFalse(util.power_of_two(Decimal(2.2)))
+        self.assertFalse(util.power_of_two(Decimal("2.2")))
         self.assertFalse(util.power_of_two(-1))
         self.assertFalse(util.power_of_two(0))
         self.assertFalse(util.power_of_two(1))


### PR DESCRIPTION
Supersedes #124. The only changes are to setUp() and tearDown() in loopbackedtestcase.py.

Uses tempfile.TemporaryNamedFile in setUp() and has tearDown() separate removing loop device from unlinking backing store.