### PR TITLE
Add a 'debug' flag and use it for LVM debugging

### DIFF
--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -90,6 +90,8 @@ def _set_global_config():
     config_string = " devices { %s } " % (devices_string) # strings can be added
     if not flags.lvm_metadata_backup:
         config_string += "backup {backup=0 archive=0} "
+    if flags.debug:
+        config_string += "log {level=7 file=/tmp/lvm.log}"
 
     blockdev.lvm.set_global_config(config_string)
 

--- a/blivet/flags.py
+++ b/blivet/flags.py
@@ -31,6 +31,7 @@ class Flags(object):
         #
         self.testing = False
         self.installer_mode = False
+        self.debug = False
 
         #
         # minor modes (installer-specific)
@@ -92,6 +93,9 @@ class Flags(object):
 
     def update_from_anaconda_flags(self, anaconda_flags):
         self.installer_mode = True
+        # always enable the debug mode when in the installer mode so that we
+        # have more data in the logs for rare cases that are hard to reproduce
+        self.debug = True
         self.testing = anaconda_flags.testing
         self.automated_install = anaconda_flags.automatedInstall
         self.live_install = anaconda_flags.livecdInstall


### PR DESCRIPTION
Many times we have been asked by the LVM team to use the '-vvvv' option whenever
we do any LVM action so that the logs contain more (debugging)
information. However, getting the output of every single LVM command cluttered
with a lot of debugging info would be confusing for both us reading the logs and
the code parsing the output of such commands. The trade-off solution is to pass
the 'log{level=7}' config with all our commands that causes LVM to put the extra
info from '-vvvv' to syslog where it looks like all the other crystal-clear
stuff.