### PR TITLE
Add PEP8 compliance checking to 'check' target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ VERSION_TAG=$(PKGNAME)-$(VERSION)
 
 PYTHON=python3
 COVERAGE=coverage
+PEP8=$(PYTHON)-pep8
 ifeq ($(PYTHON),python3)
   COVERAGE=coverage3
 endif
@@ -24,6 +25,7 @@ TEST_DEPENDENCIES += python3-gobject
 TEST_DEPENDENCIES += python-coverage python3-coverage
 TEST_DEPENDENCIES += xfsprogs hfsplus-tools
 TEST_DEPENDENCIES += python3-pocketlint
+TEST_DEPENDENCIES += python3-pep8
 TEST_DEPENDENCIES := $(shell echo $(sort $(TEST_DEPENDENCIES)) | uniq)
 
 all:
@@ -66,8 +68,15 @@ coverage: check-requires
 	$(COVERAGE) report --include="blivet/*" --show-missing
 	$(COVERAGE) report --include="blivet/*" > coverage-report.log
 
-check: check-requires
-	PYTHONPATH=.:tests/ tests/pylint/runpylint.py
+pylint: check-requires
+	@echo "*** Running pylint ***"
+	PYTHONPATH=.:tests/:$(PYTHONPATH) tests/pylint/runpylint.py
+
+pep8: check-requires
+	@echo "*** Running pep8 compliance check ***"
+	$(PEP8) --ignore=E501 blivet/ tests/ examples/
+
+check: pylint pep8
 
 clean:
 	-rm *.tar.gz blivet/*.pyc blivet/*/*.pyc ChangeLog
@@ -176,4 +185,4 @@ ci: check coverage rc-release
 	@mkdir -p repo
 	@mv *rpm repo
 
-.PHONY: check clean install tag archive local
+.PHONY: check clean pylint pep8 install tag archive local

--- a/blivet/devicelibs/edd.py
+++ b/blivet/devicelibs/edd.py
@@ -60,6 +60,7 @@ re_interface_sas = re.compile(r'^SAS\s*sas_address: (\S*)\s*lun: \(\S*\)\s*$')
 # anchoring tab that would go between them...
 re_interface_unknown = re.compile(r'^(\S*)\s*unknown: (\S*) (\S*)\s*$')
 
+
 class EddEntry(object):
 
     """ This object merely collects what the /sys/firmware/edd/* entries can
@@ -195,7 +196,7 @@ class EddEntry(object):
     def _fmt(self, line_pad, separator):
         s = "%(t)spath: %(sysfspath)s version: %(version)s %(nl)s" \
             "%(t)smbr_signature: %(mbr_sig)s sectors: %(sectors)s"
-        if self.type != None:
+        if self.type is not None:
             s += " %(type)s"
         if self.sysfslink is not None:
             s += "%(nl)s%(t)ssysfs pci path: %(sysfslink)s"
@@ -225,8 +226,8 @@ class EddEntry(object):
             s += "%(nl)s%(t)ssas_address: %(sas_address)s sas_lun: %(sas_lun)s"
 
         d = copy.copy(self.__dict__)
-        d['t']=line_pad
-        d['nl']=separator
+        d['t'] = line_pad
+        d['nl'] = separator
 
         return s % d
 
@@ -352,6 +353,7 @@ class EddMatcher(object):
 
         Assuming, heuristic analysis and guessing hapens here.
     """
+
     def __init__(self, edd_entry, root=None):
         self.edd = edd_entry
         self.root = root
@@ -361,7 +363,7 @@ class EddMatcher(object):
         retries = []
 
         def match_port(components, ata_port, ata_port_idx, path, link):
