### PR TITLE
Improve clarity of error when setting new default fstype fails.

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -1516,7 +1516,7 @@ class Blivet(object):
         if (not fmt.mountable or not fmt.formattable or not fmt.supported or
                 not fmt.linux_native):
             log.debug("invalid default fstype: %r", fmt)
-            raise ValueError("new value %s is not valid as a default fs type" % fmt)
+            raise ValueError("new value %s is not valid as a default fs type" % newtype)
 
         self._default_fstype = newtype  # pylint: disable=attribute-defined-outside-init
 


### PR DESCRIPTION
It's good to log the full format we instantiated, but we should be
inlcuding the type -- not a DeviceFormat instance -- in the error
message.