### PR TITLE
Fix mount cache for devices with symlinks

### DIFF
--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -68,12 +68,14 @@ def trigger(subsystem=None, action="add", name=None):
     util.run_program(["udevadm"] + argv)
     settle()
 
-def resolve_devspec(devspec):
+def resolve_devspec(devspec, sysname=False):
     if not devspec:
         return None
 
     # import devices locally to avoid cyclic import (devices <-> udev)
     from . import devices
+
+    devname = devices.devicePathToName(devspec)
 
     ret = None
     for dev in get_devices():
@@ -85,7 +87,7 @@ def resolve_devspec(devspec):
             if device_get_uuid(dev) == devspec[5:]:
                 ret = dev
                 break
-        elif device_get_name(dev) == devices.devicePathToName(devspec):
+        elif device_get_name(dev) == devname or dev.sys_name == devname:
             ret = dev
             break
         else:
@@ -99,7 +101,7 @@ def resolve_devspec(devspec):
                     break
 
     if ret:
-        return device_get_name(ret)
+        return ret.sys_name if sysname else device_get_name(ret)
 
 def resolve_glob(glob):
     import fnmatch


### PR DESCRIPTION
This makes it possible to use any valid device spec when accessing the cache. All device specs are resolved to the basename canonical device node name (eg: `dm-1`, `md127p2`) before being stored or search for.

It turns out that `/proc/mounts` contains `/dev/mapper/` symlinks for device-mapper devices, but does not contain `/dev/md/` symlinks for md devices. We avoid this circus by using only the canonical device node name in the cache itself. We use udev to resolve device specs to the canonical names.