### PR TITLE
Fix setting original size for format resize action. (#1225352)

### DIFF
--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -755,7 +755,13 @@ class ActionResizeFormat(DeviceAction):
             self.dir = RESIZE_GROW
         else:
             self.dir = RESIZE_SHRINK
-        self.origSize = self.device.format.targetSize
+
+        if device.format.targetSize > Size(0):
+            self.origSize = device.format.targetSize
+        # no targetSize -- original size for device was its currentSize
+        else:
+            self.origSize = device.format.currentSize
+
         self._targetSize = newsize
 
     def apply(self):


### PR DESCRIPTION
Simple fix for https://bugzilla.redhat.com/show_bug.cgi?id=1225352 Cancelling of ActionResizeFormat fails because the origSize is set to format.targetSize that can be 0.