### PR TITLE
LUKS resize

### DIFF
--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -778,7 +778,7 @@ class ActionResizeFormat(DeviceAction):
             callbacks.resize_format_pre(ResizeFormatPreData(msg))
 
         self.device.setup(orig=True)
-        self.device.format.doResize()
+        self.device.format.resize()
 
         if callbacks and callbacks.resize_format_post:
             msg = _("Resized filesystem on %(device)s") % {"device": self.device.path}

--- a/blivet/devicelibs/crypto.py
+++ b/blivet/devicelibs/crypto.py
@@ -25,5 +25,6 @@ from ..tasks import availability
 
 LUKS_METADATA_SIZE = Size("2 MiB")
 MIN_CREATE_ENTROPY = 256 # bits
+SECTOR_SIZE = Size("512 B")
 
 EXTERNAL_DEPENDENCIES = [availability.BLOCKDEV_CRYPTO_PLUGIN]

--- a/blivet/devices/luks.py
+++ b/blivet/devices/luks.py
@@ -59,6 +59,16 @@ class LUKSDevice(DMCryptDevice):
     def raw_device(self):
         return self.slave
 
+    def _setTargetSize(self, newsize):
+        if newsize > self.slave.size:
+            raise ValueError("requested size %s is larger than size of slave device %s" % (newsize, self.slave.name))
+
+        if newsize < self.format.size:
+            raise ValueError("requested size %s is smaller size of existing format %s on device" % (newsize, self.format))
+
+        super(LUKSDevice, self)._setTargetSize(newsize)
+        self.slave.format.targetSize = newsize
+
     @property
     def size(self):
         if not self.exists:
@@ -81,6 +91,9 @@ class LUKSDevice(DMCryptDevice):
 
     def dracutSetupArgs(self):
         return set(["rd.luks.uuid=luks-%s" % self.slave.format.uuid])
+
+    def resize(self):
+        self.slave.format.resize()
 
     def populateKSData(self, data):
         self.slave.populateKSData(data)

--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -287,9 +287,9 @@ class StorageDevice(Device):
     @property
     def resizable(self):
         """ Can this device be resized? """
+        fmt = self.raw_device.format
         return (self._resizable and self.exists and
-                (self.format.type is None or self.format.resizable or
-                 not self.format.exists))
+                (fmt.type is None or fmt.resizable or not fmt.exists))
 
     def notifyKernel(self):
         """ Send a 'change' uevent to the kernel for this device. """

--- a/blivet/formats/__init__.py
+++ b/blivet/formats/__init__.py
@@ -359,6 +359,24 @@ class DeviceFormat(ObjectID):
         """
         pass
 
+    def _alignToResizeUnit(self, newsize, direction=ROUND_DOWN):
+        """ Returns a new size aligned to the units of the resize tool.
+
+           :param :class:`~.Size` newsize: the proposed new size
+           :returns: newsize modified to yield an aligned size
+           :param direction: one of (decimal.ROUND_UP, decimal.ROUND_DOWN)
+           :rtype: :class:`~.Size`
+
+           The default is to round down.
+
+           If no resize unit available, returns newsize.
+        """
+        try:
+            return newsize.roundToNearest(self._resizeTask.unit, rounding=direction)
+        except NotImplementedError:
+            log.warning("Trying to align size to resize unit, but no resize unit available.")
+            return newsize
+
     def _deviceCheck(self, devspec):
         """ Verifies that device spec has a proper format.
 
@@ -600,12 +618,11 @@ class DeviceFormat(ObjectID):
 
     def _resize(self, **kwargs):
         """ Do generic resizing actions. """
-        # Bump target size to nearest whole number of the resize tool's units.
+
         # We always round down because the fs has to fit on whatever device
         # contains it. To round up would risk quietly setting a target size too
         # large for the device to hold.
