### PR TITLE
Sort the lists before comparing because coversion to set reverses order in Python3

### DIFF
--- a/tests/devices_test/device_packages_test.py
+++ b/tests/devices_test/device_packages_test.py
@@ -20,7 +20,7 @@ class DevicePackagesTestCase(unittest.TestCase):
         packages = luks.packages
 
         # no duplicates in list of packages
-        self.assertListEqual(packages, list(set(packages)))
+        self.assertEqual(len(packages), len(set(packages)))
 
         # several packages that ought to be included are
         for package in dev1.packages + dev2.packages + dev.packages:


### PR DESCRIPTION
Closes #154