-            fn = util.Path(util.join_paths(components[0:6] \
+            fn = util.Path(util.join_paths(components[0:6]
                                            + ['ata_port', ata_port]), root=self.root)
             port_no = int(util.get_sysfs_attr(fn, 'port_no'))
 
@@ -377,8 +379,8 @@ class EddMatcher(object):
                 if port_no != self.edd.ata_device + 1:
                     return
 
-            fn = components[0:6] + ['link%d' % (ata_port_idx,),]
-            exp = [r'.*']+fn+[r'dev%d\.(\d+)(\.(\d+)){0,1}$' % (ata_port_idx,)]
+            fn = components[0:6] + ['link%d' % (ata_port_idx,), ]
+            exp = [r'.*'] + fn + [r'dev%d\.(\d+)(\.(\d+)){0,1}$' % (ata_port_idx,)]
             exp = util.join_paths(exp)
             expmatcher = re.compile(exp)
 
@@ -455,7 +457,7 @@ class EddMatcher(object):
             # iterates the sata device number /independently/ of the host
             # bridge it claims things are attached to.  In that case this
             # the scsi target will always have "0" as the ID component.
-            args = { 'device': self.edd.ata_device }
+            args = {'device': self.edd.ata_device}
             exp = r"target\d+:0:%(device)s/\d+:0:%(device)s:0/block/.*" % args
             matcher = re.compile(exp)
             match = matcher.match("/".join(components[7:]))
@@ -512,9 +514,9 @@ class EddMatcher(object):
         tmpl = "../devices/pci0000:00/0000:%(pci_dev)s/virtio*/" \
             "host*/target*:0:%(dev)d/*:0:%(dev)d:%(lun)d/block/"
         args = {
-            'pci_dev' : self.edd.pci_dev,
-            'dev' : self.edd.scsi_id,
-            'lun' : self.edd.scsi_lun,
+            'pci_dev': self.edd.pci_dev,
+            'dev': self.edd.scsi_id,
+            'lun': self.edd.scsi_lun,
         }
         pattern = util.Path(tmpl % args, self.root + "/sys/block/")
         answers = []
@@ -523,7 +525,7 @@ class EddMatcher(object):
             block_entries = os.listdir(mp.ondisk)
             for be in block_entries:
                 link = mp + be
-                answers.append({'link':link, 'path':be})
+                answers.append({'link': link, 'path': be})
 
         if len(answers) > 1:
             log.error("Found too many VirtIO SCSI devices for EDD device 0x%x: %s",
@@ -533,7 +535,7 @@ class EddMatcher(object):
             self.edd.sysfslink = answers[0]['link']
             return answers[0]['path']
         else:
-            log.info("edd: Could not find VirtIO SCSI device for pci dev %s "\
+            log.info("edd: Could not find VirtIO SCSI device for pci dev %s "
                      "channel %s scsi id %s lun %s", self.edd.pci_dev,
                      self.edd.channel, self.edd.scsi_id, self.edd.scsi_lun)
 
@@ -542,10 +544,10 @@ class EddMatcher(object):
             "host%(chan)d/target%(chan)d:0:%(dev)d/" \
             "%(chan)d:0:%(dev)d:%(lun)d/block/"
         args = {
-            'pci_dev' : self.edd.pci_dev,
-            'chan' : self.edd.channel,
-            'dev' : self.edd.scsi_id,
-            'lun' : self.edd.scsi_lun,
+            'pci_dev': self.edd.pci_dev,
+            'chan': self.edd.channel,
+            'dev': self.edd.scsi_id,
+            'lun': self.edd.scsi_lun,
         }
         pattern = util.Path(tmpl % args, root=self.root + "/sys/block/")
         answers = []
@@ -554,7 +556,7 @@ class EddMatcher(object):
             block_entries = os.listdir(mp.ondisk)
             for be in block_entries:
                 link = mp + be
-                answers.append({'link':link, 'path':be})
+                answers.append({'link': link, 'path': be})
 
         if len(answers) > 1:
             log.error("Found too many SCSI devices for EDD device 0x%x: %s",
@@ -564,7 +566,7 @@ class EddMatcher(object):
             self.edd.sysfslink = answers[0]['link']
             return answers[0]['path']
         else:
-            log.warning("edd: Could not find SCSI device for pci dev %s "\
+            log.warning("edd: Could not find SCSI device for pci dev %s "
                         "channel %s scsi id %s lun %s", self.edd.pci_dev,
                         self.edd.channel, self.edd.scsi_id, self.edd.scsi_lun)
         return None
@@ -578,7 +580,7 @@ class EddMatcher(object):
             block_entries = os.listdir(mp.ondisk)
             for be in block_entries:
                 link = mp + be
-                answers.append({'link':link, 'path':be})
+                answers.append({'link': link, 'path': be})
 
         if len(answers) > 1:
             log.error("Found too many VirtIO devices for EDD device 0x%x: %s",
@@ -601,7 +603,7 @@ class EddMatcher(object):
         if name is not None:
             return name
         name = self.devname_from_virtio_scsi_pci_dev()
-        if not name is None:
+        if name is not None:
             return name
 
         unsupported = ("ATAPI", "USB", "1394", "I2O", "RAID", "FIBRE", "SAS")
@@ -629,12 +631,13 @@ class EddMatcher(object):
             This will obviously fail for a fresh drive/image, but in extreme
             cases can also show false positives for randomly matching data.
         """
-        sysblock=util.Path("/sys/block/", root=self.root)
+        sysblock = util.Path("/sys/block/", root=self.root)
         for (name, mbr_sig) in mbr_dict.items():
             if mbr_sig == self.edd.mbr_sig:
                 self.edd.sysfslink = util.sysfs_readlink(sysblock, link=name)
                 return name
         return None
+
 
 def collect_edd_data(root=None):
     edd_data_dict = {}
@@ -645,6 +648,7 @@ def collect_edd_data(root=None):
         log.debug("edd: found device 0x%x at %s", biosdev, path)
         edd_data_dict[biosdev] = EddEntry(path, root=root)
     return edd_data_dict
+
 
 def collect_mbrs(devices, root=None):
     """ Read MBR signatures from devices.
@@ -688,6 +692,7 @@ def collect_mbrs(devices, root=None):
         mbr_dict[dev.name] = mbrsig_str
     log.info("edd: collected mbr signatures: %s", mbr_dict)
     return mbr_dict
+
 
 def get_edd_dict(devices, root=None):
     """ Generates the 'device name' -> 'edd number' mapping.

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -34,6 +34,7 @@ from threading import Lock
 # this will get set to anaconda's program_log_lock in enable_installer_mode
 program_log_lock = Lock()
 
+
 class Path(str):
 
     """ Path(path, root=None) provides a filesystem path object, which
@@ -103,12 +104,12 @@ class Path(str):
 
     def __add__(self, other):
         if isinstance(other, Path):
-            if other.root != None and other.root != "/":
-                if self.root == None:
+            if other.root is not None and other.root != "/":
+                if self.root is None:
                     self._root = other.root
                 elif other.root != self.root:
                     raise ValueError("roots <%s> and <%s> don't match." %
-                        (self.root, other.root))
+                                     (self.root, other.root))
             path = "%s/%s" % (self.path, other.path)
         else:
             path = "%s/%s" % (self.path, other)
@@ -152,6 +153,7 @@ class Path(str):
 
     def __hash__(self):
         return self._path.__hash__()
+
 
 def _run_program(argv, root='/', stdin=None, env_prune=None, stderr_to_stdout=False, binary_output=False):
     if env_prune is None:
@@ -333,6 +335,7 @@ def notify_kernel(path, action="change"):
     f.write("%s\n" % action)
     f.close()
 
+
 def normalize_path_slashes(path):
     """ Normalize the slashes in a filesystem path.
         Does not actually examine the filesystme in any way.
@@ -340,6 +343,7 @@ def normalize_path_slashes(path):
     while "//" in path:
         path = path.replace("//", "/")
     return path
+
 
 def join_paths(*paths):
     """ Joins filesystem paths without any consiration of slashes or
@@ -349,13 +353,14 @@ def join_paths(*paths):
         return join_paths(*paths[0])
     return normalize_path_slashes('/'.join(paths))
 
+
 def get_sysfs_attr(path, attr, root=None):
     if not attr:
         log.debug("get_sysfs_attr() called with attr=None")
         return None
     if not isinstance(path, Path):
         path = Path(path=path, root=root)
-    elif root != None:
+    elif root is not None:
         path.newroot(root)
 
     attribute = path + attr
@@ -371,6 +376,7 @@ def get_sysfs_attr(path, attr, root=None):
     sdata = "".join(["%02x" % (ord(x),) for x in data])
     testdata_log.debug("sysfs attr %s: %s", attribute, sdata)
     return data.strip()
+
 
 def sysfs_readlink(path, link, root=None):
     if not link:
@@ -390,6 +396,7 @@ def sysfs_readlink(path, link, root=None):
     output = os.readlink(fullpath)
     testdata_log.debug("new sysfs link: \"%s\" -> \"%s\"", linkpath, output)
     return output
+
 
 def get_sysfs_path_by_name(dev_node, class_name="block"):
     """ Return sysfs path for a given device.
@@ -1019,6 +1026,7 @@ def deprecated(version, message):
 
     return deprecate_func
 
+
 def default_namedtuple(name, fields, doc=""):
     """Create a namedtuple class
 
@@ -1047,6 +1055,7 @@ def default_namedtuple(name, fields, doc=""):
     class TheDefaultNamedTuple(nt):
         if doc:
             __doc__ = doc
+
         def __new__(cls, *args, **kwargs):
             args_list = list(args)
             sorted_kwargs = sorted(kwargs.keys(), key=field_names.index)

--- a/tests/devicelibs_test/edd_test.py
+++ b/tests/devicelibs_test/edd_test.py
@@ -28,6 +28,7 @@ class FakeEddEntry(edd.EddEntry):
     def __repr__(self):
         return "<FakeEddEntry%s>" % (self._fmt(' ', ''),)
 
+
 class EddTestCase(unittest.TestCase):
 
     def __init__(self, *args, **kwds):
@@ -303,13 +304,13 @@ class EddTestCase(unittest.TestCase):
                                "block/sdd",
                                sysfspath="/sys/firmware/edd/int13_dev85/"),
         }
-        devices=(FakeDevice("sda"),
-                 FakeDevice("sdb"),
-                 FakeDevice("sdc"),
-                 FakeDevice("sdd"),
-                 FakeDevice("sde"),
-                 FakeDevice("vda"),
-                 )
+        devices = (FakeDevice("sda"),
+                   FakeDevice("sdb"),
+                   FakeDevice("sdc"),
+                   FakeDevice("sdd"),
+                   FakeDevice("sde"),
+                   FakeDevice("vda"),
+                   )
 
         edd_dict = edd.get_edd_dict(devices, root=self.root("absurd_virt"))
         self.debug('edd_dict: %s', edd_dict)
@@ -343,7 +344,7 @@ class EddTestCase(unittest.TestCase):
              '/sys/firmware/edd/int13_dev85/'),
         ]
         infos = [
-            ("edd: collected mbr signatures: %s",{ 'vda': '0x86531966',
+            ("edd: collected mbr signatures: %s", {'vda': '0x86531966',
                                                    'sda': '0xe3bf124b',
                                                    'sdb': '0x7dfff0db',
                                                    'sdc': '0x63f1d7d8',
@@ -367,22 +368,22 @@ class EddTestCase(unittest.TestCase):
     def test_collect_mbrs_strawberry_mountain(self):
         self._edd_logger.debug("starting test %s", self._testMethodName)
         edd.testdata_log.debug("starting test %s", self._testMethodName)
-        devices=(FakeDevice("sda"),
-                 FakeDevice("sdb"),
-                 FakeDevice("sdc"),
-                 FakeDevice("sdd"),
-                 )
-        fake_mbr_dict = { 'sdc': '0x00033091',
-                          'sdd': '0x91271645',
-                          }
+        devices = (FakeDevice("sda"),
+                   FakeDevice("sdb"),
+                   FakeDevice("sdc"),
+                   FakeDevice("sdd"),
+                   )
+        fake_mbr_dict = {'sdc': '0x00033091',
+                         'sdd': '0x91271645',
+                         }
         mbr_dict = edd.collect_mbrs(devices,
                                     root=self.root('strawberry_mountain'))
         infos = [
             ("edd: MBR signature on %s is zero. new disk image?", "sda"),
             ("edd: MBR signature on %s is zero. new disk image?", "sdb"),
-            ("edd: collected mbr signatures: %s", { 'sdc': '0x00033091',
-                                                    'sdd': '0x91271645',
-                                                    }),
+            ("edd: collected mbr signatures: %s", {'sdc': '0x00033091',
+                                                   'sdd': '0x91271645',
+                                                   }),
         ]
         warnings = [
         ]
@@ -440,11 +441,11 @@ class EddTestCase(unittest.TestCase):
         # test with sata sda, usb sdb
         self._edd_logger.debug("starting test %s", self._testMethodName)
         edd.testdata_log.debug("starting test %s", self._testMethodName)
-        devices=(FakeDevice("sda"),
-                 FakeDevice("sdb"),
-                 FakeDevice("sdc"),
-                 FakeDevice("sdd"),
-                 )
+        devices = (FakeDevice("sda"),
+                   FakeDevice("sdb"),
+                   FakeDevice("sdc"),
+                   FakeDevice("sdd"),
+                   )
         fakeedd = {
             0x80: FakeEddEntry(version="0x21", mbr_sig="0x91271645",
                                sectors=31293440, host_bus="PCI", type="USB",
@@ -498,9 +499,9 @@ class EddTestCase(unittest.TestCase):
         infos = [
             ("edd: MBR signature on %s is zero. new disk image?", "sda"),
             ("edd: MBR signature on %s is zero. new disk image?", "sdb"),
-            ("edd: collected mbr signatures: %s", { 'sdc': '0x00033091',
-                                                    'sdd': '0x91271645',
-                                                    }),
+            ("edd: collected mbr signatures: %s", {'sdc': '0x00033091',
+                                                   'sdd': '0x91271645',
+                                                   }),
             ("edd: matched 0x%x to %s using MBR sig", 0x80, "sdd"),
             ("edd: matched 0x%x to %s using PCI dev", 0x81, "sdc"),
             ("edd: matched 0x%x to %s using PCI dev", 0x82, "sdb"),
@@ -527,20 +528,20 @@ class EddTestCase(unittest.TestCase):
     def test_collect_mbrs_bad_sata_virt(self):
         self._edd_logger.debug("starting test %s", self._testMethodName)
         edd.testdata_log.debug("starting test %s", self._testMethodName)
-        devices=(FakeDevice("sda"),
-                 FakeDevice("sdb"),
-                 FakeDevice("sdc"),
-                 )
-        fake_mbr_dict = { 'sda': '0xe3bf124b',
-                          'sdb': '0x7dfff0db',
-                          'sdc': '0x86531966',
-                          }
+        devices = (FakeDevice("sda"),
+                   FakeDevice("sdb"),
+                   FakeDevice("sdc"),
+                   )
+        fake_mbr_dict = {'sda': '0xe3bf124b',
+                         'sdb': '0x7dfff0db',
+                         'sdc': '0x86531966',
+                         }
         mbr_dict = edd.collect_mbrs(devices, root=self.root("bad_sata_virt"))
         infos = [
-            ("edd: collected mbr signatures: %s", { 'sda': '0xe3bf124b',
-                                                    'sdb': '0x7dfff0db',
-                                                    'sdc': '0x86531966',
-                                                    }),
+            ("edd: collected mbr signatures: %s", {'sda': '0xe3bf124b',
+                                                   'sdb': '0x7dfff0db',
+                                                   'sdc': '0x86531966',
+                                                   }),
         ]
         self.check_logs(infos=infos)
         lib.assertVerboseEqual(fake_mbr_dict, mbr_dict)
@@ -581,10 +582,10 @@ class EddTestCase(unittest.TestCase):
         # test with sata sda, usb sdb
         self._edd_logger.debug("starting test %s", self._testMethodName)
         edd.testdata_log.debug("starting test %s", self._testMethodName)
-        devices=(FakeDevice("sda"),
-                 FakeDevice("sdb"),
-                 FakeDevice("sdc"),
-                 )
+        devices = (FakeDevice("sda"),
+                   FakeDevice("sdb"),
+                   FakeDevice("sdc"),
+                   )
         fakeedd = {
             0x80: FakeEddEntry(version="0x30", mbr_sig="0x86531966",
                                sectors=10485760,
@@ -617,10 +618,10 @@ class EddTestCase(unittest.TestCase):
             ('edd: data extracted from 0x%x:%r', 0x82, fakeedd[0x82]),
         ]
         infos = [
-            ('edd: collected mbr signatures: %s', { 'sda': '0xe3bf124b',
-                                                    'sdb': '0x7dfff0db',
-                                                    'sdc': '0x86531966',
-                                                    }),
+            ('edd: collected mbr signatures: %s', {'sda': '0xe3bf124b',
+                                                   'sdb': '0x7dfff0db',
+                                                   'sdc': '0x86531966',
+                                                   }),
             ('edd: matched 0x%x to %s using MBR sig', 128, 'sdc'),
             ('edd: matched 0x%x to %s using MBR sig', 129, 'sda'),
             ('edd: matched 0x%x to %s using MBR sig', 130, 'sdb'),
@@ -636,24 +637,24 @@ class EddTestCase(unittest.TestCase):
     def test_collect_mbrs_mostly_fixed_virt(self):
         self._edd_logger.debug("starting test %s", self._testMethodName)
         edd.testdata_log.debug("starting test %s", self._testMethodName)
-        devices=(FakeDevice("sda"),
-                 FakeDevice("sdb"),
-                 FakeDevice("sdc"),
-                 FakeDevice("vda"),
-                 )
-        fake_mbr_dict = { 'sda': '0xe3bf124b',
-                          'sdb': '0x7dfff0db',
-                          'sdc': '0x648873aa',
-                          'vda': '0x86531966',
-                          }
+        devices = (FakeDevice("sda"),
+                   FakeDevice("sdb"),
+                   FakeDevice("sdc"),
+                   FakeDevice("vda"),
+                   )
+        fake_mbr_dict = {'sda': '0xe3bf124b',
+                         'sdb': '0x7dfff0db',
+                         'sdc': '0x648873aa',
+                         'vda': '0x86531966',
+                         }
         mbr_dict = edd.collect_mbrs(devices,
                                     root=self.root('mostly_fixed_virt'))
         infos = [
-            ("edd: collected mbr signatures: %s", { 'sda': '0xe3bf124b',
-                                                    'sdb': '0x7dfff0db',
-                                                    'sdc': '0x648873aa',
-                                                    'vda': '0x86531966',
-                                                    }),
+            ("edd: collected mbr signatures: %s", {'sda': '0xe3bf124b',
+                                                   'sdb': '0x7dfff0db',
+                                                   'sdc': '0x648873aa',
+                                                   'vda': '0x86531966',
+                                                   }),
         ]
         self.check_logs(infos=infos)
         lib.assertVerboseEqual(fake_mbr_dict, mbr_dict)
@@ -707,11 +708,11 @@ class EddTestCase(unittest.TestCase):
         # test with sata sda, usb sdb
         self._edd_logger.debug("starting test %s", self._testMethodName)
         edd.testdata_log.debug("starting test %s", self._testMethodName)
-        devices=(FakeDevice("sda"),
-                 FakeDevice("sdb"),
-                 FakeDevice("sdc"),
-                 FakeDevice("vda"),
-                 )
+        devices = (FakeDevice("sda"),
+                   FakeDevice("sdb"),
+                   FakeDevice("sdc"),
+                   FakeDevice("vda"),
+                   )
         fakeedd = {
             0x80: FakeEddEntry(version="0x30", mbr_sig="0x86531966",
                                sectors=10485760, host_bus="PCI", type="SCSI",
@@ -762,11 +763,11 @@ class EddTestCase(unittest.TestCase):
         infos = [
             ('edd: Could not find Virtio device for pci dev %s channel %s', '00:03.0', 255),
             ('edd: Could not find Virtio device for pci dev %s channel %s', '00:0c.0', 255),
-            ('edd: collected mbr signatures: %s', { 'vda': '0x86531966',
-                                                    'sda': '0xe3bf124b',
-                                                    'sdb': '0x7dfff0db',
-                                                    'sdc': '0x648873aa',
-                                                    }),
+            ('edd: collected mbr signatures: %s', {'vda': '0x86531966',
+                                                   'sda': '0xe3bf124b',
+                                                   'sdb': '0x7dfff0db',
+                                                   'sdc': '0x648873aa',
+                                                   }),
             ('edd: matched 0x%x to %s using PCI dev', 0x80, 'vda'),
             ('edd: matched 0x%x to %s using PCI dev', 0x81, 'sda'),
             ('edd: matched 0x%x to %s using PCI dev', 0x82, 'sdb'),

--- a/tests/lib.py
+++ b/tests/lib.py
@@ -1,6 +1,7 @@
 
 import pprint
 
+
 def assertVerboseListEqual(left, right, msg=None):
     left.sort()
     right.sort()
@@ -33,18 +34,19 @@ def assertVerboseListEqual(left, right, msg=None):
     if leftmissing or rightmissing:
         raise AssertionError(s)
 
+
 def assertVerboseEqual(left, right, msg=None):
     if left != right:
         l = len(left)
         r = len(right)
         for x in range(0, max(l, r)):
-            if x > l-1:
+            if x > l - 1:
                 assertVerboseEqual(None, right[x], msg)
-            if x > r-1:
+            if x > r - 1:
                 assertVerboseEqual(left[x], None, msg)
             if left[x] != right[x]:
                 if msg:
                     raise AssertionError(msg)
                 else:
                     raise AssertionError("%s != %s" % (
-                            pprint.pformat(left), pprint.pformat(right)))
+                        pprint.pformat(left), pprint.pformat(right)))

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -24,6 +24,7 @@ class MiscTest(unittest.TestCase):
             self.assertFalse(util.power_of_two(2 ** i + 1), msg=i)
             self.assertFalse(util.power_of_two(2 ** i - 1), msg=i)
 
+
 class TestDefaultNamedtuple(unittest.TestCase):
     def test_default_namedtuple(self):
         TestTuple = util.default_namedtuple("TestTuple", ["x", "y", ("z", 5), "w"])


### PR DESCRIPTION
Moves 'pylint' to its own target, adds a 'pep8' target, and makes
the 'check' target empty with 'check' and 'pep8' as prerequisites.
This allows the user to run either pylint or pep8 separately or
together.

It also makes it possible to plumb a user-specified PYTHONPATH
into the 'pylint' target.