-        rounded = self.targetSize.roundToNearest(self._resizeTask.unit,
-                                                 rounding=ROUND_DOWN)
+        rounded = self._alignToResizeUnit(self.targetSize)
 
         # 1. target size was between the min size and max size values prior to
         #    rounding (see _setTargetSize)

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -281,7 +281,7 @@ class FS(DeviceFormat):
 
         # make sure the padded and rounded min size is not larger than
         # the current size
-        padded = min(padded.roundToNearest(self._resizeTask.unit, rounding=ROUND_UP), self.currentSize)
+        padded = min(self._alignToResizeUnit(padded, ROUND_UP), self.currentSize)
 
         return padded
 

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -38,7 +38,7 @@ from ..tasks import fssize
 from ..tasks import fssync
 from ..tasks import fswritelabel
 from ..errors import FormatCreateError, FSError, FSReadLabelError
-from ..errors import FSWriteLabelError, FSResizeError
+from ..errors import FSWriteLabelError
 from . import DeviceFormat, register_device_format
 from .. import util
 from .. import platform
@@ -329,7 +329,7 @@ class FS(DeviceFormat):
     def doResize(self):
         """ Resize this filesystem based on this instance's targetSize attr.
 
-            :raises: FSResizeError, FSError, DeviceFormatError
+            :raises: FSError, DeviceFormatError
 
             .. versionchanged:: 1.5
                Raises :class:`~.errors.DeviceFormatError`
@@ -338,26 +338,6 @@ class FS(DeviceFormat):
                Use :func:`resize` instead.
         """
         self.resize()
-
-    def _preResize(self, **kwargs):
-        if not super(FS, self)._preResize(**kwargs):
-            return False
-
-        # The first minimum size can be incorrect if the fs was not
-        # properly unmounted. After doCheck the minimum size will be correct
-        # so run the check one last time and bump up the size if it was too
-        # small.
-        self.updateSizeInfo()
-
-        # Check again if resizable is True, as updateSizeInfo() can change that
-        if not self.resizable:
-            raise FSResizeError("filesystem not resizable", self.device)
-
-        if self.targetSize < self.minSize:
-            self.targetSize = self.minSize
-            log.info("Minimum size changed, setting targetSize on %s to %s",
-                     self.device, self.targetSize)
-        return True
 
     def _postResize(self, **kwargs):
         self.doCheck()

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -48,6 +48,8 @@ class LUKS(DeviceFormat):
     _minSize = crypto.LUKS_METADATA_SIZE
     _plugin = availability.BLOCKDEV_CRYPTO_PLUGIN
     _sizeinfoClass = lukstasks.LUKSSize
+    _resizeClass = lukstasks.LUKSResize
+    _resizable = True
 
     def __init__(self, **kwargs):
         """

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -30,6 +30,7 @@ from . import DeviceFormat, register_device_format
 from ..flags import flags
 from ..i18n import _, N_
 from ..tasks import availability
+from ..tasks import lukstasks
 
 import logging
 log = logging.getLogger("blivet")
@@ -46,6 +47,7 @@ class LUKS(DeviceFormat):
     _packages = ["cryptsetup"]          # required packages
     _minSize = crypto.LUKS_METADATA_SIZE
     _plugin = availability.BLOCKDEV_CRYPTO_PLUGIN
+    _sizeinfoClass = lukstasks.LUKSSize
 
     def __init__(self, **kwargs):
         """
@@ -80,6 +82,9 @@ class LUKS(DeviceFormat):
         """
         log_method_call(self, **kwargs)
         DeviceFormat.__init__(self, **kwargs)
+
+        self._sizeinfo = self._sizeinfoClass(self)
+
         self.cipher = kwargs.get("cipher")
         self.key_size = kwargs.get("key_size")
         self.mapName = kwargs.get("name")
@@ -263,6 +268,12 @@ class LUKS(DeviceFormat):
                                       directory, backupPassphrase)
         log.debug("escrow: escrowVolume done for %s", repr(self.device))
 
+    def updateSizeInfo(self):
+        """ Update this format's current size. """
+        try:
+            self._size = self._sizeinfo.doTask()
+        except LUKSError as e:
+            log.warning("Failed to obtain current size for device %s: %s", self.device, e)
 
 register_device_format(LUKS)
 

