### PR TITLE
Don't store UUIDs or labels of multipath members.

### DIFF
--- a/blivet/populator.py
+++ b/blivet/populator.py
@@ -1449,6 +1449,12 @@ class Populator(object):
             # overarching volume UUID will be stored as volUUID
             kwargs["uuid"] = info["ID_FS_UUID_SUB"]
             kwargs["volUUID"] = uuid
+        elif format_type == "multipath_member":
+            # blkid does not care that the UUID it sees on a multipath member is
+            # for the multipath set's (and not the member's) formatting, so we
+            # have to discard it.
+            kwargs.pop("uuid")
+            kwargs.pop("label")
 
         try:
             log.info("type detected on '%s' is '%s'", name, format_designator)


### PR DESCRIPTION
multipath itself has absolutely no identifying metadata, so whatever
metadata found on the member is not related to the multipath set.
Therefore, we shouldn't be storing it in the member's format.

Resolves: rhbz#1254232