### PR TITLE
Add umount next to unmount method to avoid miscall

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -756,7 +756,7 @@ class FS(DeviceFormat):
     def unmount(self, **kwargs):
         """ Unmount this filesystem.
 
-            :param str mountpoint: Optional mountpoint to be unmounted.
+            :keyword str mountpoint: Optional mountpoint to be unmounted.
             :raises: FSError
 
             If mountpoint isn't passed this will unmount the most recent mountpoint listed
@@ -768,7 +768,7 @@ class FS(DeviceFormat):
     def umount(self, **kwargs):
         """ Unmount this filesystem.
 
-            :param str mountpoint: Optional mountpoint to be unmounted.
+            :keyword str mountpoint: Optional mountpoint to be unmounted.
             :raises: FSError
 
             If mountpoint isn't passed this will unmount the most recent mountpoint listed

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -765,6 +765,18 @@ class FS(DeviceFormat):
         """
         return self.teardown(**kwargs)
 
+    def umount(self, **kwargs):
+        """ Unmount this filesystem.
+
+            :param str mountpoint: Optional mountpoint to be unmounted.
+            :raises: FSError
+
+            If mountpoint isn't passed this will unmount the most recent mountpoint listed
+            by the system. Override this behavior by passing a specific mountpoint. FSError
+            will be raised in either case if the path doesn't exist.
+        """
+        return self.unmount(**kwargs)
+
     @property
     def status(self):
         if not self.exists:


### PR DESCRIPTION
System using umount so user could expect we will use the same naming conventions.