### PR TITLE
Master format copy b

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -1121,7 +1121,7 @@ class Blivet(object):
             self.devicetree.cancelAction(action)
 
         # make sure any random overridden attributes are reset
-        device.format = copy.copy(device.originalFormat)
+        device.format = copy.deepcopy(device.originalFormat)
 
     def resizeDevice(self, device, new_size):
         """ Schedule a resize of a device and its formatting, if any.

--- a/blivet/devices/btrfs.py
+++ b/blivet/devices/btrfs.py
@@ -204,7 +204,7 @@ class BTRFSVolumeDevice(BTRFSDevice, ContainerDevice, RaidDevice):
                                     device=self.path,
                                     subvolspec=self.vol_id,
                                     mountopts="subvolid=%d" % self.vol_id)
-            self.originalFormat = copy.copy(self.format)
+            self.originalFormat = copy.deepcopy(self.format)
 
         self._defaultSubVolumeID = None
 

--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -124,7 +124,7 @@ class StorageDevice(Device):
         self.controllable = not flags.testing
 
         self.format = fmt
-        self.originalFormat = copy.copy(self.format)
+        self.originalFormat = copy.deepcopy(self.format)
         self.fstabComment = ""
         self._targetSize = self._size
 

--- a/blivet/populator.py
+++ b/blivet/populator.py
@@ -756,7 +756,7 @@ class Populator(object):
         # now handle the device's formatting
         self.handleUdevDeviceFormat(info, device)
         if device_added or updateOrigFmt:
-            device.originalFormat = copy.copy(device.format)
+            device.originalFormat = copy.deepcopy(device.format)
         device.deviceLinks = udev.device_get_symlinks(info)
 
     def handleUdevDiskLabelFormat(self, info, device):

--- a/blivet/tasks/fsck.py
+++ b/blivet/tasks/fsck.py
@@ -27,12 +27,13 @@ from ..errors import FSError
 from .. import util
 
 from . import availability
+from . import fstask
 from . import task
 
 _UNKNOWN_RC_MSG = "Unknown return code: %d"
 
 @add_metaclass(abc.ABCMeta)
-class FSCK(task.BasicApplication):
+class FSCK(task.BasicApplication, fstask.FSTask):
     """An abstract class that represents actions associated with
        checking consistency of a filesystem.
     """
@@ -40,13 +41,6 @@ class FSCK(task.BasicApplication):
 
     options = abc.abstractproperty(
        doc="Options for invoking the application.")
-
-    def __init__(self, an_fs):
-        """ Initializer.
-
-            :param FS an_fs: a filesystem object
-        """
-        self.fs = an_fs
 
     # IMPLEMENTATION methods
 
@@ -147,11 +141,5 @@ class NTFSFSCK(FSCK):
     def _errorMessage(self, rc):
         return _UNKNOWN_RC_MSG % (rc,) if rc != 0 else None
 
-class UnimplementedFSCK(task.UnimplementedTask):
-
-    def __init__(self, an_fs):
-        """ Initializer.
-
-            :param FS an_fs: a filesystem object
-        """
-        self.fs = an_fs
+class UnimplementedFSCK(fstask.UnimplementedFSTask):
+    pass

--- a/blivet/tasks/fsinfo.py
+++ b/blivet/tasks/fsinfo.py
@@ -27,23 +27,17 @@ from ..errors import FSError
 from .. import util
 
 from . import availability
+from . import fstask
 from . import task
 
 @add_metaclass(abc.ABCMeta)
-class FSInfo(task.BasicApplication):
+class FSInfo(task.BasicApplication, fstask.FSTask):
     """ An abstract class that represents an information gathering app. """
 
     description = "filesystem info"
 
     options = abc.abstractproperty(
        doc="Options for invoking the application.")
-
-    def __init__(self, an_fs):
-        """ Initializer.
-
-            :param FS an_fs: a filesystem object
-        """
-        self.fs = an_fs
 
     @property
     def _infoCommand(self):
@@ -96,11 +90,5 @@ class XFSInfo(FSInfo):
     ext = availability.XFSDB_APP
     options = ["-c", "sb 0", "-c", "p dblocks", "-c", "p blocksize"]
 
-class UnimplementedFSInfo(task.UnimplementedTask):
-
-    def __init__(self, an_fs):
-        """ Initializer.
-
-            :param FS an_fs: a filesystem object
-        """
-        self.fs = an_fs
+class UnimplementedFSInfo(fstask.UnimplementedFSTask):
+    pass

--- a/blivet/tasks/fsminsize.py
+++ b/blivet/tasks/fsminsize.py
@@ -28,22 +28,16 @@ from .. import util
 from ..size import Size
 
 from . import availability
+from . import fstask
 from . import task
 
 @add_metaclass(abc.ABCMeta)
-class FSMinSize(task.BasicApplication):
+class FSMinSize(task.BasicApplication, fstask.FSTask):
     """ An abstract class that represents min size information extraction. """
 
     description = "minimum filesystem size"
 
     options = abc.abstractproperty(doc="Options for use with app.")
-
-    def __init__(self, an_fs):
-        """ Initializer.
-
-            :param FS an_fs: a filesystem object
-        """
-        self.fs = an_fs
 
     def _resizeCommand(self):
         return [str(self.ext)] + self.options + [self.fs.device]
@@ -177,11 +171,5 @@ class NTFSMinSize(FSMinSize):
             raise FSError("Unable to discover minimum size of filesystem on %s" % self.fs.device)
         return minSize
 
-class UnimplementedFSMinSize(task.UnimplementedTask):
-
-    def __init__(self, an_fs):
-        """ Initializer.
-
-            :param FS an_fs: a filesystem object
-        """
-        self.fs = an_fs
+class UnimplementedFSMinSize(fstask.UnimplementedFSTask):
+    pass

--- a/blivet/tasks/fsmkfs.py
+++ b/blivet/tasks/fsmkfs.py
@@ -27,10 +27,11 @@ from ..errors import FSError, FSWriteLabelError
 from .. import util
 
 from . import availability
+from . import fstask
 from . import task
 
 @add_metaclass(abc.ABCMeta)
-class FSMkfsTask(task.Task):
+class FSMkfsTask(fstask.FSTask):
 
     canLabel = abc.abstractproperty(doc="whether this task labels")
 
@@ -43,13 +44,6 @@ class FSMkfs(task.BasicApplication, FSMkfsTask):
        doc="Option for setting a filesystem label.")
 
     args = abc.abstractproperty(doc="options for creating filesystem")
-
-    def __init__(self, an_fs):
-        """ Initializer.
-
-            :param FS an_fs: a filesystem object
-        """
-        self.fs = an_fs
 
     # IMPLEMENTATION methods
 
@@ -218,13 +212,6 @@ class XFSMkfs(FSMkfs):
         return ["-f"]
 
 class UnimplementedFSMkfs(task.UnimplementedTask, FSMkfsTask):
-
-    def __init__(self, an_fs):
-        """ Initializer.
-
-            :param FS an_fs: a filesystem object
-        """
-        self.fs = an_fs
 
     @property
     def canLabel(self):

--- a/blivet/tasks/fsmount.py
+++ b/blivet/tasks/fsmount.py
@@ -27,9 +27,10 @@ from .. import util
 from ..formats import fslib
 
 from . import availability
+from . import fstask
 from . import task
 
-class FSMount(task.BasicApplication):
+class FSMount(task.BasicApplication, fstask.FSTask):
     """An abstract class that represents filesystem mounting actions. """
     description = "mount a filesystem"
 
@@ -38,9 +39,6 @@ class FSMount(task.BasicApplication):
     fstype = None
 
     ext = availability.MOUNT_APP
-
-    def __init__(self, an_fs):
-        self.fs = an_fs
 
     # TASK methods
 

--- a/blivet/tasks/fsreadlabel.py
+++ b/blivet/tasks/fsreadlabel.py
@@ -28,10 +28,11 @@ from ..errors import FSReadLabelError
 from .. import util
 
 from . import availability
+from . import fstask
 from . import task
 
 @add_metaclass(abc.ABCMeta)
-class FSReadLabel(task.BasicApplication):
+class FSReadLabel(task.BasicApplication, fstask.FSTask):
     """ An abstract class that represents reading a filesystem's label. """
     description = "read filesystem label"
 
