### PR TITLE
Mount efivarfs during os installation (#1261559)

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -1782,3 +1782,8 @@ class USBFS(NoDevFS):
 
 register_device_format(USBFS)
 
+
+class EFIVarFS(NoDevFS):
+    _type = "efivarfs"
+
+register_device_format(EFIVarFS)


### PR DESCRIPTION
Tools running inside the chroot need access to /sys/firmware/efi/efivars
if it exists on the host. eg. efibootmgr

Resolves: rhbz#1261559