### PR TITLE
Continue with recursive teardown beyond inactive devices.

### DIFF
--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -424,6 +424,8 @@ class StorageDevice(Device):
         log_method_call(self, self.name, status=self.status,
                         controllable=self.controllable)
         if not self._preTeardown(recursive=recursive):
+            if recursive:
+                self.teardownParents(recursive=recursive)
             return
 
         self._teardown(recursive=recursive)


### PR DESCRIPTION
We want to continue to recursively deactivate the parents even if
the current device is inactive, but we don't want to run the
_postTeardown method of a device we're not deactivating.

On rhel7-branch, this will be preceded by a revert of a909ea38.

Related: rhbz#1182229