### PR TITLE
Don't teardown FSs when searching for installed systems (#1252902)

### DIFF
--- a/blivet/osinstall.py
+++ b/blivet/osinstall.py
@@ -239,10 +239,11 @@ def _findExistingInstallations(devicetree):
             device.format.mount(options=options, mountpoint=getSysroot())
         except Exception: # pylint: disable=broad-except
             log_exception_info(log.warning, "mount of %s as %s failed", [device.name, device.format.type])
-            device.teardown()
+            device.format.umount(mountpoint=getSysroot())
             continue
 
         if not os.access(getSysroot() + "/etc/fstab", os.R_OK):
+            device.format.umount(mountpoint=getSysroot())
             device.teardown(recursive=True)
             continue
 
@@ -263,7 +264,7 @@ def _findExistingInstallations(devicetree):
                         {"product": product, "version": version, "arch": architecture}
 
         (mounts, swaps) = parseFSTab(devicetree, chroot=getSysroot())
-        device.teardown()
+        device.format.umount(mountpoint=getSysroot())
         if not mounts and not swaps:
             # empty /etc/fstab. weird, but I've seen it happen.
             continue


### PR DESCRIPTION
When looking for existing installations the FSs are mounted to the sysroot but if the device is protected it can't be teared down.

Umount the disks instead of teardown. The `teardownAll()` method is used when all devices were tested.

*Related: rhbz#1252902*

*Will go to master too*