### PR TITLE
Fix pylint problems with the new default namedtuple stuff.

### DIFF
--- a/blivet/util.py
+++ b/blivet/util.py
@@ -1040,12 +1040,13 @@ def default_namedtuple(name, fields, doc=""):
             field_names.append(field)
     nt = namedtuple(name, field_names)
 
+    # pylint: disable=no-init
     class TheDefaultNamedTuple(nt):
         if doc:
             __doc__ = doc
         def __new__(cls, *args, **kwargs):
             args_list = list(args)
-            sorted_kwargs = sorted(kwargs.keys(), key=lambda x: field_names.index(x))
+            sorted_kwargs = sorted(kwargs.keys(), key=field_names.index)
             for i in range(len(args), len(field_names)):
                 if field_names[i] in sorted_kwargs:
                     args_list.append(kwargs[field_names[i]])

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,3 +1,4 @@
+# pylint: skip-file
 
 import unittest
 from decimal import Decimal


### PR DESCRIPTION
(1) Something's going on with pylinting util_test.py leading to
tracebacks that end like this:

  File "/usr/lib/python3.4/site-packages/astroid/builder.py", line 39, in parse
    return compile(string, "<string>", 'exec', PyCF_ONLY_AST)
  File "<string>", line 2
    class 1(tuple):

No one wants to wade into that, so just disable pylint on that one file
for the moment.

(2) Don't worry about TheDefaultNamedTuple not having an __init__.
That's just one pylint can't figure out.

(3) Get rid of an unnecessary lambda.