### PR TITLE
Better calculate required space for LVM cache

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -616,10 +616,10 @@ class LVMLogicalVolumeDevice(DMDevice):
         log.debug("trying to set lv %s size to %s", self.name, size)
         # Don't refuse to set size if we think there's not enough space in the
         # VG for an existing LV, since it's existence proves there is enough
-        # space for it.
+        # space for it. A similar reasoning applies to shrinking the LV.
         if not self.exists and \
            not isinstance(self, LVMThinLogicalVolumeDevice) and \
-           size > self.vg.freeSpace + self.vgSpaceUsed:
+           size > self.size and size > self.vg.freeSpace + self.vgSpaceUsed:
             log.error("failed to set size: %s short", size - (self.vg.freeSpace + self.vgSpaceUsed))
             raise ValueError("not enough free space in volume group")
 

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -347,6 +347,9 @@ class LVMVolumeGroupDevice(ContainerDevice):
         elif self.reserved_space > Size(0):
             reserved = self.reserved_space
 
+        # reserve space for the pmspare LV LVM creates behind our back
+        reserved += self.pmSpareSize
+
         return self.align(reserved, roundup=True)
 
     @property
@@ -420,6 +423,16 @@ class LVMVolumeGroupDevice(ContainerDevice):
     @property
     def cachedLVs(self):
         return [l for l in self._lvs if l.cached]
+
+    @property
+    def pmSpareSize(self):
+        """Size of the pmspare LV LVM creates in every VG that contains some metadata
+        (even internal) LV. The size of such LV is equal to the size of the
+        biggest metadata LV in the VG.
+
+        """
+        # TODO: report correctly/better for existing VGs
+        return max([lv.metaDataSize for lv in self.lvs] + [Size(0)])
 
     @property
     def complete(self):

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -418,6 +418,10 @@ class LVMVolumeGroupDevice(ContainerDevice):
         return [l for l in self._lvs if isinstance(l, LVMThinLogicalVolumeDevice)]
 
     @property
+    def cachedLVs(self):
+        return [l for l in self._lvs if l.cached]
+
+    @property
     def complete(self):
         """Check if the vg has all its pvs in the system
         Return True if complete.

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -1757,11 +1757,11 @@ class LVMCacheStats(CacheStats):
         :type stats_data: :class:`blockdev.LVMCacheStats`
 
         """
-        self._block_size = stats_data.block_size
-        self._cache_size = stats_data.cache_size
+        self._block_size = Size(stats_data.block_size)
+        self._cache_size = Size(stats_data.cache_size)
         self._cache_used = stats_data.cache_used
-        self._md_block_size = stats_data.md_block_size
-        self._md_size = stats_data.md_size
+        self._md_block_size = Size(stats_data.md_block_size)
+        self._md_size = Size(stats_data.md_size)
         self._md_used = stats_data.md_used
         self._read_hits = stats_data.read_hits
         self._read_misses = stats_data.read_misses

