### PR TITLE
Master fix btrfs tempmount

### DIFF
--- a/blivet/devices/btrfs.py
+++ b/blivet/devices/btrfs.py
@@ -352,14 +352,12 @@ class BTRFSVolumeDevice(BTRFSDevice, ContainerDevice, RaidDevice):
 
         return subvols
 
+    @util.deprecated('1.16', '')
     def createSubVolumes(self):
-        self._do_temp_mount()
-
         for _name, subvol in self.subvolumes:
             if subvol.exists:
                 continue
-            subvol.create(mountpoint=self._temp_dir_prefix)
-        self._undo_temp_mount()
+            subvol.create()
 
     def removeSubVolume(self, name):
         raise NotImplementedError()


### PR DESCRIPTION
Mountpoint detection for btrfs is broken again. The problem is with btrfs raids -- btrfs format stores information only about one parent device (the first one we populate from udev devices) and `/proc/self/mountinfo` also contains name of only one device (it should be the first one in the raid). And sometimes these devices are not the same. I don't know why, I wasn't able to reproduce it but apparently udev sometimes doesn't return disks sorted by name. Result is `systemMountpoint` is `None` because we are looking for mountpoint for `sdb` but `/proc/self/mountinfo` contains information only for `sda` (example for btrfs raid over two disks).

I've changed `_do_temp_mount` to `contextmanager` so if we actually need to mount the btrfs we always use the right mountpoint for libblockdev and also always unmount it.

We should of course change the btrfs format to contain names of all parent devices, but this will require an API change (and could break more things in btrfs) so it is not possible for f23-branch.

--
The deprecation of `createSubVolumes` is unrelated to the bug, I just noticed this method doesn't work (`create` doesn't take arguments) and we actually don't use it.