### PR TITLE
Fix tests deprecation warnings in a backward compatible way

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,8 @@
+import six
+from unittest import TestCase
+
+# deprecation compatibility b/w python 2 and 3
+if six.PY2:
+    TestCase.assertRaisesRegex = TestCase.assertRaisesRegexp
+    TestCase.assertRegex = TestCase.assertRegexpMatches
+

--- a/tests/action_test.py
+++ b/tests/action_test.py
@@ -200,38 +200,30 @@ class DeviceActionTestCase(StorageTestCase):
         sdd = self.storage.devicetree.getDeviceByName("sdd")
         p = self.newDevice(device_class=PartitionDevice,
                            name="sdd1", size=Size("32 GiB"), parents=[sdd])
-        self.failUnlessRaises(ValueError,
-                              ActionResizeDevice,
-                              p,
-                              p.size + Size("7232 MiB"))
+        with self.assertRaises(ValueError):
+            ActionResizeDevice(p, p.size + Size("7232 MiB"))
 
         # instantiation of device resize action for non-resizable device
         # should fail
         vg = self.storage.devicetree.getDeviceByName("VolGroup")
         self.assertNotEqual(vg, None)
-        self.failUnlessRaises(ValueError,
-                              ActionResizeDevice,
-                              vg,
-                              vg.size + Size("32 MiB"))
+        with self.assertRaises(ValueError):
+            ActionResizeDevice(vg, vg.size + Size("32 MiB"))
 
         # instantiation of format resize action for non-resizable format type
         # should fail
         lv_swap = self.storage.devicetree.getDeviceByName("VolGroup-lv_swap")
         self.assertNotEqual(lv_swap, None)
-        self.failUnlessRaises(ValueError,
-                              ActionResizeFormat,
-                              lv_swap,
-                              lv_swap.size + Size("32 MiB"))
+        with self.assertRaises(ValueError):
+            ActionResizeFormat(lv_swap, lv_swap.size + Size("32 MiB"))
 
         # instantiation of format resize action for non-existent format
         # should fail
         lv_root = self.storage.devicetree.getDeviceByName("VolGroup-lv_root")
         self.assertNotEqual(lv_root, None)
         lv_root.format.exists = False
-        self.failUnlessRaises(ValueError,
-                              ActionResizeFormat,
-                              lv_root,
-                              lv_root.size - Size("1000 MiB"))
+        with self.assertRaises(ValueError):
+            ActionResizeFormat(lv_root, lv_root.size - Size("1000 MiB"))
         lv_root.format.exists = True
 
         # instantiation of device create action for existing device should
@@ -239,9 +231,8 @@ class DeviceActionTestCase(StorageTestCase):
         lv_swap = self.storage.devicetree.getDeviceByName("VolGroup-lv_swap")
         self.assertNotEqual(lv_swap, None)
         self.assertEqual(lv_swap.exists, True)
-        self.failUnlessRaises(ValueError,
-                              ActionCreateDevice,
-                              lv_swap)
+        with self.assertRaises(ValueError):
+            ActionCreateDevice(lv_swap)
 
         # instantiation of format destroy action for device causes device's
         # format attribute to be a DeviceFormat instance
@@ -273,9 +264,8 @@ class DeviceActionTestCase(StorageTestCase):
         self.assertNotEqual(vg, None)
         self.assertEqual(vg.isleaf, False)
         a = ActionDestroyDevice(vg)
-        self.failUnlessRaises(ValueError,
-                              self.storage.devicetree.registerAction,
-			      a)
+        with self.assertRaises(ValueError):
+            self.storage.devicetree.registerAction(a)
 
         # registering any action other than create for a device that's not in
         # the devicetree should fail
@@ -288,38 +278,33 @@ class DeviceActionTestCase(StorageTestCase):
         sdc1_format = self.newFormat("ext2", device=sdc1.path, mountpoint="/")
         create_sdc1_format = ActionCreateFormat(sdc1, sdc1_format)
         create_sdc1_format.apply()
-        self.failUnlessRaises(blivet.errors.DeviceTreeError,
-                              self.storage.devicetree.registerAction,
-                              create_sdc1_format)
+        with self.assertRaises(blivet.errors.DeviceTreeError):
+             self.storage.devicetree.registerAction(create_sdc1_format)
 
         sdc1_format.exists = True
         sdc1_format._resizable = True
         resize_sdc1_format = ActionResizeFormat(sdc1,
                                                 sdc1.size - Size("10 GiB"))
         resize_sdc1_format.apply()
-        self.failUnlessRaises(blivet.errors.DeviceTreeError,
-                              self.storage.devicetree.registerAction,
-                              resize_sdc1_format)
+        with self.assertRaises(blivet.errors.DeviceTreeError):
+            self.storage.devicetree.registerAction(resize_sdc1_format)
 
         resize_sdc1 = ActionResizeDevice(sdc1, sdc1.size - Size("10 GiB"))
         resize_sdc1.apply()
