### PR TITLE
Make distutils.filelist.findall() do the right thing with symlinks maybe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,44 @@
 # pylint: disable=interruptible-system-call
 
 from distutils.core import setup
+from distutils import filelist
 import subprocess
 import sys
 import glob
 import os
 import re
+
+# this is copied straight from distutils.filelist.findall , but with os.stat()
+# replaced with os.lstat(), so S_ISLNK() can actually tell us something.
+def findall(dirname = os.curdir):
+    from stat import ST_MODE, S_ISREG, S_ISDIR, S_ISLNK
+
+    file_list = []
+    stack = [dirname]
+    pop = stack.pop
+    push = stack.append
+
+    while stack:
+        dirname = pop()
+        names = os.listdir(dirname)
+
+        for name in names:
+            if dirname != os.curdir:        # avoid the dreaded "./" syndrome
+                fullname = os.path.join(dirname, name)
+            else:
+                fullname = name
+
+            # Avoid excess stat calls -- just one will do, thank you!
+            stat = os.lstat(fullname)
+            mode = stat[ST_MODE]
+            if S_ISREG(mode):
+                file_list.append(fullname)
+            elif S_ISDIR(mode) and not S_ISLNK(mode):
+                push(fullname)
+
+    return file_list
+
+filelist.findall = findall
 
 AM_RE = r'(^.. automodule::.+?(?P<mo>^\s+?:member-order:.+?\n)?.+?:\n)\n(?(mo)NEVER)'
 


### PR DESCRIPTION
I'm not sure this would be right if we actually wanted to /include/ the
symlink itself, but since so far they're all in directories we don't
include in the tarball, this will at least make the traversal of them
not fail.

Signed-off-by: Peter Jones <pjones@redhat.com>