### PR TITLE
Master pv free

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -265,7 +265,9 @@ class LVMVolumeGroupDevice(ContainerDevice):
             if lv.exists:
                 lv.setup()
 
-        blockdev.lvm.pvmove(member.path)
+        # do not run pvmove on empty pvs
+        if (member.size - member.format.peStart - member.format.pvFree) >= self.peSize:
+            blockdev.lvm.pvmove(member.path)
         blockdev.lvm.vgreduce(self.name, member.path)
 
         for (lv, status) in zip(self.lvs, status):

--- a/blivet/formats/lvmpv.py
+++ b/blivet/formats/lvmpv.py
@@ -79,6 +79,7 @@ class LVMPhysicalVolume(DeviceFormat):
         self.vgName = kwargs.get("vgName")
         self.vgUuid = kwargs.get("vgUuid")
         self.peStart = kwargs.get("peStart", lvm.LVM_PE_START)
+        self.pvFree = kwargs.get("pvFree", Size(0))
         self.dataAlignment = kwargs.get("dataAlignment", Size(0))
 
         self.inconsistentVG = False
@@ -143,4 +144,3 @@ class LVMPhysicalVolume(DeviceFormat):
                 os.path.isdir("/dev/%s" % self.vgName))
 
 register_device_format(LVMPhysicalVolume)
-

--- a/blivet/populator.py
+++ b/blivet/populator.py
@@ -1424,6 +1424,10 @@ class Populator(object):
                     kwargs["peStart"] = Size(pv_info.pe_start)
                 else:
                     log.warning("PV %s has no pe_start", name)
+                if pv_info.pv_free:
+                    kwargs["pvFree"] = Size(pv_info.pv_free)
+                else:
+                    log.warning("PV %s has no pv_free", name)
         elif format_type == "vfat":
             # efi magic
             if isinstance(device, PartitionDevice) and device.bootable:


### PR DESCRIPTION
There are two changes in this PR:
- I've added `pvFree` to lvmpv format. I need this for LVM cache support in blivet-gui.
- Thanks to pvFree we know if the PV is empty, so we can the solve problem with removing empty PVs from VG. We run `pvmove` automatically before `vgreduce` and `pvmove` returns 5 for empty PVs so we think it failed (and 5 is not unique return code for this situation).