### PR TITLE
suppress LVM autobackup during image installs (rhbz#1269144)

### DIFF
--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -35,6 +35,7 @@ from .. import util
 from .. import arch
 from ..errors import LVMError
 from ..i18n import _, N_
+from ..flags import flags
 
 MAX_LV_SLOTS = 256
 
@@ -104,6 +105,8 @@ def _getConfigArgs(args):
     config_string = " devices { %s } " % (devices_string) # strings can be added
     if cmd in READONLY_COMMANDS:
         config_string += "global {locking_type=4} "
+    if not flags.lvm_metadata_backup:
+        config_string += "backup {backup=0 archive=0} "
     if config_string:
         config_args = ["--config", config_string]
     return config_args

--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -281,7 +281,7 @@ def pvmove(source, dest=None):
     """
     args = ["pvmove"] + _getConfigArgs() + [source]
     if dest:
-        args.extend(dest)
+        args.append(dest)
 
     try:
         lvm(args)

--- a/blivet/flags.py
+++ b/blivet/flags.py
@@ -110,4 +110,9 @@ class Flags(object):
         self.ibft = anaconda_flags.ibft
         self.dmraid = anaconda_flags.dmraid
 
+        # We don't want image installs writing backups of the *image* metadata
+        # into the *host's* /etc/lvm. This can get real messy on build systems.
+        if self.image_install:
+            self.lvm_metadata_backup = False
+
 flags = Flags()

--- a/blivet/flags.py
+++ b/blivet/flags.py
@@ -56,6 +56,10 @@ class Flags(object):
 
         self.multipath_friendly_names = True
 
+        # set to False to suppress the default LVM behavior of saving
+        # backup metadata in /etc/lvm/{archive,backup}
+        self.lvm_metadata_backup = True
+
         # whether to include nodev filesystems in the devicetree (only
         # meaningful when flags.installer_mode is False)
         self.include_nodev = False

--- a/tests/devicelibs_test/lvm_test.py
+++ b/tests/devicelibs_test/lvm_test.py
@@ -7,6 +7,8 @@ from blivet.errors import LVMError
 
 from tests import loopbackedtestcase
 
+# TODO: test cases for lvorigin, lvsnapshot*, thin*
+
 class LVMTestCase(unittest.TestCase):
 
     def testGetPossiblePhysicalExtents(self):
@@ -30,11 +32,11 @@ class LVMTestCase(unittest.TestCase):
 # call if the device is non-existant, and usually that exception is caught and
 # an LVMError is then raised, but not always.
 
-class LVMAsRootTestCase(loopbackedtestcase.LoopBackedTestCase):
+class LVMAsRootTestCaseBase(loopbackedtestcase.LoopBackedTestCase):
 
     def __init__(self, methodName='runTest'):
         """Set up the structure of the volume group."""
-        super(LVMAsRootTestCase, self).__init__(methodName=methodName)
+        super(LVMAsRootTestCaseBase, self).__init__(methodName=methodName)
         self._vg_name = "test-vg"
         self._lv_name = "test-lv"
 
@@ -57,14 +59,17 @@ class LVMAsRootTestCase(loopbackedtestcase.LoopBackedTestCase):
         except LVMError:
             pass
 
-        try:
-            for dev in self.loopDevices:
+        for dev in self.loopDevices:
+            try:
                 lvm.pvremove(dev)
-        except LVMError:
-            pass
+            except LVMError:
+                pass
 
-        super(LVMAsRootTestCase, self).tearDown()
+        super(LVMAsRootTestCaseBase, self).tearDown()
 
+
+
+class LVMAsRootTestCase(LVMAsRootTestCaseBase):
     def testLVM(self):
         _LOOP_DEV0 = self.loopDevices[0]
         _LOOP_DEV1 = self.loopDevices[1]


### PR DESCRIPTION
Somehow the patches that fixed [rhbz#1066004] did not make their way into the previous blivet master branch, which means they got lost when this branch got rebased.. or something like that.

These patches should fix [rhbz#1269144] - which is a clone of [rhbz#1066004].

A little massaging was necessary to fix conflicts in the `devicelibs.lvm` refactor patch, but it *looks* correct, at least.

[rhbz#1066004]: https://bugzilla.redhat.com/show_bug.cgi?id=1066004
[rhbz#1269144]: https://bugzilla.redhat.com/show_bug.cgi?id=1269144