--- a/tests/devices_test/device_properties_test.py
+++ b/tests/devices_test/device_properties_test.py
@@ -791,8 +791,9 @@ class LVMLogicalVolumeDeviceTestCase(DeviceStateTestCase):
 
     def testLVMLogicalVolumeDeviceInitCached(self):
         self.stateCheck(self.cached_lv,
-            # 2 * (1 GiB - one extent) - 512 MiB
-            maxSize=xform(lambda x, m: self.assertEqual(x, Size("1528 MiB"), m) and
+            # 2 * (1 GiB - one extent) - 512 MiB - 8 MiB
+            #       PVfree               cache     pmspare
+            maxSize=xform(lambda x, m: self.assertEqual(x, Size("1520 MiB"), m) and
                           self.assertIsInstance(x, Size, m)),
             snapshots=xform(lambda x, m: self.assertEqual(x, [], m)),
             segType=xform(lambda x, m: self.assertEqual(x, "linear", m)),

--- a/tests/devices_test/lvm_test.py
+++ b/tests/devices_test/lvm_test.py
@@ -111,7 +111,12 @@ class LVMDeviceTest(unittest.TestCase):
         self.assertIsNotNone(cache)
 
         # check parameters reported by the (non-existing) cache
-        self.assertEqual(cache.size, Size("512 MiB"))
+        self.assertEqual(cache.size, Size("504 MiB"))
+        self.assertEqual(cache.md_size, Size("8 MiB"))
+        self.assertEqual(cache.vgSpaceUsed, Size("512 MiB"))
+        self.assertIsInstance(cache.size, Size)
+        self.assertIsInstance(cache.md_size, Size)
+        self.assertIsInstance(cache.vgSpaceUsed, Size)
         self.assertFalse(cache.exists)
         self.assertIsNone(cache.stats)
         self.assertEqual(cache.mode, "writethrough")

--- a/tests/partitioning_test.py
+++ b/tests/partitioning_test.py
@@ -508,8 +508,10 @@ class PartitioningTestCase(unittest.TestCase):
     def testVGChunkWithCache(self):
         pv = StorageDevice("pv1", size=Size("40 GiB"),
                            fmt=getFormat("lvmpv"))
-        # 1025 MiB so that the PV provides 1024 MiB of free space (see LVMVolumeGroupDevice.extents)
-        pv2 = StorageDevice("pv2", size=Size("1025 MiB"),
+        # 1033 MiB so that the PV provides 1032 MiB of free space (see
+        # LVMVolumeGroupDevice.extents) -- 1024 MiB for caches, 8 MiB for the
+        # pmspare LV
+        pv2 = StorageDevice("pv2", size=Size("1033 MiB"),
                            fmt=getFormat("lvmpv"))
         vg = LVMVolumeGroupDevice("vg", parents=[pv, pv2])
 
@@ -550,10 +552,11 @@ class PartitioningTestCase(unittest.TestCase):
     def testVGChunkWithCachePVfree(self):
         pv = StorageDevice("pv1", size=Size("40 GiB"),
                            fmt=getFormat("lvmpv"))
-        # 1069 MiB so that the PV provides 1068 MiB of free space (see
+        # 1077 MiB so that the PV provides 1076 MiB of free space (see
         # LVMVolumeGroupDevice.extents) which is 44 MiB more than the caches
-        # need and which should thus be split into the LVs
-        pv2 = StorageDevice("pv2", size=Size("1069 MiB"),
+        # need (including the 8MiB pmspare LV) and which should thus be split
+        # into the LVs
+        pv2 = StorageDevice("pv2", size=Size("1077 MiB"),
                            fmt=getFormat("lvmpv"))
         vg = LVMVolumeGroupDevice("vg", parents=[pv, pv2])
 


### PR DESCRIPTION
This pull request has three purposes (of descending importance):
1) it fixes a hidden issue discovered by anaconda's kickstart tests where the following kickstart snippet
```
logvol swap --name=swap --vgname=fedora --size=500 --fstype=swap
logvol / --name=root --vgname=fedora --size=4000 --grow --fstype=ext4 --cachepvs=pv.2 --cachesize=1000 --cachemode=writethrough
logvol /home --name=home --vgname=fedora --size=1000 --grow --fstype=ext4 --cachepvs=pv.2 --cachesize=1000 --cachemode=writeback
```
results in a successful installation, but the ``swap`` LV ends up being 8 MiB smaller. It's not the end of the world, but if the metadata size for cache was 256 MiB, it would be 256 MiB smaller which is quite a big difference. And even with the 8 MiB it's just wrong because the ``swap`` LV is the only one that has the exact requested size whereas the other LVs are requested to grow and fill in the remaining space.

2) It brings us closer to the target of the issue #31 where similar fixes/improvements/cleanup should happen for other types of LVs too.

3) It brings us closer to the support of LVM cache metadata size specification by users/user code.