### PR TITLE
Add unit tests for the LVM cache support

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -570,7 +570,7 @@ class LVMLogicalVolumeDevice(DMDevice):
     @property
     def logSize(self):
         log_lvs = (int_lv for int_lv in self._internal_lvs if isinstance(int_lv, LVMLogLogicalVolumeDevice))
-        return sum(lv.size for lv in log_lvs)
+        return Size(sum(lv.size for lv in log_lvs))
 
     @property
     def metaDataSize(self):
@@ -578,7 +578,7 @@ class LVMLogicalVolumeDevice(DMDevice):
             return self._metaDataSize
 
         md_lvs = (int_lv for int_lv in self._internal_lvs if isinstance(int_lv, LVMMetadataLogicalVolumeDevice))
-        return sum(lv.size for lv in md_lvs)
+        return Size(sum(lv.size for lv in md_lvs))
 
     def __repr__(self):
         s = DMDevice.__repr__(self)

--- a/tests/devices_test/device_properties_test.py
+++ b/tests/devices_test/device_properties_test.py
@@ -25,6 +25,7 @@ from blivet.devices import OpticalDevice
 from blivet.devices import StorageDevice
 from blivet.devices import ParentList
 from blivet.devices import LVMVolumeGroupDevice, LVMLogicalVolumeDevice
+from blivet.devices.lvm import LVMCacheRequest, LVMCache
 from blivet.devicelibs import btrfs
 from blivet.devicelibs import mdraid
 from blivet.size import Size
@@ -744,6 +745,16 @@ class LVMLogicalVolumeDeviceTestCase(DeviceStateTestCase):
         self.lv = LVMLogicalVolumeDevice("testlv", parents=[vg],
                                          fmt=blivet.formats.getFormat("xfs"))
 
+        pv2 = StorageDevice("pv2", fmt=blivet.formats.getFormat("lvmpv"),
+                            size=Size("1 GiB"))
+        pv3 = StorageDevice("pv3", fmt=blivet.formats.getFormat("lvmpv"),
+                            size=Size("1 GiB"))
+        vg2 = LVMVolumeGroupDevice("testvg2", parents=[pv2, pv3])
+        cache_req = LVMCacheRequest(Size("512 MiB"), [pv3], "writethrough")
+        self.cached_lv = LVMLogicalVolumeDevice("testcachedlv", parents=[vg2],
+                                    fmt=blivet.formats.getFormat("xfs"),
+                                    exists=False, cacheRequest=cache_req)
+
     def testLVMLogicalVolumeDeviceInit(self):
         self.stateCheck(self.lv,
             # 1 GiB - one extent
@@ -774,4 +785,37 @@ class LVMLogicalVolumeDeviceTestCase(DeviceStateTestCase):
             isleaf=xform(lambda x, m: self.assertTrue(x, m)),
             direct=xform(lambda x, m: self.assertTrue(x, m)),
             cached=xform(lambda x, m: self.assertFalse(x, m)),
+        )
+
+    def testLVMLogicalVolumeDeviceInitCached(self):
+        self.stateCheck(self.cached_lv,
+            # 2 * (1 GiB - one extent) - 512 MiB
+            maxSize=xform(lambda x, m: self.assertEqual(x, Size("1528 MiB"), m) and
+                          self.assertIsInstance(x, Size, m)),
+            snapshots=xform(lambda x, m: self.assertEqual(x, [], m)),
+            segType=xform(lambda x, m: self.assertEqual(x, "linear", m)),
+            req_grow=xform(lambda x, m: self.assertEqual(x, None, m)),
+            req_max_size=xform(lambda x, m: self.assertEqual(x, Size(0), m) and
+                               self.assertIsInstance(x, Size, m)),
+            req_size=xform(lambda x, m: self.assertEqual(x, Size(0), m) and
+                           self.assertIsInstance(x, Size, m)),
+            req_percent=xform(lambda x, m: self.assertEqual(x, Size(0), m)),
+            copies=xform(lambda x, m: self.assertEqual(x, 1, m)),
+            logSize=xform(lambda x, m: self.assertEqual(x, Size(0), m) and
+                          self.assertIsInstance(x, Size, m)),
+            metaDataSize=xform(lambda x, m: self.assertEqual(x, Size(0), m) and
+                               self.assertIsInstance(x, Size, m)),
+            mirrored=xform(lambda x, m: self.assertFalse(x, m)),
+            vgSpaceUsed=xform(lambda x, m: self.assertEqual(x, Size("512 MiB"), m) and
+                              self.assertIsInstance(x, Size, m)),
+            vg=xform(lambda x, m: self.assertIsInstance(x, LVMVolumeGroupDevice)),
+            container=xform(lambda x, m: self.assertIsInstance(x, LVMVolumeGroupDevice)),
+            mapName=xform(lambda x, m: self.assertEqual(x, "testvg2-testcachedlv", m)),
+            path=xform(lambda x, m: self.assertEqual(x, "/dev/mapper/testvg2-testcachedlv", m)),
+            lvname=xform(lambda x, m: self.assertEqual(x, "testcachedlv", m)),
+            complete=xform(lambda x, m: self.assertTrue(x, m)),
+            isleaf=xform(lambda x, m: self.assertTrue(x, m)),
+            direct=xform(lambda x, m: self.assertTrue(x, m)),
+            cached=xform(lambda x, m: self.assertTrue(x, m)),
+            cache=xform(lambda x, m: self.assertIsInstance(x, LVMCache, m)),
         )

