### PR TITLE
Add method to list primary partitions

### DIFF
--- a/blivet/formats/disklabel.py
+++ b/blivet/formats/disklabel.py
@@ -324,6 +324,15 @@ class DiskLabel(DeviceFormat):
         return logicals
 
     @property
+    def primaryPartitions(self):
+        try:
+            primaries = self.partedDisk.getPrimaryPartitions()
+        except Exception: # pylint: disable=broad-except
+            log_exception_info()
+            primaries = []
+        return primaries
+
+    @property
     def firstPartition(self):
         try:
             part = self.partedDisk.getFirstPartition()


### PR DESCRIPTION
We already have extendedPartition and logicalPartitions, having also primaryPartitions would make blivet-gui code a little nicer and shorter.