### PR TITLE
use floor division in calculating amount to reclaim (#1245446)

### DIFF
--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -1587,7 +1587,7 @@ def manageSizeSets(size_sets, chunks):
                     if ss.needed < 0:
                         # it would be good to take back some from each device
                         # instead of taking all from the last one(s)
-                        extra = -chunk.sizeToLength(needed) / len(ss.devices)
+                        extra = -chunk.sizeToLength(needed) // len(ss.devices)
                         if extra > request.growth and i == 0:
                             log.debug("not reclaiming from this request")
                             continue


### PR DESCRIPTION
Using true division results in a float, which eventually causes
a crash when the value is passed to sectorsToSize(), which
tries to multiply it by a Size. Multiplying a float by a Size
doesn't work. sectorsToSize() does specify that it needs an int.
This is a python2 vs. python3 thing: in py2, int/int returns
an int. See PEP 238.
This fixes #1245854 and #1245446 (tested).