### PR TITLE
Allow aligning free regions to disk grainSize (#1244671)

### DIFF
--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -424,11 +424,13 @@ def addPartition(disklabel, free, part_type, size, start=None, end=None):
                                       constraint=constraint)
     return partition
 
-def getFreeRegions(disks):
+def getFreeRegions(disks, align=False):
     """ Return a list of free regions on the specified disks.
 
         :param disks: list of disks
         :type disks: list of :class:`~.devices.Disk`
+        :param align: align the region length to disk grainSize
+        :type align: bool
         :returns: list of free regions
         :rtype: list of :class:`parted.Geometry`
 
@@ -439,7 +441,13 @@ def getFreeRegions(disks):
     free = []
     for disk in disks:
         for f in disk.format.partedDisk.getFreeSpaceRegions():
-            if f.length >= disk.format.alignment.grainSize:
+            grain_size = disk.format.alignment.grainSize
+            if f.length >= grain_size:
+                if align:
+                    aligned_length = f.length - (f.length % grain_size)
+                    log.debug("length of free region aligned from %d to %d",
+                              f.length, aligned_length)
+                    f.length = aligned_length
                 free.append(f)
 
     return free

--- a/tests/partitioning_test.py
+++ b/tests/partitioning_test.py
@@ -504,6 +504,21 @@ class PartitioningTestCase(unittest.TestCase):
         self.assertEqual(req2.growth, 3956)
         self.assertEqual(req3.growth, 512)
 
+    def testAlignFreeRegions(self):
+        # disk with two free regions -- first unaligned, second aligned
+        disk = Mock()
+        disk.format.alignment.grainSize = 2048
+        disk.format.partedDisk.getFreeSpaceRegions.return_value = [Mock(start=1, end=2049, length=2049),
+                                                                   Mock(start=1, end=2048, length=2048)]
+
+        free = getFreeRegions([disk])
+        self.assertEqual(free[0].length, 2049)
+        self.assertEqual(free[1].length, 2048)
+
+        free = getFreeRegions([disk], align=True)
+        self.assertEqual(free[0].length, 2048)
+        self.assertEqual(free[1].length, 2048)
+
 class ExtendedPartitionTestCase(ImageBackedTestCase):
 
     disks = {"disk1": Size("2 GiB")}


### PR DESCRIPTION
Using full size of a free region results in PartitioningError
because blivet expects the size of new partition to be aligned
to disk grainSize (and rounds the size up if it isn't aligned).

Signed-off-by: Vojtech Trefny <vtrefny@redhat.com>