--- a/tests/devices_test/device_properties_test.py
+++ b/tests/devices_test/device_properties_test.py
@@ -34,6 +34,8 @@ from blivet.formats import getFormat
 
 BTRFS_MIN_MEMBER_SIZE = getFormat("btrfs").minSize
 
+# pylint: disable=unnecessary-lambda
+
 def xform(func):
     """ Simple wrapper function that transforms a function that takes
         a precalculated value and a message to a function that takes

--- a/tests/devices_test/device_properties_test.py
+++ b/tests/devices_test/device_properties_test.py
@@ -24,6 +24,7 @@ from blivet.devices import MDRaidArrayDevice
 from blivet.devices import OpticalDevice
 from blivet.devices import StorageDevice
 from blivet.devices import ParentList
+from blivet.devices import LVMVolumeGroupDevice, LVMLogicalVolumeDevice
 from blivet.devicelibs import btrfs
 from blivet.devicelibs import mdraid
 from blivet.size import Size
@@ -723,3 +724,54 @@ class BTRFSDeviceTestCase(DeviceStateTestCase):
 
         self.assertEqual(snap.dependsOn(vol), True)
         self.assertEqual(vol.dependsOn(snap), False)
+
+class LVMLogicalVolumeDeviceTestCase(DeviceStateTestCase):
+    def __init__(self, methodName="runTest"):
+        super(LVMLogicalVolumeDeviceTestCase, self).__init__(methodName=methodName)
+        state_functions = {
+            "type": xform(lambda x, m: self.assertEqual(x, "lvmlv", m)),
+            "parents": xform(lambda x, m: self.assertEqual(len(x), 1, m) and
+                             self.assertIsInstance(x, ParentList) and
+                             self.assertIsInstance(x[0], LVMVolumeGroupDevice)),
+            }
+
+        self._state_functions.update(state_functions)
+
+    def setUp(self):
+        pv = StorageDevice("pv1", fmt=blivet.formats.getFormat("lvmpv"),
+                           size=Size("1 GiB"))
+        vg = LVMVolumeGroupDevice("testvg", parents=[pv])
+        self.lv = LVMLogicalVolumeDevice("testlv", parents=[vg],
+                                         fmt=blivet.formats.getFormat("xfs"))
+
+    def testLVMLogicalVolumeDeviceInit(self):
+        self.stateCheck(self.lv,
+            # 1 GiB - one extent
+            maxSize=xform(lambda x, m: self.assertEqual(x, Size("1020 MiB"), m) and
+                          self.assertIsInstance(x, Size, m)),
+            snapshots=xform(lambda x, m: self.assertEqual(x, [], m)),
+            segType=xform(lambda x, m: self.assertEqual(x, "linear", m)),
+            req_grow=xform(lambda x, m: self.assertEqual(x, None, m)),
+            req_max_size=xform(lambda x, m: self.assertEqual(x, Size(0), m) and
+                               self.assertIsInstance(x, Size, m)),
+            req_size=xform(lambda x, m: self.assertEqual(x, Size(0), m) and
+                           self.assertIsInstance(x, Size, m)),
+            req_percent=xform(lambda x, m: self.assertEqual(x, Size(0), m)),
+            copies=xform(lambda x, m: self.assertEqual(x, 1, m)),
+            logSize=xform(lambda x, m: self.assertEqual(x, Size(0), m) and
+                          self.assertIsInstance(x, Size, m)),
+            metaDataSize=xform(lambda x, m: self.assertEqual(x, Size(0), m) and
+                               self.assertIsInstance(x, Size, m)),
+            mirrored=xform(lambda x, m: self.assertFalse(x, m)),
+            vgSpaceUsed=xform(lambda x, m: self.assertEqual(x, Size(0), m) and
+                              self.assertIsInstance(x, Size, m)),
+            vg=xform(lambda x, m: self.assertIsInstance(x, LVMVolumeGroupDevice)),
+            container=xform(lambda x, m: self.assertIsInstance(x, LVMVolumeGroupDevice)),
+            mapName=xform(lambda x, m: self.assertEqual(x, "testvg-testlv", m)),
+            path=xform(lambda x, m: self.assertEqual(x, "/dev/mapper/testvg-testlv", m)),
+            lvname=xform(lambda x, m: self.assertEqual(x, "testlv", m)),
+            complete=xform(lambda x, m: self.assertTrue(x, m)),
+            isleaf=xform(lambda x, m: self.assertTrue(x, m)),
+            direct=xform(lambda x, m: self.assertTrue(x, m)),
+            cached=xform(lambda x, m: self.assertFalse(x, m)),
+        )


### PR DESCRIPTION
So that we can catch possible regressions easily in the future.