### PR TITLE
Remove /usr/bin/python shebang

### DIFF
--- a/tests/action_test.py
+++ b/tests/action_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 
 import unittest
 
@@ -1162,7 +1161,4 @@ class DeviceActionTestCase(StorageTestCase):
     def testActionSorting(self, *args, **kwargs):
         """ Verify correct functioning of action sorting. """
         pass
-
-if __name__ == "__main__":
-    unittest.main()
 

--- a/tests/devicefactory_test.py
+++ b/tests/devicefactory_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 
 import unittest
 
@@ -59,5 +58,3 @@ class MDFactoryTestCase(unittest.TestCase):
 
         self.assertIsNone(self.factory2.get_container())
 
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/devicelibs_test/mdraid_test.py
+++ b/tests/devicelibs_test/mdraid_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 import unittest
 
 import blivet.devicelibs.mdraid as mdraid
@@ -17,5 +16,3 @@ class MDRaidTestCase(unittest.TestCase):
         self.assertEqual(mdraid.RAID_levels.raidLevel("RAID6").name, "raid6")
         self.assertEqual(mdraid.RAID_levels.raidLevel("raid10").name, "raid10")
 
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/devicelibs_test/raid_test.py
+++ b/tests/devicelibs_test/raid_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 import unittest
 
 import blivet.devicelibs.raid as raid

--- a/tests/devices_test/dependencies_test.py
+++ b/tests/devices_test/dependencies_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # vim:set fileencoding=utf-8
 
 import unittest
@@ -86,5 +85,3 @@ class MockingDeviceDependenciesTestCase(unittest.TestCase):
 
         availability.CACHE_AVAILABILITY = self.cache_availability
 
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/devices_test/device_names_test.py
+++ b/tests/devices_test/device_names_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # vim:set fileencoding=utf-8
 
 import unittest
@@ -42,5 +41,3 @@ class DeviceNameTestCase(unittest.TestCase):
         for name in bad_names:
             self.assertFalse(LVMLogicalVolumeDevice.isNameValid(name))
 
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/devices_test/device_packages_test.py
+++ b/tests/devices_test/device_packages_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # vim:set fileencoding=utf-8
 
 import unittest
@@ -30,5 +29,3 @@ class DevicePackagesTestCase(unittest.TestCase):
         for package in dev1.format.packages + dev2.format.packages + dev.format.packages:
             self.assertIn(package, packages)
 
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/devices_test/device_properties_test.py
+++ b/tests/devices_test/device_properties_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # vim:set fileencoding=utf-8
 
 import unittest
@@ -710,5 +709,3 @@ class BTRFSDeviceTestCase(DeviceStateTestCase):
         self.assertEqual(snap.dependsOn(vol), True)
         self.assertEqual(vol.dependsOn(snap), False)
 
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/devices_test/lvm_test.py
+++ b/tests/devices_test/lvm_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # vim:set fileencoding=utf-8
 
 import unittest
@@ -138,5 +137,3 @@ class LVMDeviceTest(unittest.TestCase):
         self.assertEqual(lv.targetSize, orig_size)
         self.assertEqual(lv.size, orig_size)
 
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/devices_test/network_test.py
+++ b/tests/devices_test/network_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # vim:set fileencoding=utf-8
 
 import unittest
@@ -36,5 +35,3 @@ class NetDevMountOptionTestCase(unittest.TestCase):
 
         self.assertTrue("_netdev" in dev.format.options.split(","))
 
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/devices_test/partition_test.py
+++ b/tests/devices_test/partition_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # vim:set fileencoding=utf-8
 
 import os
@@ -156,5 +155,3 @@ class PartitionDeviceTestCase(unittest.TestCase):
                 disk.format.endAlignment.isAligned(free, max_end_sector),
                 True)
 
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/devicetree_test.py
+++ b/tests/devicetree_test.py
@@ -279,5 +279,3 @@ class LVMOnMDTestCase(BlivetResetTestCase):
                                   disks=self.blivet.disks[:],
                                   container_raid_level="raid1")
 
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/formats_test/device_test.py
+++ b/tests/formats_test/device_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 import unittest
 
 import blivet
