### PR TITLE
Remove facilities for running tests as standalone modules.

### DIFF
--- a/tests/action_test.py
+++ b/tests/action_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 
 import unittest
 
@@ -1162,7 +1161,3 @@ class DeviceActionTestCase(StorageTestCase):
     def testActionSorting(self, *args, **kwargs):
         """ Verify correct functioning of action sorting. """
         pass
-
-if __name__ == "__main__":
-    unittest.main()
-

--- a/tests/devicefactory_test.py
+++ b/tests/devicefactory_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 
 import unittest
 
@@ -58,6 +57,3 @@ class MDFactoryTestCase(unittest.TestCase):
         self.assertEqual(self.factory2.container_list, [])
 
         self.assertIsNone(self.factory2.get_container())
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/devicelibs_test/mdraid_test.py
+++ b/tests/devicelibs_test/mdraid_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 import unittest
 
 import blivet.devicelibs.mdraid as mdraid
@@ -16,6 +15,3 @@ class MDRaidTestCase(unittest.TestCase):
         self.assertEqual(mdraid.RAID_levels.raidLevel(5).name, "raid5")
         self.assertEqual(mdraid.RAID_levels.raidLevel("RAID6").name, "raid6")
         self.assertEqual(mdraid.RAID_levels.raidLevel("raid10").name, "raid10")
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/devicelibs_test/raid_test.py
+++ b/tests/devicelibs_test/raid_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 import unittest
 
 import blivet.devicelibs.raid as raid

--- a/tests/devices_test/dependencies_test.py
+++ b/tests/devices_test/dependencies_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # vim:set fileencoding=utf-8
 
 import unittest
@@ -85,6 +84,3 @@ class MockingDeviceDependenciesTestCase(unittest.TestCase):
         availability.BLOCKDEV_DM_PLUGIN.available # pylint: disable=pointless-statement
 
         availability.CACHE_AVAILABILITY = self.cache_availability
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/devices_test/device_names_test.py
+++ b/tests/devices_test/device_names_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # vim:set fileencoding=utf-8
 
 import unittest
@@ -41,6 +40,3 @@ class DeviceNameTestCase(unittest.TestCase):
 
         for name in bad_names:
             self.assertFalse(LVMLogicalVolumeDevice.isNameValid(name))
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/devices_test/device_packages_test.py
+++ b/tests/devices_test/device_packages_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # vim:set fileencoding=utf-8
 
 import unittest
@@ -29,6 +28,3 @@ class DevicePackagesTestCase(unittest.TestCase):
 
         for package in dev1.format.packages + dev2.format.packages + dev.format.packages:
             self.assertIn(package, packages)
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/devices_test/device_properties_test.py
+++ b/tests/devices_test/device_properties_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # vim:set fileencoding=utf-8
 
 import unittest
@@ -709,6 +708,3 @@ class BTRFSDeviceTestCase(DeviceStateTestCase):
 
         self.assertEqual(snap.dependsOn(vol), True)
         self.assertEqual(vol.dependsOn(snap), False)
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/devices_test/lvm_test.py
+++ b/tests/devices_test/lvm_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # vim:set fileencoding=utf-8
 
 import unittest
@@ -137,6 +136,3 @@ class LVMDeviceTest(unittest.TestCase):
         lv.targetSize = orig_size
         self.assertEqual(lv.targetSize, orig_size)
         self.assertEqual(lv.size, orig_size)
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/devices_test/network_test.py
+++ b/tests/devices_test/network_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # vim:set fileencoding=utf-8
 
 import unittest
@@ -35,6 +34,3 @@ class NetDevMountOptionTestCase(unittest.TestCase):
         dev.create()
 
         self.assertTrue("_netdev" in dev.format.options.split(","))
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/devices_test/partition_test.py
+++ b/tests/devices_test/partition_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # vim:set fileencoding=utf-8
 
 import os
@@ -155,6 +154,3 @@ class PartitionDeviceTestCase(unittest.TestCase):
             self.assertEqual(
                 disk.format.endAlignment.isAligned(free, max_end_sector),
                 True)
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/devicetree_test.py
+++ b/tests/devicetree_test.py
@@ -278,6 +278,3 @@ class LVMOnMDTestCase(BlivetResetTestCase):
                                   None,
                                   disks=self.blivet.disks[:],
                                   container_raid_level="raid1")
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/formats_test/device_test.py
+++ b/tests/formats_test/device_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 import unittest
 
 import blivet
