### PR TITLE
Fix calling non-existing method (#1252902)

### DIFF
--- a/blivet/osinstall.py
+++ b/blivet/osinstall.py
@@ -239,11 +239,11 @@ def _findExistingInstallations(devicetree):
             device.format.mount(options=options, mountpoint=getSysroot())
         except Exception: # pylint: disable=broad-except
             log_exception_info(log.warning, "mount of %s as %s failed", [device.name, device.format.type])
-            device.format.umount(mountpoint=getSysroot())
+            util.umount(mountpoint=getSysroot())
             continue
 
         if not os.access(getSysroot() + "/etc/fstab", os.R_OK):
-            device.format.umount(mountpoint=getSysroot())
+            util.umount(mountpoint=getSysroot())
             device.teardown(recursive=True)
             continue
 
@@ -264,7 +264,7 @@ def _findExistingInstallations(devicetree):
                         {"product": product, "version": version, "arch": architecture}
 
         (mounts, swaps) = parseFSTab(devicetree, chroot=getSysroot())
-        device.format.umount(mountpoint=getSysroot())
+        util.umount(mountpoint=getSysroot())
         if not mounts and not swaps:
             # empty /etc/fstab. weird, but I've seen it happen.
             continue


### PR DESCRIPTION
Fix my bug from commit (#05feef37e2c5ae8fd63abe2198ccd8d55e09b08a) where
I was calling non-existing device.format.umount() method, the unmount()
(missing 'n') method exists there but it's still only calling teardown()
instead of system umount. I'm changing call to util.umount() which
calling the system umount.
Because of this regression the first call of the
_findExistingInstallations method will raise an exception so no existing
installations were found and everything were in the Unknown group.
The exception was logged to storage log as info so I missed it.

Sorry guys for this issue.

*Related: rhbz#1252902*

*Will go to master branch too*