### PR TITLE
Add pylint stuff to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ build/
 .directory
 .coverage
 coverage-report.log
+pylint-log
+tests/pylint/.pylint.d/


### PR DESCRIPTION
This adds pylint-log and tests/pylint/.pylint.d/ to .gitignore.

I hate looking at this stuff in "git status", but removing it isn't
worth the trouble.

Signed-off-by: Peter Jones <pjones@redhat.com>