-        self.failUnlessRaises(blivet.errors.DeviceTreeError,
-                              self.storage.devicetree.registerAction,
-                              resize_sdc1)
+        with self.assertRaises(blivet.errors.DeviceTreeError):
+            self.storage.devicetree.registerAction(resize_sdc1)
 
         resize_sdc1.cancel()
         resize_sdc1_format.cancel()
 
         destroy_sdc1_format = ActionDestroyFormat(sdc1)
-        self.failUnlessRaises(blivet.errors.DeviceTreeError,
-                              self.storage.devicetree.registerAction,
-                              destroy_sdc1_format)
+        with self.assertRaises(blivet.errors.DeviceTreeError):
+            self.storage.devicetree.registerAction(destroy_sdc1_format)
 
 
         destroy_sdc1 = ActionDestroyDevice(sdc1)
-        self.failUnlessRaises(blivet.errors.DeviceTreeError,
-                              self.storage.devicetree.registerAction,
-                              destroy_sdc1)
+        with self.assertRaises(blivet.errors.DeviceTreeError):
+            self.storage.devicetree.registerAction(destroy_sdc1)
 
         # registering a device destroy action should cause the device to be
         # removed from the devicetree

--- a/tests/devicefactory_test.py
+++ b/tests/devicefactory_test.py
@@ -29,16 +29,16 @@ class MDFactoryTestCase(unittest.TestCase):
            raid_level=0)
 
     def testMDFactory(self):
-        with self.assertRaisesRegexp(devicefactory.DeviceFactoryError, "must have some RAID level"):
+        with self.assertRaisesRegex(devicefactory.DeviceFactoryError, "must have some RAID level"):
             devicefactory.get_device_factory(
                self.b,
                devicefactory.DEVICE_TYPE_MD,
                Size("1 GiB"))
 
-        with self.assertRaisesRegexp(RaidError, "requires at least"):
+        with self.assertRaisesRegex(RaidError, "requires at least"):
             self.factory1._get_device_space()
 
-        with self.assertRaisesRegexp(RaidError, "requires at least"):
+        with self.assertRaisesRegex(RaidError, "requires at least"):
             self.factory1._configure()
 
         self.assertEqual(self.factory1.container_list, [])
@@ -51,7 +51,7 @@ class MDFactoryTestCase(unittest.TestCase):
         ]
         self.assertIsNotNone(self.factory1._get_new_device(parents=parents))
 
-        with self.assertRaisesRegexp(RaidError, "requires at least"):
+        with self.assertRaisesRegex(RaidError, "requires at least"):
             self.factory2._get_device_space()
 
         self.assertEqual(self.factory2.container_list, [])

--- a/tests/devicelibs_test/raid_test.py
+++ b/tests/devicelibs_test/raid_test.py
@@ -13,7 +13,7 @@ class RaidTestCase(unittest.TestCase):
 
     def testRaid(self):
 
-        with self.assertRaisesRegexp(TypeError, "Can't instantiate abstract class"):
+        with self.assertRaisesRegex(TypeError, "Can't instantiate abstract class"):
             raid.ErsatzRAID()
 
         ##
@@ -145,11 +145,11 @@ class RaidTestCase(unittest.TestCase):
         ##
         ## __init__
         ##
-        with self.assertRaisesRegexp(errors.RaidError, "invalid RAID level"):
+        with self.assertRaisesRegex(errors.RaidError, "invalid RAID level"):
             self.levels_none.raidLevel(10)
 
-        with self.assertRaisesRegexp(errors.RaidError, "invalid RAID level"):
+        with self.assertRaisesRegex(errors.RaidError, "invalid RAID level"):
             self.levels_some.raidLevel(10)
 
-        with self.assertRaisesRegexp(errors.RaidError, "invalid standard RAID level descriptor"):
+        with self.assertRaisesRegex(errors.RaidError, "invalid standard RAID level descriptor"):
             raid.RAIDLevels(["raid3.1415"])

--- a/tests/devices_test/device_properties_test.py
+++ b/tests/devices_test/device_properties_test.py
@@ -60,7 +60,7 @@ class DeviceStateTestCase(unittest.TestCase):
            "parents" : xform(lambda x, m: self.assertEqual(len(x), 0, m) and
                                     self.assertIsInstance(x, ParentList, m)),
            "partitionable" : xform(self.assertFalse),
-           "path" : xform(lambda x, m: self.assertRegexpMatches(x, "^/dev", m)),
+           "path" : xform(lambda x, m: self.assertRegex(x, "^/dev", m)),
            "raw_device" : xform(self.assertIsNotNone),
            "resizable" : xform(self.assertFalse),
            "size" : xform(lambda x, m: self.assertEqual(x, Size(0), m)),
@@ -516,35 +516,35 @@ class MDRaidArrayDeviceTestCase(DeviceStateTestCase):
                         parents=xform(lambda x, m: self.assertEqual(len(x), 2, m)),
                         uuid=xform(lambda x, m: self.assertEqual(x, self.dev20.uuid, m)))
 