@@ -79,5 +78,3 @@ class DeviceValueTestCase(unittest.TestCase):
                 self.assertEqual(an_fs.type, typ)
                 self.assertEqual(an_fs.device, "/abc:/def")
 
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/formats_test/fs_test.py
+++ b/tests/formats_test/fs_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 import os
 import tempfile
 import unittest
@@ -140,5 +139,3 @@ class ResizeTmpFSTestCase(loopbackedtestcase.LoopBackedTestCase):
             pass
         os.rmdir(self.mountpoint)
 
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/formats_test/fslabeling.py
+++ b/tests/formats_test/fslabeling.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 
 import abc
 from six import add_metaclass

--- a/tests/formats_test/fstesting.py
+++ b/tests/formats_test/fstesting.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 
 import abc
 from six import add_metaclass

--- a/tests/formats_test/init_test.py
+++ b/tests/formats_test/init_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 import copy
 import unittest
 

--- a/tests/formats_test/labeling_test.py
+++ b/tests/formats_test/labeling_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 import unittest
 
 from tests import loopbackedtestcase
@@ -104,5 +103,3 @@ class LabelingSwapSpaceTestCase(loopbackedtestcase.LoopBackedTestCase):
         swp = swap.SwapSpace(device=self.loopDevices[0], label="")
         self.assertIsNone(swp.create())
 
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/formats_test/selinux_test.py
+++ b/tests/formats_test/selinux_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 import os
 import selinux
 import tempfile
@@ -95,5 +94,3 @@ class SELinuxContextTestCase(loopbackedtestcase.LoopBackedTestCase):
         super(SELinuxContextTestCase, self).tearDown()
         blivet.flags.installer_mode = self.installer_mode
 
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/parentlist_test.py
+++ b/tests/parentlist_test.py
@@ -82,6 +82,3 @@ def suite():
     return unittest.TestLoader().loadTestsFromTestCase(ParentListTestCase)
 
 
-if __name__ == "__main__":
-    unittest.main()
-

--- a/tests/partitioning_test.py
+++ b/tests/partitioning_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 
 import unittest
 from mock import Mock
@@ -587,5 +586,3 @@ class ExtendedPartitionTestCase(ImageBackedTestCase):
 
         self.blivet.doIt()
 
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/size_test.py
+++ b/tests/size_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # pylint: disable=environment-modify
 #
 # tests/storage/size_tests.py
@@ -450,5 +449,3 @@ class UtilityMethodsTestCase(unittest.TestCase):
         self.assertIsInstance(2**Size(2), Decimal)
         self.assertIsInstance(1024 % Size(127), Decimal)
 
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/storagetestcase.py
+++ b/tests/storagetestcase.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 
 import unittest
 from mock import Mock

--- a/tests/tasks_test/basic_tests.py
+++ b/tests/tasks_test/basic_tests.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 import unittest
 
 import blivet.tasks.task as task

--- a/tests/tsort_test.py
+++ b/tests/tsort_test.py
@@ -52,5 +52,3 @@ class TopologicalSortTestCase(unittest.TestCase):
         self.failUnless(check_order(order, graph),
                         "ordering constraints not satisfied")
 
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/udev_test.py
+++ b/tests/udev_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 
 import unittest
 import mock
@@ -37,5 +36,3 @@ class UdevTest(unittest.TestCase):
         self.assertTrue(blivet.udev.util.run_program.called)
 
 
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 
 import unittest
 from decimal import Decimal


### PR DESCRIPTION
*  replaces /usr/bin/python with /usr/bin/env python inside test cases. NOTE: I don't see any executable tests/*.py files but maybe this is a good measure. Otherwise this line doesn't have any effect and can be removed.

There are still a few places which use hard-coded python version:

*    Makefile uses PYTHON=python2 which is used in a few places calling setup.py
*    some scripts/ use /usr/bin/python explicitly
*    runpylint.py uses /usr/bin/python3 explicitly
