### PR TITLE
Handle sysfs size if it is missing (#1265090)

### DIFF
--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -620,7 +620,7 @@ class StorageDevice(Device):
         size = Size(0)
         if self.exists and os.path.exists(self.path) and \
            os.path.isdir(self.sysfsPath):
-            blocks = int(util.get_sysfs_attr(self.sysfsPath, "size"))
+            blocks = int(util.get_sysfs_attr(self.sysfsPath, "size") or '0')
             size = Size(blocks * LINUX_SECTOR_SIZE)
 
             self._mockPartedDevice(size)


### PR DESCRIPTION
sysfs paths may, for whatever reason, not exist. Return '0' for int()
instead of None if this is the case.

Resolves: rhbz#1265090