-        with self.assertRaisesRegexp(DeviceError, "invalid"):
+        with self.assertRaisesRegex(DeviceError, "invalid"):
             MDRaidArrayDevice("dev")
 
-        with self.assertRaisesRegexp(DeviceError, "invalid"):
+        with self.assertRaisesRegex(DeviceError, "invalid"):
             MDRaidArrayDevice("dev", level="raid2")
 
-        with self.assertRaisesRegexp(DeviceError, "invalid"):
+        with self.assertRaisesRegex(DeviceError, "invalid"):
             MDRaidArrayDevice(
                "dev",
                parents=[StorageDevice("parent", fmt=getFormat("mdmember"))])
 
-        with self.assertRaisesRegexp(DeviceError, "at least 2 members"):
+        with self.assertRaisesRegex(DeviceError, "at least 2 members"):
             MDRaidArrayDevice(
                "dev",
                level="raid0",
                parents=[StorageDevice("parent", fmt=getFormat("mdmember"))])
 
-        with self.assertRaisesRegexp(DeviceError, "invalid"):
+        with self.assertRaisesRegex(DeviceError, "invalid"):
             MDRaidArrayDevice("dev", level="junk")
 
-        with self.assertRaisesRegexp(DeviceError, "at least 2 members"):
+        with self.assertRaisesRegex(DeviceError, "at least 2 members"):
             MDRaidArrayDevice("dev", level=0, memberDevices=2)
 
     def testMDRaidArrayDeviceMethods(self):
         """Test for method calls on initialized MDRaidDevices."""
-        with self.assertRaisesRegexp(DeviceError, "invalid" ):
+        with self.assertRaisesRegex(DeviceError, "invalid" ):
             self.dev7.level = "junk"
 
-        with self.assertRaisesRegexp(DeviceError, "invalid" ):
+        with self.assertRaisesRegex(DeviceError, "invalid" ):
             self.dev7.level = None
 
 class BTRFSDeviceTestCase(DeviceStateTestCase):
@@ -614,26 +614,26 @@ class BTRFSDeviceTestCase(DeviceStateTestCase):
            size=xform(lambda x, m: self.assertEqual(x, Size("32 MiB"), m)),
            type=xform(lambda x, m: self.assertEqual(x, "btrfs volume", m)))
 
-        with self.assertRaisesRegexp(ValueError, "BTRFSDevice.*must have at least one parent"):
+        with self.assertRaisesRegex(ValueError, "BTRFSDevice.*must have at least one parent"):
             BTRFSVolumeDevice("dev")
 
-        with self.assertRaisesRegexp(ValueError, "format"):
+        with self.assertRaisesRegex(ValueError, "format"):
             BTRFSVolumeDevice("dev", parents=[StorageDevice("deva", size=btrfs.MIN_MEMBER_SIZE)])
 
-        with self.assertRaisesRegexp(DeviceError, "btrfs subvolume.*must be a btrfs volume"):
+        with self.assertRaisesRegex(DeviceError, "btrfs subvolume.*must be a btrfs volume"):
             fmt = blivet.formats.getFormat("btrfs")
             device = StorageDevice("deva", fmt=fmt, size=btrfs.MIN_MEMBER_SIZE)
             BTRFSSubVolumeDevice("dev1", parents=[device])
 
         deva = OpticalDevice("deva", fmt=blivet.formats.getFormat("btrfs"))
-        with self.assertRaisesRegexp(BTRFSValueError, "at least"):
+        with self.assertRaisesRegex(BTRFSValueError, "at least"):
             BTRFSVolumeDevice("dev1", dataLevel="raid1", parents=[deva])
 
         deva = StorageDevice("deva", fmt=blivet.formats.getFormat("btrfs"), size=btrfs.MIN_MEMBER_SIZE)
         self.assertIsNotNone(BTRFSVolumeDevice("dev1", metaDataLevel="dup", parents=[deva]))
 
         deva = StorageDevice("deva", fmt=blivet.formats.getFormat("btrfs"), size=btrfs.MIN_MEMBER_SIZE)
-        with self.assertRaisesRegexp(BTRFSValueError, "invalid"):
+        with self.assertRaisesRegex(BTRFSValueError, "invalid"):
             BTRFSVolumeDevice("dev1", dataLevel="dup", parents=[deva])
 
         self.assertEqual(self.dev1.isleaf, False)
@@ -658,24 +658,24 @@ class BTRFSDeviceTestCase(DeviceStateTestCase):
         self.assertIsNotNone(self.dev2.volume)
 
         # size
