### PR TITLE
EDD - Rework a lot to find the bug in the absurd_virt test case.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ coverage: check-requires
 	$(COVERAGE) report --include="blivet/*" > coverage-report.log
 
 check: check-requires
-	PYTHONPATH=. tests/pylint/runpylint.py
+	PYTHONPATH=.:tests/ tests/pylint/runpylint.py
 
 clean:
 	-rm *.tar.gz blivet/*.pyc blivet/*/*.pyc ChangeLog

--- a/blivet/devicelibs/edd.py
+++ b/blivet/devicelibs/edd.py
@@ -529,8 +529,11 @@ class EddMatcher(object):
             This will obviously fail for a fresh drive/image, but in extreme
             cases can also show false positives for randomly matching data.
         """
+        sysblock = "%s/%s" % (fsroot, "/sys/block")
         for (name, mbr_sig) in mbr_dict.items():
             if mbr_sig == self.edd.mbr_sig:
+                self.edd.sysfslink = util.sysfs_readlink(sysblock, link=name,
+                                                         root=fsroot)
                 return name
         return None
 

--- a/blivet/devicelibs/edd.py
+++ b/blivet/devicelibs/edd.py
@@ -358,9 +358,7 @@ class EddMatcher(object):
 
     def devname_from_ata_pci_dev(self):
         pattern = util.Path('/sys/block/*', root=self.root)
-        testdata_log.debug("sysfs glob: %s", pattern)
         for path in pattern.glob():
-            testdata_log.debug("sysfs glob match: %s", path)
             emptyslash = util.Path("/", root=self.root)
             path = util.Path(path, root=self.root)
             link = util.sysfs_readlink(path=emptyslash, link=path)
@@ -426,9 +424,7 @@ class EddMatcher(object):
             dev = util.join_paths(fn + ['dev%d.*' % (ata_port_idx,)])
             dev = util.Path(dev, root=self.root)
             for ataglob in [pmp, dev]:
-                testdata_log.debug("sysfs glob: %s", ataglob)
                 for atapath in ataglob.glob():
-                    testdata_log.debug("sysfs glob match: %s", atapath)
                     match = expmatcher.match(atapath.ondisk)
                     if match is None:
                         continue
@@ -469,10 +465,7 @@ class EddMatcher(object):
         }
         path = util.Path(tmpl0 % args, root=self.root)
         pattern = util.Path(tmpl1 % args, root=self.root)
-        testdata_log.debug("sysfs glob: %s", pattern)
         matching_paths = list(pattern.glob())
-        for mp in matching_paths:
-            testdata_log.debug("sysfs glob match: %s", mp)
         if os.path.isdir(path.ondisk):
             block_entries = os.listdir(path.ondisk)
             if len(block_entries) == 1:
@@ -505,11 +498,7 @@ class EddMatcher(object):
     def devname_from_virt_pci_dev(self):
         pattern = util.Path("/sys/devices/pci0000:00/0000:%s/virtio*" %
                             (self.edd.pci_dev,), root=self.root)
-        testdata_log.debug("sysfs glob: %s", pattern)
         matching_paths = tuple(pattern.glob())
-        for mp in matching_paths:
-            testdata_log.debug("sysfs glob match: %s", mp)
-
         if len(matching_paths) == 1 and os.path.exists(matching_paths[0]):
             # Normal VirtIO devices just have the block link right there...
             newpath = util.Path(matching_paths[0], root=self.root) + "/block"
@@ -571,9 +560,7 @@ class EddMatcher(object):
 def collect_edd_data(root=None):
     edd_data_dict = {}
     globstr = util.Path("/sys/firmware/edd/int13_dev*/", root=root)
-    testdata_log.debug("sysfs glob: %s", globstr)
     for path in globstr.glob():
-        testdata_log.debug("sysfs glob match: %s", path)
         match = re_bios_device_number.match(path)
         biosdev = int("0x%s" % (match.group(1),), base=16)
         log.debug("edd: found device 0x%x at %s", biosdev, path)

--- a/blivet/devicelibs/edd.py
+++ b/blivet/devicelibs/edd.py
@@ -80,7 +80,7 @@ class EddEntry(object):
             that this is a particular device.  Used for logging later.
         """
 
