### PR TITLE
Some small patches

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -197,7 +197,10 @@ class FS(DeviceFormat):
        doc="this filesystem's label")
 
     def _setTargetSize(self, newsize):
-        """ Set a target size for this filesystem. """
+        """ Set the target size for this filesystem.
+
+            :param :class:`~.size.Size` newsize: the newsize
+        """
         if not isinstance(newsize, Size):
             raise ValueError("new size must be of type Size")
 
@@ -207,13 +210,11 @@ class FS(DeviceFormat):
         if not self.resizable:
             raise FSError("filesystem is not resizable")
 
-        if newsize is None:
-            # unset any outstanding resize request
-            self._targetSize = self._size
-            return
+        if newsize < self.minSize:
+            raise ValueError("requested size %s must be at least minimum size %s" % (newsize, self.minSize))
 
-        if not self.minSize <= newsize < self.maxSize:
-            raise ValueError("requested size %s must fall between minimum size %s and maximum size %s" % (newsize, self.minSize, self.maxSize))
+        if self.maxSize and newsize >= self.maxSize:
+            raise ValueError("requested size %s must be less than maximum size %s" % (newsize, self.maxSize))
 
         self._targetSize = newsize
 

--- a/blivet/size.py
+++ b/blivet/size.py
@@ -438,12 +438,11 @@ class Size(Decimal):
         if rounding not in (ROUND_UP, ROUND_DOWN, ROUND_DEFAULT):
             raise ValueError("invalid rounding specifier")
 
-        factor = getattr(unit, "factor", unit)
+        factor = Decimal(getattr(unit, "factor", unit))
 
-        if factor == Size(0):
+        if factor == 0:
             return Size(0)
 
-        factor = Decimal(factor)
         if factor < 0:
             raise ValueError("invalid rounding unit: %s" % factor)
 

--- a/blivet/size.py
+++ b/blivet/size.py
@@ -337,10 +337,21 @@ class Size(Decimal):
         """ Return the size in the units indicated by the specifier.
 
             :param spec: a units specifier
+            :type spec: a units specifier or :class:`Size`
             :returns: a numeric value in the units indicated by the specifier
             :rtype: Decimal
+            :raises ValueError: if Size unit specifier is non-positive
+
+            .. versionadded:: 1.6
+               spec parameter may be Size as well as units specifier.
         """
-        return Decimal(self) / Decimal((spec or B).factor)
+        spec = B if spec is None else spec
+        factor = Decimal(getattr(spec, "factor", spec))
+
+        if factor <= 0:
+            raise ValueError("invalid conversion unit: %s" % factor)
+
+        return Decimal(self) / factor
 
     def humanReadable(self, max_places=2, strip=True, min_value=1, xlate=True):
         """ Return a string representation of this size with appropriate

--- a/tests/size_test.py
+++ b/tests/size_test.py
@@ -179,6 +179,16 @@ class SizeTestCase(unittest.TestCase):
         self.assertEqual(s.convertTo(KiB), 1792)
         self.assertEqual(s.convertTo(MiB), Decimal("1.75"))
 
+    def testConvertToWithSize(self):
+        s = Size(1835008)
+        self.assertEqual(s.convertTo(Size(1)), s.convertTo(B))
+        self.assertEqual(s.convertTo(Size(1024)), s.convertTo(KiB))
+        self.assertEqual(Size(512).convertTo(Size(1024)), Decimal("0.5"))
+        self.assertEqual(Size(1024).convertTo(Size(512)), Decimal(2))
+
+        with self.assertRaises(ValueError):
+            s.convertTo(Size(0))
+
     def testNegative(self):
         s = Size("-500MiB")
         self.assertEqual(s.humanReadable(), "-500 MiB")


### PR DESCRIPTION
These came up while working on LUKS resize but are in some sense orthogonal.

Extending Size.convertTo() to take Size parameter is necessary for resizing LUKS format to multiples
of sector size, but also brings convertTo() into line with roundToNearest(), which now also takes
a Size parameter and generally makes it more useful.

Changes to FS._setTargetSize() came up when hoisting size related methods to DeviceFormat.