--- a/blivet/osinstall.py
+++ b/blivet/osinstall.py
@@ -31,7 +31,7 @@ from . import getSysroot, getTargetPhysicalRoot, errorHandler, ERROR_RAISE
 
 from .storage_log import log_exception_info
 from .devices import FileDevice, NFSDevice, NoDevice, OpticalDevice, NetworkStorageDevice, DirectoryDevice
-from .errors import FSTabTypeMismatchError, UnrecognizedFSTabEntryError, StorageError, FSResizeError, UnknownSourceDeviceError
+from .errors import FSTabTypeMismatchError, UnrecognizedFSTabEntryError, StorageError, UnknownSourceDeviceError
 from .formats import get_device_format_class
 from .formats import getFormat
 from .flags import flags
@@ -1055,10 +1055,7 @@ def turnOnFilesystems(storage, mountOnly=False, callbacks=None):
 
         try:
             storage.doIt(callbacks)
-        except FSResizeError as e:
-            if errorHandler.cb(e) == ERROR_RAISE:
-                raise
-        except Exception as e:
+        except Exception:
             raise
 
         storage.turnOnSwap()

--- a/blivet/populator.py
+++ b/blivet/populator.py
@@ -29,7 +29,7 @@ import parted
 
 from gi.repository import BlockDev as blockdev
 
-from .errors import CorruptGPTError, DeviceError, DeviceTreeError, DiskLabelScanError, DuplicateVGError, FSError, InvalidDiskLabelError, LUKSError
+from .errors import CorruptGPTError, DeviceError, DeviceFormatError, DeviceTreeError, DiskLabelScanError, DuplicateVGError, InvalidDiskLabelError, LUKSError
 from .devices import BTRFSSubVolumeDevice, BTRFSVolumeDevice, BTRFSSnapShotDevice
 from .devices import DASDDevice, DMDevice, DMLinearDevice, DMRaidArrayDevice, DiskDevice
 from .devices import FcoeDiskDevice, FileDevice, LoopDevice, LUKSDevice
@@ -1404,7 +1404,7 @@ class Populator(object):
             device.format = formats.getFormat(format_designator, **kwargs)
             if device.format.type:
                 log.info("got format: %s", device.format)
-        except FSError:
+        except DeviceFormatError:
             log.warning("type '%s' on '%s' invalid, assuming no format",
                       format_designator, name)
             device.format = formats.DeviceFormat()

--- a/blivet/tasks/availability.py
+++ b/blivet/tasks/availability.py
@@ -285,4 +285,5 @@ XFSADMIN_APP = application("xfs_admin")
 XFSDB_APP = application("xfs_db")
 XFSFREEZE_APP = application("xfs_freeze")
 
+LSBLK_APP = application("lsblk")
 MOUNT_APP = application("mount")

--- a/blivet/tasks/dfresize.py
+++ b/blivet/tasks/dfresize.py
@@ -1,0 +1,45 @@
+# dfresize.py
+# DeviceFormat resizing classes.
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Anne Mulhern <amulhern@redhat.com>
+
+import abc
+
+from six import add_metaclass
+
+from . import task
+
+@add_metaclass(abc.ABCMeta)
+class DFResizeTask(task.Task):
+    """ The abstract properties that any resize task must have. """
+
+    unit = abc.abstractproperty(doc="Resize unit.")
+
+class UnimplementedDFResize(task.UnimplementedTask, DFResizeTask):
+
+    def __init__(self, a_df):
+        """ Initializer.
+
+            :param DeviceFormat a_df: a device format object
+        """
+        self.df = a_df
+
+    @property
+    def unit(self):
+        raise NotImplementedError()

--- a/blivet/tasks/fsresize.py
+++ b/blivet/tasks/fsresize.py
@@ -29,12 +29,12 @@ from ..import util
 
 from . import availability
 from . import task
+from . import dfresize
 
 @add_metaclass(abc.ABCMeta)
