### PR TITLE
x-initrd.mount should only be set for /var (#1238603)

### DIFF
--- a/blivet/__init__.py
+++ b/blivet/__init__.py
@@ -2826,7 +2826,7 @@ class FSSet(object):
             for netdev in netdevs:
                 if device.dependsOn(netdev):
                     options = options + ",_netdev"
-                    if root_on_netdev and mountpoint not in ["/", "/usr"]:
+                    if root_on_netdev and mountpoint == "/var":
                         options = options + ",x-initrd.mount"
                     break
             if device.encrypted:


### PR DESCRIPTION
Only add it to /var and only when /var is on a _netdev.

Resolves: rhbz#1238603