### PR TITLE
Allow allocation of small, minimally-aligned partitions.

### DIFF
--- a/blivet/errors.py
+++ b/blivet/errors.py
@@ -112,6 +112,9 @@ class InvalidDiskLabelError(DiskLabelError):
 class DiskLabelCommitError(DiskLabelError):
     pass
 
+class AlignmentError(DiskLabelError):
+    pass
+
 # devicelibs
 class RaidError(StorageError):
     pass

--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -31,7 +31,7 @@ from gi.repository import BlockDev as blockdev
 
 import parted
 
-from .errors import DeviceError, PartitioningError
+from .errors import DeviceError, PartitioningError, AlignmentError
 from .flags import flags
 from .devices import Device, PartitionDevice, LUKSDevice, devicePathToName
 from .size import Size
@@ -374,6 +374,21 @@ def addPartition(disklabel, free, part_type, size, start=None, end=None):
             alignment unless a start sector is provided.
 
     """
+    # get alignment information based on disklabel, device, and partition size
+    if start is None:
+        if size is None:
+            # implicit request for extended partition (will use full free area)
+            _size = sectorsToSize(free.length, disklabel.sectorSize)
+        else:
+            _size = size
+
+        alignment = disklabel.getAlignment(size=_size)
+        end_alignment = disklabel.getEndAlignment(alignment=alignment)
+    else:
+        alignment = parted.Alignment(grainSize=1, offset=0)
+        end_alignment = parted.Alignment(grainSize=1, offset=-1)
+    log.debug("using alignment: %s", alignment)
+
     sectorSize = Size(disklabel.partedDevice.sectorSize)
     if start is not None:
         if end is None:
@@ -381,15 +396,15 @@ def addPartition(disklabel, free, part_type, size, start=None, end=None):
     else:
         start = free.start
 
-        if not disklabel.alignment.isAligned(free, start):
-            start = disklabel.alignment.alignNearest(free, start)
+        if not alignment.isAligned(free, start):
+            start = alignment.alignNearest(free, start)
 
         if disklabel.labelType == "sun" and start == 0:
-            start = disklabel.alignment.alignUp(free, start)
+            start = alignment.alignUp(free, start)
 
         if part_type == parted.PARTITION_LOGICAL:
             # make room for logical partition's metadata
-            start += disklabel.alignment.grainSize
+            start += alignment.grainSize
 
         if start != free.start:
             log.debug("adjusted start sector from %d to %d", free.start, start)
@@ -401,8 +416,8 @@ def addPartition(disklabel, free, part_type, size, start=None, end=None):
             length = sizeToSectors(size, sectorSize)
             end = start + length - 1
 
-        if not disklabel.endAlignment.isAligned(free, end):
-            end = disklabel.endAlignment.alignUp(free, end)
+        if not end_alignment.isAligned(free, end):
+            end = end_alignment.alignUp(free, end)
             log.debug("adjusted length from %d to %d", length, end - start + 1)
             if start > end:
                 raise PartitioningError(_("unable to allocate aligned partition"))
@@ -680,6 +695,7 @@ def allocatePartitions(storage, disks, partitions, freespace):
             disklabel = disklabels[_disk.path]
             best = None
             current_free = free
+            alignment = disklabel.getAlignment(size=_part.req_size)
 
             # for growable requests, we don't want to pass the current free
             # geometry to getBestFreeRegion -- this allows us to try the
@@ -727,7 +743,7 @@ def allocatePartitions(storage, disks, partitions, freespace):
                                           best_free=current_free,
                                           boot=boot,
                                           grow=_part.req_grow,
-                                          alignment=disklabel.alignment)
+                                          alignment=alignment)
 
             if best == free and not _part.req_primary and \
                new_part_type == parted.PARTITION_NORMAL:
@@ -743,7 +759,7 @@ def allocatePartitions(storage, disks, partitions, freespace):
                                                   best_free=current_free,
                                                   boot=boot,
                                                   grow=_part.req_grow,
-                                                  alignment=disklabel.alignment)
+                                                  alignment=alignment)
 
             if best and free != best:
                 update = True
@@ -780,7 +796,7 @@ def allocatePartitions(storage, disks, partitions, freespace):
                                                                start=_part.req_start_sector,
                                                                boot=boot,
                                                                grow=_part.req_grow,
-                                                               alignment=disklabel.alignment)
+                                                               alignment=alignment)
                                 if not _free:
                                     log.info("not enough space after adding "
                                              "extended partition for growth test")
@@ -1468,15 +1484,23 @@ def getDiskChunks(disk, partitions, free):
         # also check that the resulting aligned geometry has a non-zero length.
         # (It is possible that both will align to the same sector in a small
         #  enough region.)
-        al_start = disk.format.alignment.alignUp(f, f.start)
-        al_end = disk.format.endAlignment.alignDown(f, f.end)
+        try:
+            size = sectorsToSize(f.length, disk.format.sectorSize)
+            alignment = disk.format.getAlignment(size=size)
+            end_alignment = disk.format.getEndAlignment(alignment=alignment)
+        except AlignmentError:
+            disk_free.remove(f)
+            continue
+
+        al_start = alignment.alignUp(f, f.start)
+        al_end = end_alignment.alignDown(f, f.end)
         if al_start >= al_end:
             disk_free.remove(f)
             continue
         geom = parted.Geometry(device=f.device,
                                start=al_start,
                                end=al_end)
-        if geom.length < disk.format.alignment.grainSize:
+        if geom.length < alignment.grainSize:
             disk_free.remove(f)
             continue
 
@@ -1725,6 +1749,7 @@ def growPartitions(disks, partitions, free, size_sets=None):
             # recalculate partition geometries
             disklabel = disk.format
             start = chunk.geometry.start
+            default_alignment = disklabel.getAlignment()
 
             # find any extended partition on this disk
             extended_geometry = getattr(disklabel.extendedPartition,
@@ -1732,8 +1757,8 @@ def growPartitions(disks, partitions, free, size_sets=None):
                                         None)  # parted.Geometry
 
             # align start sector as needed
-            if not disklabel.alignment.isAligned(chunk.geometry, start):
-                start = disklabel.alignment.alignUp(chunk.geometry, start)
+            if not default_alignment.isAligned(chunk.geometry, start):
+                start = default_alignment.alignUp(chunk.geometry, start)
             new_partitions = []
             for p in chunk.requests:
                 ptype = p.device.partedPartition.type
@@ -1742,17 +1767,19 @@ def growPartitions(disks, partitions, free, size_sets=None):
                 if ptype == parted.PARTITION_EXTENDED:
                     continue
 
+                new_length = p.base + p.growth
+                alignment = disklabel.getAlignment(size=chunk.lengthToSize(new_length))
+                end_alignment = disklabel.getEndAlignment(alignment=alignment)
                 # XXX since we need one metadata sector before each
                 #     logical partition we burn one logical block to
                 #     safely align the start of each logical partition
                 if ptype == parted.PARTITION_LOGICAL:
-                    start += disklabel.alignment.grainSize
+                    start += alignment.grainSize
 
-                new_length = p.base + p.growth
                 end = start + new_length - 1
                 # align end sector as needed
-                if not disklabel.endAlignment.isAligned(chunk.geometry, end):
-                    end = disklabel.endAlignment.alignDown(chunk.geometry, end)
+                if not end_alignment.isAligned(chunk.geometry, end):
+                    end = end_alignment.alignDown(chunk.geometry, end)
                 new_geometry = parted.Geometry(device=disklabel.partedDevice,
                                                start=start,
                                                end=end)
@@ -1784,7 +1811,7 @@ def growPartitions(disks, partitions, free, size_sets=None):
                         # account for the logical block difference in start
                         # sector for the extended -v- first logical
                         # (partition.geometry.start is already aligned)
-                        ext_start = partition.geometry.start - disklabel.alignment.grainSize
+                        ext_start = partition.geometry.start - default_alignment.grainSize
 
                 new_geometry = parted.Geometry(device=disklabel.partedDevice,
                                                start=ext_start,

--- a/tests/formats_test/disklabel_test.py
+++ b/tests/formats_test/disklabel_test.py
@@ -1,0 +1,66 @@
+import parted
+import six
+import unittest
+
+import blivet
+from blivet.size import Size
+
+if six.PY2:
+    import mock
+else:
+    from unittest import mock
+
+patch = mock.patch
+
+class DiskLabelTestCase(unittest.TestCase):
+    @patch("blivet.formats.disklabel.DiskLabel.freshPartedDisk", None)
+    def testGetAlignment(self):
+        dl = blivet.formats.disklabel.DiskLabel()
+        dl._partedDisk = mock.Mock()
+        dl._partedDevice = mock.Mock()
+        dl._partedDevice.sectorSize = 512
+
+        # 512 byte grain sze
+        disklabel_alignment = parted.Alignment(grainSize=1, offset=0)
+        dl._partedDisk.partitionAlignment = disklabel_alignment
+
+        # 1 MiB grain size
+        minimal_alignment = parted.Alignment(grainSize = 2048, offset=0)
+        dl._partedDevice.minimumAlignment = minimal_alignment
+
+        # 4 MiB grain size
+        optimal_alignment = parted.Alignment(grainSize=8192, offset=0)
+        dl._partedDevice.optimumAlignment = optimal_alignment
+
+        # expected end alignments
+        optimal_end_alignment = parted.Alignment(
+                                        grainSize=optimal_alignment.grainSize,
+                                        offset=-1)
+        minimal_end_alignment = parted.Alignment(
+                                        grainSize=minimal_alignment.grainSize,
+                                        offset=-1)
+
+        # make sure the private methods all return the expected values
+        self.assertEqual(dl._getDiskLabelAlignment(), disklabel_alignment)
+        self.assertEqual(dl._getMinimalAlignment(), minimal_alignment)
+        self.assertEqual(dl._getOptimalAlignment(), optimal_alignment)
+
+        # validate result when passing a start alignment to getEndAlignment
+        self.assertEqual(dl.getEndAlignment(alignment=optimal_alignment),
+                                            optimal_end_alignment)
+        self.assertEqual(dl.getEndAlignment(alignment=minimal_alignment),
+                         minimal_end_alignment)
+
+        # by default we should return the optimal alignment
+        self.assertEqual(dl.getAlignment(), optimal_alignment)
+        self.assertEqual(dl.getEndAlignment(), optimal_end_alignment)
+
+        # when passed a size smaller than the optimal io size we should return
+        # the minimal alignment
+        self.assertEqual(dl.getAlignment(size=Size("2 MiB")), minimal_alignment)
+        self.assertEqual(dl.getEndAlignment(size=Size("2 MiB")),
+                         minimal_end_alignment)
+
+        # test the old deprecated properties' values
+        self.assertEqual(dl.alignment, dl._getOptimalAlignment())
+        self.assertEqual(dl.endAlignment, dl.getEndAlignment())


### PR DESCRIPTION
Without this patch, blivet cannot create any partition smaller than the optimal io size reported by the disk it's being created on (without passing a start sector to `partitioninging.addPartition` to disable alignment). This PR makes it possible.