@@ -78,6 +77,3 @@ class DeviceValueTestCase(unittest.TestCase):
                 an_fs.device = "/abc:/def"
                 self.assertEqual(an_fs.type, typ)
                 self.assertEqual(an_fs.device, "/abc:/def")
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/formats_test/fs_test.py
+++ b/tests/formats_test/fs_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 import os
 import tempfile
 import unittest
@@ -139,6 +138,3 @@ class ResizeTmpFSTestCase(loopbackedtestcase.LoopBackedTestCase):
         except Exception: # pylint: disable=broad-except
             pass
         os.rmdir(self.mountpoint)
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/formats_test/fslabeling.py
+++ b/tests/formats_test/fslabeling.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 
 import abc
 from six import add_metaclass

--- a/tests/formats_test/fstesting.py
+++ b/tests/formats_test/fstesting.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 
 import abc
 from six import add_metaclass

--- a/tests/formats_test/init_test.py
+++ b/tests/formats_test/init_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 import copy
 import unittest
 

--- a/tests/formats_test/labeling_test.py
+++ b/tests/formats_test/labeling_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 import unittest
 
 from tests import loopbackedtestcase
@@ -103,6 +102,3 @@ class LabelingSwapSpaceTestCase(loopbackedtestcase.LoopBackedTestCase):
     def testCreatingSwapSpaceEmpty(self):
         swp = swap.SwapSpace(device=self.loopDevices[0], label="")
         self.assertIsNone(swp.create())
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/formats_test/selinux_test.py
+++ b/tests/formats_test/selinux_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 import os
 import selinux
 import tempfile
@@ -94,6 +93,3 @@ class SELinuxContextTestCase(loopbackedtestcase.LoopBackedTestCase):
     def tearDown(self):
         super(SELinuxContextTestCase, self).tearDown()
         blivet.flags.installer_mode = self.installer_mode
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/parentlist_test.py
+++ b/tests/parentlist_test.py
@@ -76,12 +76,3 @@ class ParentListTestCase(unittest.TestCase):
 
         dev3.parents = []
         self.assertEqual(len(dev3.parents), 0)
-
-
-def suite():
-    return unittest.TestLoader().loadTestsFromTestCase(ParentListTestCase)
-
-
-if __name__ == "__main__":
-    unittest.main()
-

--- a/tests/partitioning_test.py
+++ b/tests/partitioning_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 
 import unittest
 from mock import Mock
@@ -586,6 +585,3 @@ class ExtendedPartitionTestCase(ImageBackedTestCase):
                          "user-specified extended partition was removed")
 
         self.blivet.doIt()
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/size_test.py
+++ b/tests/size_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 # pylint: disable=environment-modify
 #
 # tests/storage/size_tests.py
@@ -449,6 +448,3 @@ class UtilityMethodsTestCase(unittest.TestCase):
         self.assertIsInstance(2/s, Decimal)
         self.assertIsInstance(2**Size(2), Decimal)
         self.assertIsInstance(1024 % Size(127), Decimal)
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/storagetestcase.py
+++ b/tests/storagetestcase.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 
 import unittest
 from mock import Mock

--- a/tests/tasks_test/basic_tests.py
+++ b/tests/tasks_test/basic_tests.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 import unittest
 
 import blivet.tasks.task as task

--- a/tests/tsort_test.py
+++ b/tests/tsort_test.py
@@ -51,6 +51,3 @@ class TopologicalSortTestCase(unittest.TestCase):
         # verify that all ordering constraints are satisfied
         self.failUnless(check_order(order, graph),
                         "ordering constraints not satisfied")
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/udev_test.py
+++ b/tests/udev_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 
 import unittest
 import mock
@@ -35,7 +34,3 @@ class UdevTest(unittest.TestCase):
         import blivet.udev
         blivet.udev.trigger()
         self.assertTrue(blivet.udev.util.run_program.called)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,4 +1,3 @@
-#!/usr/bin/python
 
 import unittest
 from decimal import Decimal


### PR DESCRIPTION
* Remove #!/usr/bin/python shebang from tests.
* Remove unittest.main() from tests.
* Remove a definition of suite method, which we no longer use.

The tests should be run via the unittest discovery mechanism.
They are best run by invoking the "test" target in the Makefile.

This allows any necessary setup to occur, including overrides
for Python2/3 compatibility.

Signed-off-by: mulhern <amulhern@redhat.com>