### PR TITLE
Make blivet aware of internal LVs

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -408,9 +408,8 @@ class Blivet(object):
             does not necessarily reflect the actual on-disk state of the
             system's disks.
         """
-        lvs = self.devicetree.getDevicesByType("lvmlv")
-        lvs.sort(key=lambda d: d.name)
-        return lvs
+        lvs = (d for d in self.devices if d.type in ("lvmlv", "lvmthinpool", "lvmthinlv"))
+        return sorted(lvs, key=lambda d: d.name)
 
     @property
     def thinlvs(self):

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -41,7 +41,7 @@ from ..tasks import availability
 import logging
 log = logging.getLogger("blivet")
 
-from .lib import LINUX_SECTOR_SIZE
+from .lib import LINUX_SECTOR_SIZE, ParentList
 from .device import Device
 from .storage import StorageDevice
 from .container import ContainerDevice
@@ -529,7 +529,7 @@ class LVMLogicalVolumeDevice(DMDevice):
     def _check_parents(self):
         """Check that this device has parents as expected"""
 
-        if isinstance(self.parents, list):
+        if isinstance(self.parents, (list, ParentList)):
             if len(self.parents) != 1:
                 raise ValueError("constructor requires a single %s instance" % self._containerClass.__name__)
 

--- a/blivet/populator.py
+++ b/blivet/populator.py
@@ -937,6 +937,9 @@ class Populator(object):
                 if lv_name.endswith("_pmspare]"):
                     # spare metadata area for any thin pool that needs repair
                     return
+                elif lv_name.endswith("_cmeta]"):
+                    # cache metadata volume (skip, we ignore cache volumes)
+                    return
 
                 # raid metadata volume
                 lv_name = re.sub(r'_[tr]meta.*', '', lv_name[1:-1])
@@ -974,7 +977,7 @@ class Populator(object):
             elif lv_name.endswith(']'):
                 # Internal LVM2 device
                 return
-            elif lv_attr[0] not in '-mMrRoO':
+            elif lv_attr[0] not in '-mMrRoOC':
                 # Ignore anything else except for the following:
                 #   - normal lv
                 #   m mirrored
@@ -983,6 +986,7 @@ class Populator(object):
                 #   R raid without initial sync
                 #   o origin
                 #   O origin with merging snapshot
+                #   C cached LV
                 return
 
             lv_dev = self.getDeviceByUuid(lv_uuid)

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -18,7 +18,7 @@ Source0: http://github.com/dwlehman/blivet/archive/%{realname}-%{version}.tar.gz
 %define pypartedver 3.10.4
 %define e2fsver 1.41.0
 %define utillinuxver 2.15.1
-%define libblockdevver 1.0
+%define libblockdevver 1.1
 
 BuildArch: noarch
 BuildRequires: gettext


### PR DESCRIPTION
This is really more a request for comments than a real pull request as I'd like to know your opinion on the chosen approach. Making blivet aware of internal LVs is one of the crucial steps towards creation and manipulation of thin/cache pools' metadata volumes and other things.

The internal LVs are not part of the DeviceTree, they are only referenced by their "parent" LVs as they should not be manipulated with directly and because there may be many of them (tens on quite simple setups). However, these LVs are still just LVs like any other as far as things like name, UUID, size, etc. go.