### PR TITLE
Add a class constructor for namedtuples with default values

### DIFF
--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -22,3 +22,26 @@ class MiscTest(unittest.TestCase):
             self.assertTrue(util.power_of_two(2 ** i), msg=i)
             self.assertFalse(util.power_of_two(2 ** i + 1), msg=i)
             self.assertFalse(util.power_of_two(2 ** i - 1), msg=i)
+
+class TestDefaultNamedtuple(unittest.TestCase):
+    def test_default_namedtuple(self):
+        TestTuple = util.default_namedtuple("TestTuple", ["x", "y", ("z", 5), "w"])
+        dnt = TestTuple(1, 2, 3, 6)
+        self.assertEqual(dnt.x, 1)
+        self.assertEqual(dnt.y, 2)
+        self.assertEqual(dnt.z, 3)
+        self.assertEqual(dnt.w, 6)
+        self.assertEqual(dnt, (1, 2, 3, 6))
+
+        dnt = TestTuple(1, 2, 3, w=6)
+        self.assertEqual(dnt.x, 1)
+        self.assertEqual(dnt.y, 2)
+        self.assertEqual(dnt.z, 3)
+        self.assertEqual(dnt.w, 6)
+        self.assertEqual(dnt, (1, 2, 3, 6))
+
+        dnt = TestTuple(z=3, x=2, w=1, y=5)
+        self.assertEqual(dnt, (2, 5, 3, 1))
+
+        dnt = TestTuple()
+        self.assertEqual(dnt, (None, None, 5, None))


### PR DESCRIPTION
namedtuple classes are great as pure data objects one can store things in and
then access them really easily. The problem is that if a new field is added to a
namedtuple, all places creating instances of it has to be modified to provide a
value for that new field. The default_namedtuple class constructor implemented
in this commit constructs namedtuples with default values for (some) fields and
fields without any value passed defaulting to None.

Such default namedtuple classes are still great for storing data and
e.g. passing data to functions/methods grouped into a few objects (like
DeviceInfo, FormatInfo,...) passed as arguments, but allow us to add extra
fields in the future (e.g. a new device attribute to DeviceInfo) without
breaking the API.