### PR TITLE
Use default md metadata version for everything except /boot/efi

### DIFF
--- a/blivet/devices/md.py
+++ b/blivet/devices/md.py
@@ -457,16 +457,8 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
         """ Determine create parameters for this set """
         mountpoints = kwargs.pop("mountpoints")
         log_method_call(self, self.name, mountpoints)
-
-        if "/boot" in mountpoints:
-            bootmountpoint = "/boot"
-        else:
-            bootmountpoint = "/"
-
-        # If we are used to boot from we cannot use 1.1 metadata
-        if getattr(self.format, "mountpoint", None) == bootmountpoint or \
-           getattr(self.format, "mountpoint", None) == "/boot/efi" or \
-           self.format.type == "prepboot":
+        # UEFI firmware/bootloader cannot read 1.1 or 1.2 metadata arrays
+        if getattr(self.format, "mountpoint", None) == "/boot/efi":
             self.metadataVersion = "1.0"
 
     def _postCreate(self):

--- a/blivet/devices/md.py
+++ b/blivet/devices/md.py
@@ -453,10 +453,9 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
 
         self._postTeardown(recursive=recursive)
 
-    def preCommitFixup(self, *args, **kwargs):
+    def preCommitFixup(self):
         """ Determine create parameters for this set """
-        mountpoints = kwargs.pop("mountpoints")
-        log_method_call(self, self.name, mountpoints)
+        log_method_call(self, self.name)
         # UEFI firmware/bootloader cannot read 1.1 or 1.2 metadata arrays
         if getattr(self.format, "mountpoint", None) == "/boot/efi":
             self.metadataVersion = "1.0"

--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -337,7 +337,7 @@ class PartitionDevice(StorageDevice):
     partedPartition = property(lambda d: d._getPartedPartition(),
                                lambda d,p: d._setPartedPartition(p))
 
-    def preCommitFixup(self, *args, **kwargs):
+    def preCommitFixup(self):
         """ Re-get self.partedPartition from the original disklabel. """
         log_method_call(self, self.name)
         if not self.exists:

--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -628,7 +628,7 @@ class StorageDevice(Device):
                       lambda d,f: d._setFormat(f),
                       doc="The device's formatting.")
 
-    def preCommitFixup(self, *args, **kwargs):
+    def preCommitFixup(self):
         """ Do any necessary pre-commit fixups."""
         pass
 


### PR DESCRIPTION
We began using this metadata version because grub1 could not read arrays with v1.1 or newer metadata. Now that we're using grub2 we can stop using v1.0. The UEFI bootloader still needs us to use v1.0 for /boot/efi arrays.

See https://bugzilla.redhat.com/show_bug.cgi?id=1061711#c6