@@ -39,13 +40,6 @@ class FSReadLabel(task.BasicApplication):
         doc="Matches the string output by the reading application.")
 
     args = abc.abstractproperty(doc="arguments for reading a label.")
-
-    def __init__(self, an_fs):
-        """ Initializer.
-
-           :param FS an_fs: a filesystem object
-        """
-        self.fs = an_fs
 
     # IMPLEMENTATION methods
 
@@ -123,11 +117,5 @@ class XFSReadLabel(FSReadLabel):
     def args(self):
         return ["-l", self.fs.device]
 
-class UnimplementedFSReadLabel(task.UnimplementedTask):
-
-    def __init__(self, an_fs):
-        """ Initializer.
-
-            :param FS an_fs: a filesystem object
-        """
-        self.fs = an_fs
+class UnimplementedFSReadLabel(fstask.UnimplementedFSTask):
+    pass

--- a/blivet/tasks/fsresize.py
+++ b/blivet/tasks/fsresize.py
@@ -28,10 +28,11 @@ from ..size import B, KiB, MiB, GiB, KB, MB, GB
 from ..import util
 
 from . import availability
+from . import fstask
 from . import task
 
 @add_metaclass(abc.ABCMeta)
-class FSResizeTask(task.Task):
+class FSResizeTask(fstask.FSTask):
     """ The abstract properties that any resize task must have. """
 
     unit = abc.abstractproperty(doc="Resize unit.")
