### PR TITLE
Update dmdev size when setting up disk images

### DIFF
--- a/blivet/populator.py
+++ b/blivet/populator.py
@@ -1534,6 +1534,7 @@ class Populator(object):
                                        exists=True)
                 dmdev.setup()
                 dmdev.updateSysfsPath()
+                dmdev.updateSize()
                 log.debug("%s", dmdev)
             except (ValueError, DeviceError) as e:
                 log.error("failed to set up disk image: %s", e)

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -1,0 +1,59 @@
+import os
+import unittest
+from blivet import Blivet
+from blivet.flags import flags
+from blivet import util
+from blivet.size import Size
+from blivet.osinstall import storageInitialize
+try:
+    from pyanaconda import kickstart
+    pyanaconda_present = True
+except ImportError:
+    pyanaconda_present = False
+
+@unittest.skipUnless(pyanaconda_present, "pyanaconda is missing")
+class setupDiskImagesNonZeroSizeTestCase(unittest.TestCase):
+    """
+        Test if size of disk images is > 0. Related: rhbz#1252703.
+        This test emulates how anaconda configures its storage.
+    """
+
+    disks = { "disk1": Size("2 GiB") }
+
+    def setUp(self):
+        self.blivet = Blivet()
+
+        # anaconda first configures disk images
+        for (name, size) in iter(self.disks.items()):
+            path = util.create_sparse_tempfile(name, size)
+            self.blivet.config.diskImages[name] = path
+
+        # at this point the DMLinearDevice has correct size
+        self.blivet.setupDiskImages()
+
+        # emulates setting the anaconda flags which later update
+        # blivet flags as the first thing to do in storageInitialize
+        flags.image_install = True
+        # no kickstart available
+        ksdata = kickstart.AnacondaKSHandler([])
+        # anaconda calls storageInitialize regardless of whether or not
+        # this is an image install. Somewhere along the line this will
+        # execute setupDiskImages() once more and the DMLinearDevice created
+        # in this second execution has size 0
+        storageInitialize(self.blivet, ksdata, [])
+
+    def tearDown(self):
+        self.blivet.reset()
+        self.blivet.devicetree.teardownDiskImages()
+        for fn in self.blivet.config.diskImages.values():
+            if os.path.exists(fn):
+                os.unlink(fn)
+
+        flags.image_install = False
+
+    def runTest(self):
+        for d in self.blivet.devicetree.devices:
+            self.assertTrue(d.size > 0)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The size needs to be updated after the sysfs path has been setup.
Related: rhbz#1252703

This is fixed on rhel7-branch but not on master:
https://github.com/rhinstaller/blivet/commit/828ddb09535357a35bde6b3b18ae871bfe2c52ad

The result is --image installs don't work b/c the device has size 0 and anaconda ignores it. I've also added a test case for this. It looks like this test should probably go into anaconda but I'm not sure if the infrastructure there allows for that that's why I've added it here.