### PR TITLE
PartitionDevice may not have a disk set (#1248973)

### DIFF
--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -753,7 +753,7 @@ class PartitionDevice(StorageDevice):
 
         # the rest is for changing the size of an allocated-but-not-existing
         # partition, which I'm not sure is advisable
-        if newsize > self.disk.size:
+        if self.disk and newsize > self.disk.size:
             raise ValueError("partition size would exceed disk size")
 
         maxAvailableSize = Size(self.partedPartition.getMaxAvailableSize(unit="B"))


### PR DESCRIPTION
When it is an implicit partition and hasn't been assigned a disk yet
self.disk may be None, so skip checking the size against the disk when
there isn't one.

Resolves: rhbz#1248973