### PR TITLE
Fixes needed for livemedia-creator and anaconda --dirinstall

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -629,7 +629,7 @@ class FS(DeviceFormat):
         if rc:
             # try and catch whatever is causing the umount problem
             util.run_program(["lsof", mountpoint])
-            raise FSError("umount failed")
+            raise FSError("umount of %s failed (%d)" % (mountpoint, rc))
 
         if mountpoint == self._chrootedMountpoint:
             self._chrootedMountpoint = None

--- a/blivet/osinstall.py
+++ b/blivet/osinstall.py
@@ -617,8 +617,8 @@ class FSSet(object):
                (device.format.type == "swap" and not swapoff):
                 continue
 
+            # Unmount the devices
             device.format.teardown()
-            device.teardown()
 
         self.active = False
 


### PR DESCRIPTION
Skipping device teardown is a bit of a hack, but it solves the problem for the moment. We need to look at how mountpoints are being handled and fix that at some point soon. It is nuts that repeated calls to teardown can result in different behavior.