-        self.version = util.get_sysfs_attr(self.sysfspath, "version")
+        self.version = util.get_sysfs_attr(self.sysfspath, "version", root=fsroot)
         """ The edd version this entry claims conformance with, from
             /sys/firmware/edd/int13_devXX/version """
 
@@ -239,7 +239,7 @@ class EddEntry(object):
         return "<EddEntry%s>" % (self._fmt(' ', ''),)
 
     def load(self):
-        interface = util.get_sysfs_attr(self.sysfspath, "interface")
+        interface = util.get_sysfs_attr(self.sysfspath, "interface", root=fsroot)
         # save this so we can log it from the matcher.
         self.interface = interface
         if interface:
@@ -302,11 +302,11 @@ class EddEntry(object):
                 else:
                     raise e
 
-        self.mbr_sig = util.get_sysfs_attr(self.sysfspath, "mbr_signature")
-        sectors = util.get_sysfs_attr(self.sysfspath, "sectors")
+        self.mbr_sig = util.get_sysfs_attr(self.sysfspath, "mbr_signature", root=fsroot)
+        sectors = util.get_sysfs_attr(self.sysfspath, "sectors", root=fsroot)
         if sectors:
             self.sectors = int(sectors)
-        hbus = util.get_sysfs_attr(self.sysfspath, "host_bus")
+        hbus = util.get_sysfs_attr(self.sysfspath, "host_bus", root=fsroot)
         if hbus:
             match = re_host_bus_pci.match(hbus)
             if match:
@@ -372,7 +372,7 @@ class EddMatcher(object):
             ata_port_idx = int(components[5][3:])
 
             fn = components[0:6] + ['ata_port', ata_port]
