### PR TITLE
lvactivate when lvmetad is active

### DIFF
--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -20,6 +20,7 @@
 # Author(s): Dave Lehman <dlehman@redhat.com>
 #
 
+import os
 import re
 
 from collections import namedtuple
@@ -55,6 +56,8 @@ KNOWN_THPOOL_PROFILES = (ThPoolProfile("thin-generic", N_("Generic")),
                          ThPoolProfile("thin-performance", N_("Performance")))
 
 EXTERNAL_DEPENDENCIES = [availability.BLOCKDEV_LVM_PLUGIN]
+
+LVMETAD_SOCKET_PATH = "/run/lvm/lvmetad.socket"
 
 # Start config_args handling code
 #
@@ -172,3 +175,6 @@ def determine_parent_lv(vg_name, internal_lv, lvs):
                 return lv
 
     return None
+
+def lvmetad_socket_exists():
+    return os.path.exists(LVMETAD_SOCKET_PATH)


### PR DESCRIPTION
When lvmetad is running and the last PV in a VG is activated, an asynchronous system unit (`lvm2-pvscan@...service`) is scheduled to update LVM's view of things and to auto-activate the LVs. During the interim between that unit being scheduled and run, LVM behaves as if the PV were still inactive. So, when we're deactivating/activating the PVs we should wait for auto-activation instead of plowing ahead and trying to activate the LVs ourselves. This has caused several bugs in which we activate an MD PV, then try to activate an LV, and get an error from LVM saying the VG doesn't exist.