### PR TITLE
Perform fast format when creating NTFS

### DIFF
--- a/blivet/tasks/fsmkfs.py
+++ b/blivet/tasks/fsmkfs.py
@@ -195,7 +195,7 @@ class NTFSMkfs(FSMkfs):
 
     @property
     def args(self):
-        return []
+        return ["-f"]
 
 class ReiserFSMkfs(FSMkfs):
     ext = availability.MKREISERFS_APP


### PR DESCRIPTION
Without the `-f` option mkfs.ntfs takes ages.