### PR TITLE
Convert float to str for better precision in Size

### DIFF
--- a/blivet/size.py
+++ b/blivet/size.py
@@ -305,23 +305,23 @@ class Size(Decimal):
     def __add__(self, other, context=None):
         # because float is not automatically converted to Decimal type
         if isinstance(other, float):
-            other = Decimal(other)
+            other = Decimal(str(other))
         return Size(Decimal.__add__(self, other))
 
     # needed to make sum() work with Size arguments
     def __radd__(self, other, context=None):
         if isinstance(other, float):
-            other = Decimal(other)
+            other = Decimal(str(other))
         return Size(Decimal.__radd__(self, other))
 
     def __sub__(self, other, context=None):
         if isinstance(other, float):
-            other = Decimal(other)
+            other = Decimal(str(other))
         return Size(Decimal.__sub__(self, other))
 
     def __mul__(self, other, context=None):
         if isinstance(other, float):
-            other = Decimal(other)
+            other = Decimal(str(other))
         return Size(Decimal.__mul__(self, other))
     __rmul__ = __mul__
 


### PR DESCRIPTION
Convert float to string before it's converted to Decimal. This prevents precision loss.

*Related: rhbz#1224048*

----------------------------------
This was discussed on storage meeting.