-class FSResizeTask(task.Task):
+class FSResizeTask(dfresize.DFResizeTask):
     """ The abstract properties that any resize task must have. """
 
-    unit = abc.abstractproperty(doc="Resize unit.")
     size_fmt = abc.abstractproperty(doc="Size format string.")
 
 @add_metaclass(abc.ABCMeta)
@@ -133,18 +133,7 @@ class TmpFSResize(FSResize):
         options = ("remount", opts, self.sizeSpec())
         return ['-o', ",".join(options), self.fs._type, self.fs.systemMountpoint]
 
-class UnimplementedFSResize(task.UnimplementedTask, FSResizeTask):
-
-    def __init__(self, an_fs):
-        """ Initializer.
-
-            :param FS an_fs: a filesystem object
-        """
-        self.fs = an_fs
-
-    @property
-    def unit(self):
-        raise NotImplementedError()
+class UnimplementedFSResize(dfresize.UnimplementedDFResize, FSResizeTask):
 
     @property
     def size_fmt(self):

--- a/blivet/tasks/fsresize.py
+++ b/blivet/tasks/fsresize.py
@@ -80,7 +80,7 @@ class FSResize(task.BasicApplication, FSResizeTask):
             raise FSError(e)
 
         if ret:
-            raise FSError("resize failed: %s" % ret)
+            raise FSError("resize of format on device %s failed: %s" % (self.fs.device, ret))
 
 class Ext2FSResize(FSResize):
     ext = availability.RESIZE2FS_APP

--- a/blivet/tasks/lukstasks.py
+++ b/blivet/tasks/lukstasks.py
@@ -26,6 +26,7 @@ from ..size import Size
 
 from . import availability
 from . import task
+from . import dfresize
 
 class LUKSSize(task.BasicApplication):
     """ Obtain information about the size of a LUKS format. """

--- a/blivet/tasks/lukstasks.py
+++ b/blivet/tasks/lukstasks.py
@@ -1,0 +1,102 @@
+# lukstasks.py
+# Tasks for a LUKS format.
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Anne Mulhern <amulhern@redhat.com>
+
+from .. import util
+
+from ..errors import LUKSError
+from ..size import Size
+
+from . import availability
+from . import task
+
+class LUKSSize(task.BasicApplication):
+    """ Obtain information about the size of a LUKS format. """
+
+    # Note that this task currently makes use of lsblk. It must
+    # parse the output of lsblk --list and use the mapName of the device
+    # to identify the correct entry. Ideally, it would be possible
+    # to get the information by specifying the device using the mapName,
+    # but lsblk won't cooperate, reporting that the luks devices is not
+    # a block device instead.
+
+    ext = availability.LSBLK_APP
+
+    description = "size of a luks device"
+
+    def __init__(self, a_luks):
+        """ Initializer.
+
+            :param :class:`~.formats.luks.LUKS` a_luks: a LUKS format object
+        """
+        self.luks = a_luks
+
+    @property
+    def _sizeCommand(self):
+        """ Returns the command for reading luks format size.
+
+            :returns: a list consisting of the appropriate command
+            :rtype: list of str
+        """
+        return [
+           str(self.ext),
+           '--list',
+           '--noheadings',
+           '--bytes',
+           '--output=NAME,SIZE'
+        ]
+
+    def _extractSize(self, tab):
+        """ Extract size information from blkid output.
+
+            :param str tab: tabular information for blkid
+            :rtype: :class:`~.size.Size`
+            :raises :class:`~.errors.LUKSError`: if size cannot be obtained
+
+            Expects tab to be in name, value lines, where the value is
+            the size in bytes.
+        """
+        for line in tab.strip().split('\n'):
+            name, size = line.split()
+            if name == self.luks.mapName:
+                return Size(int(size))
+        raise LUKSError("Could not extract size from blkid output for %s" % self.luks.mapName)
+
+    def doTask(self):
+        """ Returns the size of the luks format.
+
+            :returns: the size of the luks format
+            :rtype: :class:`~.size.Size`
+            :raises :class:`~.errors.LUKSError`: if size cannot be obtained
+        """
+        error_msgs = self.availabilityErrors
+        if error_msgs:
+            raise LUKSError("\n".join(error_msgs))
+
+        error_msg = None
+        try:
+            (rc, out) = util.run_program_and_capture_output(self._sizeCommand)
+            if rc:
+                error_msg = "failed to gather luks size info: %s" % rc
+        except OSError as e:
+            error_msg = "failed to gather luks size info: %s" % e
+        if error_msg:
+            raise LUKSError(error_msg)
+        return self._extractSize(out)