-            port_no = int(util.get_sysfs_attr(os.path.join(*fn), 'port_no'))
+            port_no = int(util.get_sysfs_attr(os.path.join(*fn), 'port_no', root=fsroot))
 
             if self.edd.type == "ATA":
                 # On ATA, port_no is kernel's ata_port->local_port_no, which

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -137,8 +137,14 @@ class Path(str):
             account when globbing and returns path objects with the same
             root, so you don't have to think about that part.
         """
+
+        testdata_log.debug("glob: %s", self.ondisk)
+        if "None" in self.ondisk:
+            log.error("glob: %s", self.ondisk)
+            log.error("^^ Somehow \"None\" got logged and that's never right.")
         for g in glob.glob(self.ondisk):
-            yield Path(g, root=self.root)
+            testdata_log.debug("glob match: %s", g)
+            yield Path(g, self.root)
 
     def __hash__(self):
         return self._path.__hash__()

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -213,6 +213,21 @@ def notify_kernel(path, action="change"):
     f.write("%s\n" % action)
     f.close()
 
+def normalize_path_slashes(path):
+    """ Normalize the slashes in a filesystem path.
+        Does not actually examine the filesystme in any way.
+    """
+    while "//" in path:
+        path = path.replace("//", "/")
+    return path
+
+def join_paths(*paths):
+    """ Joins filesystem paths without any consiration of slashes or
+        whatnot and then normalizes repeated slashes.
+    """
+    if len(paths) == 1 and hasattr(paths[0], "__iter__"):
+        return join_paths(*paths[0])
+    return normalize_path_slashes('/'.join(paths))
 
 def get_sysfs_attr(path, attr):
     if not attr:

--- a/tests/devicelibs_test/edd_test.py
+++ b/tests/devicelibs_test/edd_test.py
@@ -161,14 +161,17 @@ class EddTestCase(unittest.TestCase):
                                pci_dev="00:1f.2", channel=255, ata_device=1,
                                interface="SATA    \tdevice: 1",
                                sysfspath="/sys/firmware/edd/int13_dev80",
-                               sysfslink="../devices/pci0000:00/0000:00:1f.2/ata2"
-                               "/host1/target1:0:0/1:0:0:0/block/sda"),
+                               sysfslink="../devices/pci0000:00/0000:00:1f.2/"
+                               "ata2/host1/target1:0:0/1:0:0:0/block/sda"),
             0x81: FakeEddEntry(version="0x21", mbr_sig="0x96a20d28",
                                sectors=31293440, host_bus="PCI", type="USB",
                                pci_dev="ff:ff.255", channel=255,
                                usb_serial=0x30302e31,
                                interface="USB     \tserial_number: 30302e31",
-                               sysfspath="/sys/firmware/edd/int13_dev81"),
+                               sysfspath="/sys/firmware/edd/int13_dev81",
+                               sysfslink="../devices/pci0000:00/0000:00:1d.0/"
+                               "usb4/4-1/4-1.2/4-1.2:1.0/host6/target6:0:0/"
+                               "6:0:0:0/block/sdb"),
         }
 
         edd_dict = edd.get_edd_dict(devices)

--- a/tests/devicelibs_test/edd_test.py
+++ b/tests/devicelibs_test/edd_test.py
@@ -6,6 +6,7 @@ import logging
 import copy
 
 from blivet.devicelibs import edd
+import lib
 
 
 class FakeDevice(object):
@@ -39,8 +40,14 @@ class FakeEddEntry(edd.EddEntry):
 
 
 class EddTestCase(unittest.TestCase):
-    _edd_logger = None
-    max_diff = None
+
+    def __init__(self, *args, **kwds):
+        super(EddTestCase, self).__init__(*args, **kwds)
+        self._edd_logger = None
+
+        # these don't follow PEP8 because unittest.TestCase expects them this way
+        self.maxDiff = None
+        self.longMessage = True
 
     def setUp(self):
         super(EddTestCase, self).setUp()
@@ -86,15 +93,13 @@ class EddTestCase(unittest.TestCase):
 
     def check_logs(self, debugs=None, infos=None, warnings=None, errors=None):
         def check(left, right_object):
-            left = [mock.call(*x) for x in left or []]
-            left.sort()
+            newleft = [mock.call(*x) for x in left or []]
             right = copy.copy(right_object.call_args_list or [])
-            right.sort()
-            self.assertEqual(left, right)
-            if len(left) == 0:
-                self.assertEqual(right_object.called, False)
+            lib.assertVerboseListEqual(newleft, right)
+            if len(newleft) == 0:
+                lib.assertVerboseEqual(right_object.called, False)
             else:
-                self.assertEqual(right_object.called, True)
+                lib.assertVerboseEqual(right_object.called, True)
 
         check(debugs, edd.log.debug)
         check(infos, edd.log.info)
@@ -142,9 +147,9 @@ class EddTestCase(unittest.TestCase):
             ("edd: found device 0x%x at %s", 0x81,
              '/sys/firmware/edd/int13_dev81'),
         ]
-        self.assertEqual(len(edd_dict), 2)
-        self.assertEqual(fakeedd[0x80], edd_dict[0x80])
-        self.assertEqual(fakeedd[0x81], edd_dict[0x81])
+        lib.assertVerboseEqual(len(edd_dict), 2)
+        lib.assertVerboseEqual(fakeedd[0x80], edd_dict[0x80])
+        lib.assertVerboseEqual(fakeedd[0x81], edd_dict[0x81])
         self.check_logs(debugs=debugs)
 
     def test_get_edd_dict_sata_usb(self):
@@ -176,9 +181,9 @@ class EddTestCase(unittest.TestCase):
 
         edd_dict = edd.get_edd_dict(devices)
         self.debug('edd_dict: %s', edd_dict)
-        self.assertEqual(len(edd_dict), 2)
-        self.assertEqual(edd_dict["sda"], 0x80)
-        self.assertEqual(edd_dict["sdb"], 0x81)
+        lib.assertVerboseEqual(len(edd_dict), 2)
+        lib.assertVerboseEqual(edd_dict["sda"], 0x80)
+        lib.assertVerboseEqual(edd_dict["sdb"], 0x81)
         debugs = [
             ("edd: data extracted from 0x%x:\n%s", 0x80, fakeedd[0x80]),
             ("edd: data extracted from 0x%x:\n%s", 0x81, fakeedd[0x81]),

--- a/tests/devicelibs_test/edd_test.py
+++ b/tests/devicelibs_test/edd_test.py
@@ -55,7 +55,7 @@ class EddTestCase(unittest.TestCase):
         edd.log.addHandler(self.log_handler)
 
         self.td_log_handler = logging.FileHandler("%s/%s" %
-                                        (ws, "blivet-edd-testdata.log"))
+                                                  (ws, "blivet-edd-testdata.log"))
         self.td_log_handler.setLevel(logging.DEBUG)
         formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
         self.td_log_handler.setFormatter(formatter)

--- a/tests/devicelibs_test/edd_test.py
+++ b/tests/devicelibs_test/edd_test.py
@@ -190,6 +190,8 @@ class EddTestCase(unittest.TestCase):
             ("edd: collected mbr signatures: %s", {'sdb': '0x96a20d28'}),
             ("edd: matched 0x%x to %s using PCI dev", 0x80, "sda"),
             ("edd: matched 0x%x to %s using MBR sig", 0x81, "sdb"),
+            ('edd: Could not find Virtio device for pci dev %s channel %s', '00:1f.2', 255),
+            ('edd: Could not find Virtio device for pci dev %s channel %s', 'ff:ff.255', 255),
         ]
         warnings = [
             ("edd: interface type %s is not implemented (%s)", "USB",

--- a/tests/lib.py
+++ b/tests/lib.py
@@ -1,0 +1,50 @@
+
+import pprint
+
+def assertVerboseListEqual(left, right, msg=None):
+    left.sort()
+    right.sort()
+
+    found = []
+    rightmissing = []
+    leftmissing = []
+    for x in left:
+        if x in right:
+            found.append(x)
+        else:
+            rightmissing.append(x)
+    for x in right:
+        if x not in found:
+            leftmissing.append(x)
+    if msg:
+        raise AssertionError(msg)
+
+    s = "\n"
+    if leftmissing:
+        s += "log has: \n"
+        for l in leftmissing:
+            s += " %s\n" % (pprint.pformat(l),)
+
+    if rightmissing:
+        s += "expected: \n"
+        for r in rightmissing:
+            s += " %s\n" % (pprint.pformat(r),)
+
+    if leftmissing or rightmissing:
+        raise AssertionError(s)
+
+def assertVerboseEqual(left, right, msg=None):
+    if left != right:
+        l = len(left)
+        r = len(right)
+        for x in range(0, max(l, r)):
+            if x > l-1:
+                assertVerboseEqual(None, right[x], msg)
+            if x > r-1:
+                assertVerboseEqual(left[x], None, msg)
+            if left[x] != right[x]:
+                if msg:
+                    raise AssertionError(msg)
+                else:
+                    raise AssertionError("%s != %s" % (
+                            pprint.pformat(left), pprint.pformat(right)))


### PR DESCRIPTION
This adds utility functions join_paths() and normalize_path_slashes(), which do what they say and not other random surprising things, and a Path() class that can be used to automatically deal with paths in a chroot, without having to do a lot of joining and splitting yourself all the time.

It then uses these functions to clean up a lot of the EDD code, and adds some things to our testdata_log, so we can make test cases from strange machines we see in the wild. It also makes the EDD code notice and log when it would find more than one matching disk.