### PR TITLE
Switch to using rd.iscsi.initiator (#1268315)

### DIFF
--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -440,7 +440,7 @@ class iScsiDiskDevice(DiskDevice, NetworkStorageDevice):
                                       iface_spec,
                                       self.node.name)
 
-        initiator = "iscsi_initiator=%s" % self.initiator
+        initiator = "rd.iscsi.initiator=%s" % self.initiator
 
         return set([netroot, initiator])
 


### PR DESCRIPTION
Deprecated dracut argument.

Resolves: rhbz#1268315