### PR TITLE
Drop check from the release build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ tag:
 	  echo "Tagged as $$tag" ; \
 	done
 
-release: check tag archive
+release: tag archive
 
 archive: po-pull
 	@rm -f ChangeLog


### PR DESCRIPTION
It has become impossible to do builds for rawhide from previous releases
because the system is expected to match what it's being built for. Run
make check manually when making commits instead.