### PR TITLE
Don't teardown protected devices

### DIFF
--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -405,7 +405,7 @@ class StorageDevice(Device):
         if not self.exists and not recursive:
             raise errors.DeviceError("device has not been created", self.name)
 
-        if not self.status or not self.controllable:
+        if not self.status or not self.controllable or self.protected:
             return False
 
         if self.originalFormat.exists:


### PR DESCRIPTION
We don't want to unmount protected devices.

It tries to umount ``/run/install/isodir`` even when ISO was loaded.

This will go to master too.