--- a/tests/formats_test/fs_test.py
+++ b/tests/formats_test/fs_test.py
@@ -121,7 +121,7 @@ class ResizeTmpFSTestCase(loopbackedtestcase.LoopBackedTestCase):
         self.an_fs.updateSizeInfo()
         newsize = self.an_fs.currentSize * 2
         self.an_fs.targetSize = newsize
-        self.assertIsNone(self.an_fs.doResize())
+        self.assertIsNone(self.an_fs.resize())
         self.assertEqual(self.an_fs.size, newsize.roundToNearest(self.an_fs._resizeTask.unit, rounding=ROUND_DOWN))
 
     def testShrink(self):

--- a/tests/formats_test/fs_test.py
+++ b/tests/formats_test/fs_test.py
@@ -122,7 +122,7 @@ class ResizeTmpFSTestCase(loopbackedtestcase.LoopBackedTestCase):
         newsize = self.an_fs.currentSize * 2
         self.an_fs.targetSize = newsize
         self.assertIsNone(self.an_fs.doResize())
-        self.assertEqual(self.an_fs.size, newsize.roundToNearest(self.an_fs._resize.unit, rounding=ROUND_DOWN))
+        self.assertEqual(self.an_fs.size, newsize.roundToNearest(self.an_fs._resizeTask.unit, rounding=ROUND_DOWN))
 
     def testShrink(self):
         # Can not shrink tmpfs, because its minimum size is its current size

