### PR TITLE
Pass a sysfs path to MultipathDevice constructor (#1245201)

### DIFF
--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -856,6 +856,7 @@ class DeviceTree(object):
                 raise DeviceTreeError("multipath %s has no DM_UUID" % name)
 
             device = MultipathDevice(name, parents=slave_devs,
+                                     sysfsPath=udev.device_get_sysfs_path(info),
                                      serial=serial)
             self._addDevice(device)
 


### PR DESCRIPTION
As dlehman advised, I

Cherry-picked master
commit d2a27294a05b0c34bb6a69d3393cda1d17ae0a7

And tested that it works.

Resolves: rhbz#1245201