-        with self.assertRaisesRegexp(RuntimeError, "cannot directly set size of btrfs volume"):
+        with self.assertRaisesRegex(RuntimeError, "cannot directly set size of btrfs volume"):
             self.dev1.size = 32
 
     def testBTRFSSnapShotDeviceInit(self):
         parents = [StorageDevice("p1", fmt=blivet.formats.getFormat("btrfs"), size=btrfs.MIN_MEMBER_SIZE)]
         vol = BTRFSVolumeDevice("test", parents=parents)
-        with self.assertRaisesRegexp(ValueError, "non-existent btrfs snapshots must have a source"):
+        with self.assertRaisesRegex(ValueError, "non-existent btrfs snapshots must have a source"):
             BTRFSSnapShotDevice("snap1", parents=[vol])
 
-        with self.assertRaisesRegexp(ValueError, "btrfs snapshot source must already exist"):
+        with self.assertRaisesRegex(ValueError, "btrfs snapshot source must already exist"):
             BTRFSSnapShotDevice("snap1", parents=[vol], source=vol)
 
-        with self.assertRaisesRegexp(ValueError, "btrfs snapshot source must be a btrfs subvolume"):
+        with self.assertRaisesRegex(ValueError, "btrfs snapshot source must be a btrfs subvolume"):
             BTRFSSnapShotDevice("snap1", parents=[vol], source=parents[0])
 
         parents2 = [StorageDevice("p1", fmt=blivet.formats.getFormat("btrfs"), size=btrfs.MIN_MEMBER_SIZE)]
         vol2 = BTRFSVolumeDevice("test2", parents=parents2, exists=True)
-        with self.assertRaisesRegexp(ValueError, ".*snapshot and source must be in the same volume"):
+        with self.assertRaisesRegex(ValueError, ".*snapshot and source must be in the same volume"):
             BTRFSSnapShotDevice("snap1", parents=[vol], source=vol2)
 
         vol.exists = True

--- a/tests/devices_test/lvm_test.py
+++ b/tests/devices_test/lvm_test.py
@@ -32,16 +32,16 @@ class LVMDeviceTest(unittest.TestCase):
         lv = LVMLogicalVolumeDevice("testlv", parents=[vg],
                                     fmt=blivet.formats.getFormat("xfs"))
 
-        with self.assertRaisesRegexp(ValueError, "lvm snapshot devices require an origin lv"):
+        with self.assertRaisesRegex(ValueError, "lvm snapshot devices require an origin lv"):
             LVMSnapShotDevice("snap1", parents=[vg])
 
-        with self.assertRaisesRegexp(ValueError, "lvm snapshot origin volume must already exist"):
+        with self.assertRaisesRegex(ValueError, "lvm snapshot origin volume must already exist"):
             LVMSnapShotDevice("snap1", parents=[vg], origin=lv)
 
-        with self.assertRaisesRegexp(ValueError, "lvm snapshot origin must be a logical volume"):
+        with self.assertRaisesRegex(ValueError, "lvm snapshot origin must be a logical volume"):
             LVMSnapShotDevice("snap1", parents=[vg], origin=pv)
 
-        with self.assertRaisesRegexp(ValueError, "only existing vorigin snapshots are supported"):
+        with self.assertRaisesRegex(ValueError, "only existing vorigin snapshots are supported"):
             LVMSnapShotDevice("snap1", parents=[vg], vorigin=True)
 
         lv.exists = True
@@ -67,13 +67,13 @@ class LVMDeviceTest(unittest.TestCase):
         thinlv = LVMThinLogicalVolumeDevice("thinlv", parents=[pool],
                                             size=Size("200 MiB"))
 
-        with self.assertRaisesRegexp(ValueError, "lvm thin snapshots require an origin"):
+        with self.assertRaisesRegex(ValueError, "lvm thin snapshots require an origin"):
             LVMThinSnapShotDevice("snap1", parents=[pool])
 
-        with self.assertRaisesRegexp(ValueError, "lvm snapshot origin volume must already exist"):
+        with self.assertRaisesRegex(ValueError, "lvm snapshot origin volume must already exist"):
             LVMThinSnapShotDevice("snap1", parents=[pool], origin=thinlv)
 
-        with self.assertRaisesRegexp(ValueError, "lvm snapshot origin must be a logical volume"):
+        with self.assertRaisesRegex(ValueError, "lvm snapshot origin must be a logical volume"):
             LVMThinSnapShotDevice("snap1", parents=[pool], origin=pv)
 
         # now make the constructor succeed so we can test some properties
@@ -111,7 +111,7 @@ class LVMDeviceTest(unittest.TestCase):
         self.assertEqual(lv.size, orig_size)
 
         # ValueError if size smaller than minSize
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      "size.*smaller than the minimum"):
             lv.targetSize = Size("1 MiB")
 
@@ -119,7 +119,7 @@ class LVMDeviceTest(unittest.TestCase):
         self.assertEqual(lv.targetSize, orig_size)
 
         # ValueError if size larger than maxSize
