### PR TITLE
warn on failure to scan partitions

### DIFF
--- a/blivet/populator.py
+++ b/blivet/populator.py
@@ -441,12 +441,11 @@ class Populator(object):
                not self._isIgnoredDisk(disk):
                 if info.get("ID_PART_TABLE_TYPE") == "gpt":
                     msg = "corrupt gpt disklabel on disk %s" % disk.name
-                    cls = CorruptGPTError
                 else:
                     msg = "failed to scan disk %s" % disk.name
-                    cls = DiskLabelScanError
 
-                raise cls(msg)
+                log.error(msg)
+                return
 
             # there's no need to filter partitions on members of multipaths or
             # fwraid members from lvm since multipath and dmraid are already


### PR DESCRIPTION
I had a Fedora install fail due to https://bugzilla.redhat.com/1263832,
and I wonder if we should be treating failures at this point in the code
as warnings rather than errors.  This would permit blivet to continue
scanning other devices.

This would seem to be in line with the comments at the beginning of this
section of code, which suggest that the desired behavior is to ignore
the device rather than throwing an exception:

    # Ignore partitions on:
    #  - devices we do not support partitioning of, like logical volumes
    #  - devices that do not have a usable disklabel
    #  - devices that contain disklabels made by isohybrid