@@ -44,13 +45,6 @@ class FSResize(task.BasicApplication, FSResizeTask):
     description = "resize filesystem"
 
     args = abc.abstractproperty(doc="Resize arguments.")
-
-    def __init__(self, an_fs):
-        """ Initializer.
-
-            :param FS an_fs: a filesystem object
-        """
-        self.fs = an_fs
 
     # IMPLEMENTATION methods
 
@@ -134,13 +128,6 @@ class TmpFSResize(FSResize):
         return ['-o', ",".join(options), self.fs._type, self.fs.systemMountpoint]
 
 class UnimplementedFSResize(task.UnimplementedTask, FSResizeTask):
-
-    def __init__(self, an_fs):
-        """ Initializer.
-
-            :param FS an_fs: a filesystem object
-        """
-        self.fs = an_fs
 
     @property
     def unit(self):

--- a/blivet/tasks/fssize.py
+++ b/blivet/tasks/fssize.py
@@ -29,25 +29,19 @@ from ..size import Size
 from .. import util
 
 from . import availability
+from . import fstask
 from . import task
 
 _tags = ("count", "size")
 _Tags = namedtuple("_Tags", _tags)
 
 @add_metaclass(abc.ABCMeta)
-class FSSize(task.Task):
+class FSSize(fstask.FSTask):
     """ An abstract class that represents size information extraction. """
     description = "current filesystem size"
 
     tags = abc.abstractproperty(
         doc="Strings used for extracting components of size.")
-
-    def __init__(self, an_fs):
-        """ Initializer.
-
-            :param FS an_fs: a filesystem object
-        """
-        self.fs = an_fs
 
     # TASK methods
 
@@ -121,17 +115,10 @@ class ReiserFSSize(FSSize):
 class XFSSize(FSSize):
     tags = _Tags(size="blocksize =", count="dblocks =")
 
-class TmpFSSize(task.BasicApplication):
+class TmpFSSize(task.BasicApplication, fstask.FSTask):
     description = "current filesystem size"
 
     ext = availability.DF_APP
-
-    def __init__(self, an_fs):
-        """ Initializer.
-
-           :param FS an_fs: a filesystem object
-        """
-        self.fs = an_fs
 
     @property
     def _sizeCommand(self):
@@ -156,11 +143,5 @@ class TmpFSSize(task.BasicApplication):
         return Size("%s KiB" % lines[1])
 
 
-class UnimplementedFSSize(task.UnimplementedTask):
-
-    def __init__(self, an_fs):
-        """ Initializer.
-
-            :param FS an_fs: a filesystem object
-        """
-        self.fs = an_fs
+class UnimplementedFSSize(fstask.UnimplementedFSTask):
+    pass

