### PR TITLE
Don't fail in storage.py:isNameValid when name is None

### DIFF
--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -745,6 +745,8 @@ class StorageDevice(Device):
         # ...except some names *do* contain directory components, for this
         # is an imperfect world of joy and sorrow mingled. For cciss, split
         # the path into its components and do the real check on each piece
+        if name is None:
+            return False
         if name.startswith("cciss/"):
             return all(cls.isNameValid(n) for n in name.split('/'))
 


### PR DESCRIPTION
With ISM RAID-0 configured I get the following error when using blivet:

Traceback (most recent call last):
  File "list-devices.py", line 34, in <module>
    storage.reset()             # detect system storage configuration
  File "/usr/lib/python2.7/site-packages/blivet/**init**.py", line 372, in reset
    self.devicetree.populate(cleanupOnly=cleanupOnly)
  File "/usr/lib/python2.7/site-packages/blivet/devicetree.py", line 2113, in populate
    self._populate()
  File "/usr/lib/python2.7/site-packages/blivet/devicetree.py", line 2179, in _populate
    self.addUdevDevice(dev)
  File "/usr/lib/python2.7/site-packages/blivet/devicetree.py", line 1258, in addUdevDevice
    self.handleUdevDeviceFormat(info, device)
  File "/usr/lib/python2.7/site-packages/blivet/devicetree.py", line 1879, in handleUdevDeviceFormat
    self.handleUdevMDMemberFormat(info, device)
  File "/usr/lib/python2.7/site-packages/blivet/devicetree.py", line 1637, in handleUdevMDMemberFormat
    exists=True)
  File "/usr/lib/python2.7/site-packages/blivet/devices/md.py", line 87, in __init__
    sysfsPath=sysfsPath)
  File "/usr/lib/python2.7/site-packages/blivet/devices/container.py", line 63, in **init**
    super(ContainerDevice, self).**init**(_args, *_kwargs)
  File "/usr/lib/python2.7/site-packages/blivet/devices/storage.py", line 106, in **init**
    super(StorageDevice, self).**init**(name, parents=parents)
  File "/usr/lib/python2.7/site-packages/blivet/devices/device.py", line 83, in **init**
    if not self.isNameValid(name):
  File "/usr/lib/python2.7/site-packages/blivet/devices/storage.py", line 787, in isNameValid
    if name.startswith("cciss/"):
AttributeError: 'NoneType' object has no attribute 'startswith'

mdadm --examine --brief /dev/sdc
ARRAY metadata=imsm UUID=17ca54e9:88114b9d:2072a87d:cc2c4c61
ARRAY /dev/md/Test0 container=17ca54e9:88114b9d:2072a87d:cc2c4c61 member=0 UUID=11cc7cbd:e42aabbf:d57faea8:baaa6425

md_info: {'MD_LEVEL': 'container', 'MD_UUID': '17ca54e9-8811-4b9d-2072-a87dcc2c4c61', 'MD_DEVICES': '2', 'MD_METADATA': 'imsm'}

Device name was not detected due to some error, but I think that None value should be considered as not valid name anyway.