-        with self.assertRaisesRegexp(ValueError,
+        with self.assertRaisesRegex(ValueError,
                                      "size.*larger than the maximum"):
             lv.targetSize = Size("1 GiB")
 

--- a/tests/devices_test/partition_test.py
+++ b/tests/devices_test/partition_test.py
@@ -44,28 +44,28 @@ class PartitionDeviceTestCase(unittest.TestCase):
             self.assertEqual(device.maxSize, Size("9 MiB"))
 
             # ValueError if not Size
-            with self.assertRaisesRegexp(ValueError,
+            with self.assertRaisesRegex(ValueError,
                                          "new size must.*type Size"):
                 device.targetSize = 22
 
             self.assertEqual(device.targetSize, orig_size)
 
             # ValueError if size smaller than minSize
-            with self.assertRaisesRegexp(ValueError,
+            with self.assertRaisesRegex(ValueError,
                                          "size.*smaller than the minimum"):
                 device.targetSize = Size("1 MiB")
 
             self.assertEqual(device.targetSize, orig_size)
 
             # ValueError if size larger than maxSize
-            with self.assertRaisesRegexp(ValueError,
+            with self.assertRaisesRegex(ValueError,
                                          "size.*larger than the maximum"):
                 device.targetSize = Size("11 MiB")
 
             self.assertEqual(device.targetSize, orig_size)
 
             # ValueError if unaligned
-            with self.assertRaisesRegexp(ValueError, "new size.*not.*aligned"):
+            with self.assertRaisesRegex(ValueError, "new size.*not.*aligned"):
                 device.targetSize = Size("3.1 MiB")
 
             self.assertEqual(device.targetSize, orig_size)

--- a/tests/formats_test/fslabeling.py
+++ b/tests/formats_test/fslabeling.py
@@ -96,11 +96,11 @@ class LabelingWithRelabeling(LabelingAsRoot):
         self.assertIsNone(an_fs.writeLabel())
 
         an_fs.label = None
-        with self.assertRaisesRegexp(FSError, "default label"):
+        with self.assertRaisesRegex(FSError, "default label"):
             an_fs.writeLabel()
 
         an_fs.label = self._invalid_label
-        with self.assertRaisesRegexp(FSError, "bad label format"):
+        with self.assertRaisesRegex(FSError, "bad label format"):
             an_fs.writeLabel()
 
 class CompleteLabelingAsRoot(LabelingAsRoot):
@@ -135,11 +135,11 @@ class CompleteLabelingAsRoot(LabelingAsRoot):
         self.assertEqual(an_fs.readLabel(), an_fs.label)
 
         an_fs.label = None
-        with self.assertRaisesRegexp(FSError, "default label"):
+        with self.assertRaisesRegex(FSError, "default label"):
             an_fs.writeLabel()
 
         an_fs.label = "n" * 129
-        with self.assertRaisesRegexp(FSError, "bad label format"):
+        with self.assertRaisesRegex(FSError, "bad label format"):
             an_fs.writeLabel()
 
     def testCreating(self):

--- a/tests/partitioning_test.py
+++ b/tests/partitioning_test.py
@@ -184,7 +184,7 @@ class PartitioningTestCase(unittest.TestCase):
             #
             # fail: add a logical partition to a primary free region
             #
-            with self.assertRaisesRegexp(parted.PartitionException,
+            with self.assertRaisesRegex(parted.PartitionException,
                                          "no extended partition"):
                 part = addPartition(disk.format, free, parted.PARTITION_LOGICAL,
                                     Size("10 MiB"))
@@ -216,7 +216,7 @@ class PartitioningTestCase(unittest.TestCase):
             #
             # fail: add a primary partition to an extended free region
             #
-            with self.assertRaisesRegexp(parted.PartitionException, "overlap"):
+            with self.assertRaisesRegex(parted.PartitionException, "overlap"):
                 part = addPartition(disk.format, all_free[1],
                                     parted.PARTITION_NORMAL,
                                     Size("10 MiB"), all_free[1].start)
@@ -296,7 +296,7 @@ class PartitioningTestCase(unittest.TestCase):
             disks = [disk]
             partitions = [p1, p2]
             free = getFreeRegions([disk])
-            self.assertEquals(len(free), 1,
+            self.assertEqual(len(free), 1,
                               "free region count %d not expected" % len(free))
 
             b = Mock()
@@ -359,7 +359,7 @@ class PartitioningTestCase(unittest.TestCase):
             disks = [disk]
             partitions = [p1, p2, p3, p4, p5]
             free = getFreeRegions([disk])
-            self.assertEquals(len(free), 1,
+            self.assertEqual(len(free), 1,
                               "free region count %d not expected" % len(free))
 
             b = Mock()

--- a/tests/size_test.py
+++ b/tests/size_test.py
@@ -59,17 +59,17 @@ class SizeTestCase(unittest.TestCase):
         c = numunits * unit.factor
 
         s = Size(c)
-        self.assertEquals(s, Size(c))
+        self.assertEqual(s, Size(c))
 
         u = size._makeSpec(unit.prefix, size._BYTES_WORDS[0], False)
         s = Size("%ld %s" % (numunits, u))
-        self.assertEquals(s, c)
-        self.assertEquals(s.convertTo(unit), numunits)
+        self.assertEqual(s, c)
+        self.assertEqual(s.convertTo(unit), numunits)
 
         u = size._makeSpec(unit.abbr, size._BYTES_SYMBOL, False)
         s = Size("%ld %s" % (numunits, u))
-        self.assertEquals(s, c)
-        self.assertEquals(s.convertTo(unit), numunits)
+        self.assertEqual(s, c)
+        self.assertEqual(s.convertTo(unit), numunits)
 
     def testPrefixes(self):
         numbytes = 47
@@ -79,115 +79,115 @@ class SizeTestCase(unittest.TestCase):
 
     def testHumanReadable(self):
         s = Size(58929971)
-        self.assertEquals(s.humanReadable(), "56.2 MiB")
+        self.assertEqual(s.humanReadable(), "56.2 MiB")
 
         s = Size(478360371)
-        self.assertEquals(s.humanReadable(), "456.2 MiB")
+        self.assertEqual(s.humanReadable(), "456.2 MiB")
 
         # humanReable output should be the same as input for big enough sizes
         # and enough places and integer values
         s = Size("12.68 TiB")
-        self.assertEquals(s.humanReadable(max_places=2), "12.68 TiB")
+        self.assertEqual(s.humanReadable(max_places=2), "12.68 TiB")
         s = Size("26.55 MiB")
-        self.assertEquals(s.humanReadable(max_places=2), "26.55 MiB")
+        self.assertEqual(s.humanReadable(max_places=2), "26.55 MiB")
         s = Size("300 MiB")
-        self.assertEquals(s.humanReadable(max_places=2), "300 MiB")
+        self.assertEqual(s.humanReadable(max_places=2), "300 MiB")
 
         # when min_value is 10 and single digit on left of decimal, display
         # with smaller unit.
         s = Size("9.68 TiB")
-        self.assertEquals(s.humanReadable(max_places=2, min_value=10), "9912.32 GiB")
+        self.assertEqual(s.humanReadable(max_places=2, min_value=10), "9912.32 GiB")
         s = Size("4.29 MiB")
-        self.assertEquals(s.humanReadable(max_places=2, min_value=10), "4392.96 KiB")
+        self.assertEqual(s.humanReadable(max_places=2, min_value=10), "4392.96 KiB")
         s = Size("7.18 KiB")
-        self.assertEquals(s.humanReadable(max_places=2, min_value=10), "7352 B")
+        self.assertEqual(s.humanReadable(max_places=2, min_value=10), "7352 B")
 
         # rounding should work with max_places limitted
         s = Size("12.687 TiB")
-        self.assertEquals(s.humanReadable(max_places=2), "12.69 TiB")
+        self.assertEqual(s.humanReadable(max_places=2), "12.69 TiB")
         s = Size("23.7874 TiB")
-        self.assertEquals(s.humanReadable(max_places=3), "23.787 TiB")
+        self.assertEqual(s.humanReadable(max_places=3), "23.787 TiB")
         s = Size("12.6998 TiB")
-        self.assertEquals(s.humanReadable(max_places=2), "12.7 TiB")
+        self.assertEqual(s.humanReadable(max_places=2), "12.7 TiB")
 
         # byte values close to multiples of 2 are shown without trailing zeros
         s = Size(0xff)
-        self.assertEquals(s.humanReadable(max_places=2), "255 B")
+        self.assertEqual(s.humanReadable(max_places=2), "255 B")
         s = Size(8193)
-        self.assertEquals(s.humanReadable(max_places=2, min_value=10), "8193 B")
+        self.assertEqual(s.humanReadable(max_places=2, min_value=10), "8193 B")
 
         # a fractional quantity is shown if the value deviates
         # from the whole number of units by more than 1%
         s = Size(16384 - (1024/100 + 1))
-        self.assertEquals(s.humanReadable(max_places=2), "15.99 KiB")
+        self.assertEqual(s.humanReadable(max_places=2), "15.99 KiB")
 
         # if max_places is set to None, all digits are displayed
         s = Size(0xfffffffffffff)
-        self.assertEquals(s.humanReadable(max_places=None), "3.9999999999999991118215803 PiB")
+        self.assertEqual(s.humanReadable(max_places=None), "3.9999999999999991118215803 PiB")
         s = Size(0x10000)
-        self.assertEquals(s.humanReadable(max_places=None), "64 KiB")
+        self.assertEqual(s.humanReadable(max_places=None), "64 KiB")
         s = Size(0x10001)
-        self.assertEquals(s.humanReadable(max_places=None), "64.0009765625 KiB")
+        self.assertEqual(s.humanReadable(max_places=None), "64.0009765625 KiB")
 
         # test a very large quantity with no associated abbreviation or prefix
         s = Size(1024**9)
-        self.assertEquals(s.humanReadable(max_places=2), "1024 YiB")
+        self.assertEqual(s.humanReadable(max_places=2), "1024 YiB")
         s = Size(1024**9 - 1)
-        self.assertEquals(s.humanReadable(max_places=2), "1024 YiB")
+        self.assertEqual(s.humanReadable(max_places=2), "1024 YiB")
         s = Size(1024**9 + 1)
-        self.assertEquals(s.humanReadable(max_places=2, strip=False), "1024.00 YiB")
+        self.assertEqual(s.humanReadable(max_places=2, strip=False), "1024.00 YiB")
         s = Size(1024**10)
-        self.assertEquals(s.humanReadable(max_places=2), "1048576 YiB")
+        self.assertEqual(s.humanReadable(max_places=2), "1048576 YiB")
 
     def testHumanReadableFractionalQuantities(self):
         s = Size(0xfffffffffffff)
-        self.assertEquals(s.humanReadable(max_places=2), "4 PiB")
+        self.assertEqual(s.humanReadable(max_places=2), "4 PiB")
         s = Size(0xfffff)
-        self.assertEquals(s.humanReadable(max_places=2, strip=False), "1024.00 KiB")
+        self.assertEqual(s.humanReadable(max_places=2, strip=False), "1024.00 KiB")
         s = Size(0xffff)
         # value is not exactly 64 KiB, but w/ 2 places, value is 64.00 KiB
         # so the trailing 0s are stripped.
-        self.assertEquals(s.humanReadable(max_places=2), "64 KiB")
+        self.assertEqual(s.humanReadable(max_places=2), "64 KiB")
         # since all significant digits are shown, there are no trailing 0s.
-        self.assertEquals(s.humanReadable(max_places=None), "63.9990234375 KiB")
+        self.assertEqual(s.humanReadable(max_places=None), "63.9990234375 KiB")
 
         # deviation is less than 1/2 of 1% of 1024
         s = Size(16384 - (1024/100//2))
-        self.assertEquals(s.humanReadable(max_places=2), "16 KiB")
+        self.assertEqual(s.humanReadable(max_places=2), "16 KiB")
         # deviation is greater than 1/2 of 1% of 1024
         s = Size(16384 - ((1024/100//2) + 1))
-        self.assertEquals(s.humanReadable(max_places=2), "15.99 KiB")
+        self.assertEqual(s.humanReadable(max_places=2), "15.99 KiB")
 
         s = Size(0x10000000000000)
-        self.assertEquals(s.humanReadable(max_places=2), "4 PiB")
+        self.assertEqual(s.humanReadable(max_places=2), "4 PiB")
 
 
     def testMinValue(self):
         s = Size("9 MiB")
-        self.assertEquals(s.humanReadable(), "9 MiB")
-        self.assertEquals(s.humanReadable(min_value=10), "9216 KiB")
+        self.assertEqual(s.humanReadable(), "9 MiB")
+        self.assertEqual(s.humanReadable(min_value=10), "9216 KiB")
 
         s = Size("0.5 GiB")
-        self.assertEquals(s.humanReadable(max_places=2, min_value=1), "512 MiB")
-        self.assertEquals(s.humanReadable(max_places=2, min_value=Decimal("0.1")), "0.5 GiB")
-        self.assertEquals(s.humanReadable(max_places=2, min_value=Decimal(1)), "512 MiB")
+        self.assertEqual(s.humanReadable(max_places=2, min_value=1), "512 MiB")
+        self.assertEqual(s.humanReadable(max_places=2, min_value=Decimal("0.1")), "0.5 GiB")
+        self.assertEqual(s.humanReadable(max_places=2, min_value=Decimal(1)), "512 MiB")
 
     def testConvertToPrecision(self):
         s = Size(1835008)
-        self.assertEquals(s.convertTo(None), 1835008)
-        self.assertEquals(s.convertTo(B), 1835008)
-        self.assertEquals(s.convertTo(KiB), 1792)
-        self.assertEquals(s.convertTo(MiB), Decimal("1.75"))
+        self.assertEqual(s.convertTo(None), 1835008)
+        self.assertEqual(s.convertTo(B), 1835008)
+        self.assertEqual(s.convertTo(KiB), 1792)
+        self.assertEqual(s.convertTo(MiB), Decimal("1.75"))
 
     def testNegative(self):
         s = Size("-500MiB")
-        self.assertEquals(s.humanReadable(), "-500 MiB")
-        self.assertEquals(s.convertTo(B), -524288000)
+        self.assertEqual(s.humanReadable(), "-500 MiB")
+        self.assertEqual(s.convertTo(B), -524288000)
 
     def testPartialBytes(self):
-        self.assertEquals(Size("1024.6"), Size(1024))
-        self.assertEquals(Size("%s KiB" % (1/1025.0,)), Size(0))
-        self.assertEquals(Size("%s KiB" % (1/1023.0,)), Size(1))
+        self.assertEqual(Size("1024.6"), Size(1024))
+        self.assertEqual(Size("%s KiB" % (1/1025.0,)), Size(0))
+        self.assertEqual(Size("%s KiB" % (1/1023.0,)), Size(1))
 
     def testNoUnitsInString(self):
         self.assertEqual(Size("1024"), Size("1 KiB"))
@@ -332,25 +332,25 @@ class TranslationTestCase(unittest.TestCase):
             locale.setlocale(locale.LC_ALL, '')
 
             # Check English parsing
-            self.assertEquals(s, Size("56.19 MiB"))
+            self.assertEqual(s, Size("56.19 MiB"))
 
             # Check native parsing
-            self.assertEquals(s, Size("56.19 %s%s" % (_("Mi"), _("B"))))
+            self.assertEqual(s, Size("56.19 %s%s" % (_("Mi"), _("B"))))
 
             # Check native parsing, all lowercase
-            self.assertEquals(s, Size(("56.19 %s%s" % (_("Mi"), _("B"))).lower()))
+            self.assertEqual(s, Size(("56.19 %s%s" % (_("Mi"), _("B"))).lower()))
 
             # Check native parsing, all uppercase
-            self.assertEquals(s, Size(("56.19 %s%s" % (_("Mi"), _("B"))).upper()))
+            self.assertEqual(s, Size(("56.19 %s%s" % (_("Mi"), _("B"))).upper()))
 
             # If the radix separator is not a period, repeat the tests with the
             # native separator
             radix = locale.nl_langinfo(locale.RADIXCHAR)
             if radix != '.':
-                self.assertEquals(s, Size("56%s19 MiB" % radix))
-                self.assertEquals(s, Size("56%s19 %s%s" % (radix, _("Mi"), _("B"))))
-                self.assertEquals(s, Size(("56%s19 %s%s" % (radix, _("Mi"), _("B"))).lower()))
-                self.assertEquals(s, Size(("56%s19 %s%s" % (radix, _("Mi"), _("B"))).upper()))
+                self.assertEqual(s, Size("56%s19 MiB" % radix))
+                self.assertEqual(s, Size("56%s19 %s%s" % (radix, _("Mi"), _("B"))))
+                self.assertEqual(s, Size(("56%s19 %s%s" % (radix, _("Mi"), _("B"))).lower()))
+                self.assertEqual(s, Size(("56%s19 %s%s" % (radix, _("Mi"), _("B"))).upper()))
 
     def testHumanReadableTranslation(self):
         s = Size("56.19 MiB")

--- a/tests/tsort_test.py
+++ b/tests/tsort_test.py
@@ -15,15 +15,13 @@ class TopologicalSortTestCase(unittest.TestCase):
 
         edges = [(5, 4), (4, 3), (3, 2), (2, 1), (3, 5)]
         graph = blivet.tsort.create_graph(items, edges)
-        self.failUnlessRaises(blivet.tsort.CyclicGraphError,
-                              blivet.tsort.tsort,
-                              graph)
+        with self.assertRaises(blivet.tsort.CyclicGraphError):
+            blivet.tsort.tsort(graph)
 
         edges = [(5, 4), (4, 3), (3, 2), (2, 1), (2, 3)]
         graph = blivet.tsort.create_graph(items, edges)
-        self.failUnlessRaises(blivet.tsort.CyclicGraphError,
-                              blivet.tsort.tsort,
-                              graph)
+        with self.assertRaises(blivet.tsort.CyclicGraphError):
+            blivet.tsort.tsort(graph)
 
         items = ['a', 'b', 'c', 'd']
         edges = [('a', 'c'), ('c', 'b')]
@@ -45,9 +43,9 @@ class TopologicalSortTestCase(unittest.TestCase):
             self.fail(e)
 
         # verify output list is of the correct length
-        self.failIf(len(order) != len(graph['items']),
+        self.assertFalse(len(order) != len(graph['items']),
                     "sorted list length is incorrect")
 
         # verify that all ordering constraints are satisfied
-        self.failUnless(check_order(order, graph),
+        self.assertTrue(check_order(order, graph),
                         "ordering constraints not satisfied")


### PR DESCRIPTION
From the original review in PR #120

@mulkieran
> Please use "with self.assertRaises" everywhere. It's just easier on the eyes.

This doesn't work b/c assertRaises and assertRaisesRegex are different. I'm not quite sure what do you mean but directly changing one for the other doesn't seem to work.

> Also, we always use six.PY2 and six.PY3 to check the python version for this kind of thing, not sys.version_info, so it's probably best to stick with that.

Fixed.

> I think you should be able to avoid modifying the class hierarchy to deal with the versioning problem in commit 3. You might consider modifying unittest.TestCase instead, for example.

Let me see how can I do this. Is there a place where I can hook into before the test cases are actually executed? If so I can monkey-patch unittest.TestCase instead of creating another base class.