--- a/blivet/tasks/fssync.py
+++ b/blivet/tasks/fssync.py
@@ -27,20 +27,14 @@ from ..errors import FSError
 from .. import util
 
 from . import availability
+from . import fstask
 from . import task
 
 @add_metaclass(abc.ABCMeta)
-class FSSync(task.BasicApplication):
+class FSSync(task.BasicApplication, fstask.FSTask):
     """ An abstract class that represents syncing a filesystem. """
 
     description = "filesystem syncing"
-
-    def __init__(self, an_fs):
-        """ Initializer.
-
-            :param FS an_fs: a filesystem object
-        """
-        self.fs = an_fs
 
     @abc.abstractmethod
     def doTask(self):
@@ -79,11 +73,5 @@ class XFSSync(FSSync):
         if error_msg:
             raise FSError(error_msg)
 
-class UnimplementedFSSync(task.UnimplementedTask):
-
-    def __init__(self, an_fs):
-        """ Initializer.
-
-            :param FS an_fs: a filesystem object
-        """
-        self.fs = an_fs
+class UnimplementedFSSync(fstask.UnimplementedFSTask):
+    pass

--- a/blivet/tasks/fstask.py
+++ b/blivet/tasks/fstask.py
@@ -1,0 +1,47 @@
+# fstask.py
+# Superclass for filesystem tasks.
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Anne Mulhern <amulhern@redhat.com>
+
+import abc
+
+from six import add_metaclass
+
+from . import task
+
+@add_metaclass(abc.ABCMeta)
+class FSTask(task.Task):
+    """ An abstract class that encapsulates the fact that all FSTasks
+        have a single master object: the filesystem that they belong to.
+    """
+    description = "parent of all filesystem tasks"
+
+    def __init__(self, an_fs):
+        """ Initializer.
+
+            :param FS an_fs: a filesystem object
+        """
+        self.fs = an_fs
+
+class UnimplementedFSTask(FSTask, task.UnimplementedTask):
+    """ A convenience class for unimplemented filesystem tasks.
+        Useful in the usual case where an Unimplemented task has
+        no special methods that it is required to implement.
+    """
+    pass

--- a/blivet/tasks/fswritelabel.py
+++ b/blivet/tasks/fswritelabel.py
@@ -27,22 +27,16 @@ from .. import util
 from ..errors import FSWriteLabelError
 
 from . import availability
+from . import fstask
 from . import task
 
 @add_metaclass(abc.ABCMeta)
-class FSWriteLabel(task.BasicApplication):
+class FSWriteLabel(task.BasicApplication, fstask.FSTask):
     """ An abstract class that represents writing a label for a filesystem. """
 
     description = "write filesystem label"
 
     args = abc.abstractproperty(doc="arguments for writing a label")
-
-    def __init__(self, an_fs):
-        """ Initializer.
-
-            :param FS an_fs: a filesystem object
-        """
-        self.fs = an_fs
 
     # IMPLEMENTATION methods
 
@@ -106,11 +100,5 @@ class XFSWriteLabel(FSWriteLabel):
     def args(self):
         return ["-L", self.fs.label if self.fs.label != "" else "--", self.fs.device]
 
-class UnimplementedFSWriteLabel(task.UnimplementedTask):
-
-    def __init__(self, an_fs):
-        """ Initializer.
-
-            :param FS an_fs: a filesystem object
-        """
-        self.fs = an_fs
+class UnimplementedFSWriteLabel(fstask.UnimplementedFSTask):
+    pass


### PR DESCRIPTION
This is an alternative to #165. The approach is to deepcopy all format objects when copying, instead of to define an ```__copy__``` method that handles tasks specially.

The first two patches are the same as in #165.

It's tested, in that I tried an experiment whereby I made a deep copy of all formats objects in fstesting.py and ran all tests on the deepcopy, rather than the original format object, and they all passed. Using copy, instead of deepcopy, they all failed. Using copy, and overriding ```__copy__``` in FS, they all passed.

It should be noted that format objects are already deep copied, rather than shallow copied, in actionlist.