--- a/tests/formats_test/fstesting.py
+++ b/tests/formats_test/fstesting.py
@@ -16,7 +16,7 @@ def can_resize(an_fs):
 
         :param an_fs: a filesystem object
     """
-    resize_tasks = (an_fs._resize, an_fs._sizeinfo, an_fs._minsize)
+    resize_tasks = (an_fs._resizeTask, an_fs._sizeinfo, an_fs._minsize)
     return not any(t.availabilityErrors for t in resize_tasks)
 
 @add_metaclass(abc.ABCMeta)
@@ -209,7 +209,7 @@ class FSAsRoot(loopbackedtestcase.LoopBackedTestCase):
             self.assertEqual(an_fs.targetSize, TARGET_SIZE)
             self.assertNotEqual(an_fs._size, TARGET_SIZE)
             self.assertIsNone(an_fs.doResize())
-            ACTUAL_SIZE = TARGET_SIZE.roundToNearest(an_fs._resize.unit, rounding=ROUND_DOWN)
+            ACTUAL_SIZE = TARGET_SIZE.roundToNearest(an_fs._resizeTask.unit, rounding=ROUND_DOWN)
             self.assertEqual(an_fs.size, ACTUAL_SIZE)
             self.assertEqual(an_fs._size, ACTUAL_SIZE)
             self._test_sizes(an_fs)
@@ -294,7 +294,7 @@ class FSAsRoot(loopbackedtestcase.LoopBackedTestCase):
         if isinstance(an_fs, fs.NTFS):
             return
         self.assertIsNone(an_fs.doResize())
-        ACTUAL_SIZE = TARGET_SIZE.roundToNearest(an_fs._resize.unit, rounding=ROUND_DOWN)
+        ACTUAL_SIZE = TARGET_SIZE.roundToNearest(an_fs._resizeTask.unit, rounding=ROUND_DOWN)
         self.assertEqual(an_fs._size, ACTUAL_SIZE)
         self._test_sizes(an_fs)
 
@@ -357,7 +357,7 @@ class FSAsRoot(loopbackedtestcase.LoopBackedTestCase):
 
         # CHECKME: size and target size will be adjusted attempted values
         # while currentSize will be actual value
-        TARGET_SIZE = BIG_SIZE.roundToNearest(an_fs._resize.unit, rounding=ROUND_DOWN)
+        TARGET_SIZE = BIG_SIZE.roundToNearest(an_fs._resizeTask.unit, rounding=ROUND_DOWN)
         self.assertEqual(an_fs.targetSize, TARGET_SIZE)
         self.assertEqual(an_fs.size, an_fs.targetSize)
         self.assertEqual(an_fs.currentSize, old_size)

--- a/tests/formats_test/fstesting.py
+++ b/tests/formats_test/fstesting.py
@@ -6,7 +6,7 @@ import os
 import tempfile
 
 from tests import loopbackedtestcase
-from blivet.errors import FSError, FSResizeError
+from blivet.errors import DeviceFormatError, FSError, FSResizeError
 from blivet.size import Size, ROUND_DOWN
 from blivet.formats import fs
 
@@ -197,9 +197,9 @@ class FSAsRoot(loopbackedtestcase.LoopBackedTestCase):
         if not can_resize(an_fs):
             self.assertFalse(an_fs.resizable)
             # Not resizable, so can not do resizing actions.
-            with self.assertRaises(FSError):
+            with self.assertRaises(DeviceFormatError):
                 an_fs.targetSize = Size("64 MiB")
-            with self.assertRaises(FSError):
+            with self.assertRaises(DeviceFormatError):
                 an_fs.doResize()
         else:
             self.assertTrue(an_fs.resizable)

--- a/tests/formats_test/fstesting.py
+++ b/tests/formats_test/fstesting.py
@@ -6,7 +6,7 @@ import os
 import tempfile
 
 from tests import loopbackedtestcase
-from blivet.errors import DeviceFormatError, FSError, FSResizeError
+from blivet.errors import DeviceFormatError, FSError
 from blivet.size import Size, ROUND_DOWN
 from blivet.formats import fs
 
@@ -200,7 +200,7 @@ class FSAsRoot(loopbackedtestcase.LoopBackedTestCase):
             with self.assertRaises(DeviceFormatError):
                 an_fs.targetSize = Size("64 MiB")
             with self.assertRaises(DeviceFormatError):
-                an_fs.doResize()
+                an_fs.resize()
         else:
             self.assertTrue(an_fs.resizable)
             # Try a reasonable target size
@@ -208,7 +208,7 @@ class FSAsRoot(loopbackedtestcase.LoopBackedTestCase):
             an_fs.targetSize = TARGET_SIZE
             self.assertEqual(an_fs.targetSize, TARGET_SIZE)
             self.assertNotEqual(an_fs._size, TARGET_SIZE)
-            self.assertIsNone(an_fs.doResize())
+            self.assertIsNone(an_fs.resize())
             ACTUAL_SIZE = TARGET_SIZE.roundToNearest(an_fs._resizeTask.unit, rounding=ROUND_DOWN)
             self.assertEqual(an_fs.size, ACTUAL_SIZE)
             self.assertEqual(an_fs._size, ACTUAL_SIZE)
@@ -237,7 +237,7 @@ class FSAsRoot(loopbackedtestcase.LoopBackedTestCase):
         self.assertNotEqual(an_fs.currentSize, an_fs.targetSize)
         self.assertEqual(an_fs.currentSize, an_fs._size)
         self.assertEqual(an_fs.targetSize, Size(0))
-        self.assertIsNone(an_fs.doResize())
+        self.assertIsNone(an_fs.resize())
         self.assertEqual(an_fs.currentSize, an_fs.minSize)
         self.assertEqual(an_fs.targetSize, an_fs.minSize)
         self._test_sizes(an_fs)
@@ -261,7 +261,7 @@ class FSAsRoot(loopbackedtestcase.LoopBackedTestCase):
         # set in the constructor.
         self.assertNotEqual(an_fs.currentSize, an_fs.targetSize)
         self.assertEqual(an_fs.targetSize, SIZE)
-        self.assertIsNone(an_fs.doResize())
+        self.assertIsNone(an_fs.resize())
         self.assertEqual(an_fs.currentSize, SIZE)
         self.assertEqual(an_fs.targetSize, SIZE)
         self._test_sizes(an_fs)
@@ -279,7 +279,7 @@ class FSAsRoot(loopbackedtestcase.LoopBackedTestCase):
 
         TARGET_SIZE = Size("64 MiB")
         an_fs.targetSize = TARGET_SIZE
-        self.assertIsNone(an_fs.doResize())
+        self.assertIsNone(an_fs.resize())
 
         TARGET_SIZE = TARGET_SIZE / 2
         self.assertTrue(TARGET_SIZE > an_fs.minSize)
@@ -287,13 +287,13 @@ class FSAsRoot(loopbackedtestcase.LoopBackedTestCase):
         self.assertEqual(an_fs.targetSize, TARGET_SIZE)
         self.assertNotEqual(an_fs._size, TARGET_SIZE)
         # FIXME:
-        # doCheck() in updateSizeInfo() in doResize() does not complete tidily
+        # doCheck() in updateSizeInfo() in resize() does not complete tidily
         # here, so resizable becomes False and self.targetSize can not be
         # assigned to. This alerts us to the fact that now min size
         # and size are both incorrect values.
         if isinstance(an_fs, fs.NTFS):
             return
-        self.assertIsNone(an_fs.doResize())
+        self.assertIsNone(an_fs.resize())
         ACTUAL_SIZE = TARGET_SIZE.roundToNearest(an_fs._resizeTask.unit, rounding=ROUND_DOWN)
         self.assertEqual(an_fs._size, ACTUAL_SIZE)
         self._test_sizes(an_fs)
@@ -352,8 +352,8 @@ class FSAsRoot(loopbackedtestcase.LoopBackedTestCase):
         BIG_SIZE = an_fs.maxSize - Size(1)
         an_fs.targetSize = BIG_SIZE
         self.assertEqual(an_fs.targetSize, BIG_SIZE)
-        with self.assertRaises(FSResizeError):
-            an_fs.doResize()
+        with self.assertRaises(FSError):
+            an_fs.resize()
 
         # CHECKME: size and target size will be adjusted attempted values
         # while currentSize will be actual value

--- a/tests/formats_test/luks_test.py
+++ b/tests/formats_test/luks_test.py
@@ -53,11 +53,14 @@ class LUKSTestCase(loopbackedtestcase.LoopBackedTestCase):
         # update the size info
         self.fmt.updateSizeInfo()
 
+        # set target size to imitate FS constructor
+        self.fmt.targetSize = self.fmt._size
+
         # the size is greater than zero and less than the size of the device
         self.assertLess(self.fmt.size, self.DEFAULT_STORE_SIZE)
         self.assertGreater(self.fmt.size, Size(0))
 
         self.assertEqual(self.fmt.currentSize, self.fmt.size)
-        self.assertEqual(self.fmt.targetSize, Size(0))
+        self.assertEqual(self.fmt.targetSize, self.fmt.size)
 
         self.fmt.teardown()

--- a/tests/formats_test/luks_test.py
+++ b/tests/formats_test/luks_test.py
@@ -1,0 +1,29 @@
+import blivet.formats.luks as luks
+
+from tests import loopbackedtestcase
+
+class LUKSTestCase(loopbackedtestcase.LoopBackedTestCase):
+
+    def __init__(self, methodName='runTest'):
+        super(LUKSTestCase, self).__init__(methodName=methodName, deviceSpec=[self.DEFAULT_STORE_SIZE])
+        self.fmt = luks.LUKS(passphrase="passphrase", name="super-luks")
+
+    def testSimple(self):
+        """ Simple test of creation, setup, and teardown. """
+        # test that creation of format on device occurs w/out error
+        device = self.loopDevices[0]
+
+        self.assertFalse(self.fmt.exists)
+        self.fmt.device = device
+        self.assertIsNone(self.fmt.create())
+        self.assertIsNotNone(self.fmt.mapName)
+        self.assertTrue(self.fmt.exists)
+        self.assertTrue("LUKS" in self.fmt.name)
+
+        # test that the device can be opened once created
+        self.assertIsNone(self.fmt.setup())
+        self.assertTrue(self.fmt.status)
+
+        # test that the device can be closed again
+        self.assertIsNone(self.fmt.teardown())
+        self.assertFalse(self.fmt.status)

--- a/tests/formats_test/luks_test.py
+++ b/tests/formats_test/luks_test.py
@@ -1,4 +1,5 @@
 import blivet.formats.luks as luks
+from blivet.size import Size
 
 from tests import loopbackedtestcase
 
@@ -27,3 +28,36 @@ class LUKSTestCase(loopbackedtestcase.LoopBackedTestCase):
         # test that the device can be closed again
         self.assertIsNone(self.fmt.teardown())
         self.assertFalse(self.fmt.status)
+
+    def testSize(self):
+        """ Test that sizes are calculated correctly. """
+        device = self.loopDevices[0]
+
+        # create the device
+        self.fmt.device = device
+        self.assertIsNone(self.fmt.create())
+
+        # the size is 0
+        self.assertEqual(self.fmt.size, Size(0))
+        self.assertEqual(self.fmt.currentSize, Size(0))
+        self.assertEqual(self.fmt.targetSize, Size(0))
+
+        # open the luks device
+        self.assertIsNone(self.fmt.setup())
+
+        # size is unchanged
+        self.assertEqual(self.fmt.size, Size(0))
+        self.assertEqual(self.fmt.currentSize, Size(0))
+        self.assertEqual(self.fmt.targetSize, Size(0))
+
+        # update the size info
+        self.fmt.updateSizeInfo()
+
+        # the size is greater than zero and less than the size of the device
+        self.assertLess(self.fmt.size, self.DEFAULT_STORE_SIZE)
+        self.assertGreater(self.fmt.size, Size(0))
+
+        self.assertEqual(self.fmt.currentSize, self.fmt.size)
+        self.assertEqual(self.fmt.targetSize, Size(0))
+
+        self.fmt.teardown()

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -18,6 +18,7 @@ class BlivetLintConfig(PocketLintConfig):
                                 FalsePositive(r"Method 'doTask' is abstract in class 'UnimplementedTask' but is not overridden"),
                                 FalsePositive(r"No value for argument 'member_count' in unbound method call$"),
                                 FalsePositive(r"No value for argument 'smallest_member_size' in unbound method call$"),
+                                FalsePositive(r"TmpFS._sizeOption: Instance of 'UnimplementedDFResize' has no 'size_fmt' member$"),
 
                                 # FIXME:  These are temporary, until there's a python3 anaconda.
                                 FalsePositive(r"Unable to import 'pyanaconda'$"),


### PR DESCRIPTION
This is a request for comment, because it is incomplete. I am trying to figure out better ways to test the higher-level functionality but am having problems obtaining a cooperating virtual machine.

There are a few points:
* What makes this a bit tricky is that LUKS is handled as both a device and a format. There is a sense
in which it is both.
* I decided to start from the bottom up this time, working on resizing the format first, rather than worrying about the Actions.
* If the resize of a LUKSDevice is handled as just a resize of its slave's LUKS format then blivet.resizeDevice() does not need to change at all to handle LUKS devices AFAICT.
* However, it does not make much sense to resize a LUKS format outside the LUKS device...since the format knows nothing about the size of the, e.g., filesystem that it encrypts. And yet, it is still possible. Not sure whether it is necessary or desirable to do anything about that.
* I have not handled the dependencies between the actions.
