### PR TITLE
Do not try to get LVM cache's size from stats for inactive LV

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -1786,8 +1786,10 @@ class LVMCache(Cache):
 
     @property
     def size(self):
-        if self.exists:
-            return self.stats.size
+        # self.stats is always dynamically fetched so store and reuse the value here
+        stats = self.stats
+        if stats:
+            return stats.size
         else:
             return self._size
 
@@ -1808,9 +1810,11 @@ class LVMCache(Cache):
 
     @property
     def stats(self):
-        if not self._exists:
+        # to get the stats we need the cached LV to exist and be activated
+        if self._exists and self._cached_lv.status:
+            return LVMCacheStats(blockdev.lvm.cache_stats(self._cached_lv.vg.name, self._cached_lv.lvname))
+        else:
             return None
-        return LVMCacheStats(blockdev.lvm.cache_stats(self._cached_lv.vg.name, self._cached_lv.lvname))
 
     @property
     def mode(self):


### PR DESCRIPTION
If the cached LV is not active, we cannot determine the size of its cache from
the stats because these are only available for activated LVs. However, if the LV
and cache exist, we examined them on devicetree population and got the
information about the size at that point. Thus we can used the stored value if
the LV is no longer active.

Also, keep the logic of when we should be able to get stats in one place.

note: this fixes a bug I hit when trying to install F23 on my workstation -- blivet.reset() fails because when we try to dump the state, the cached LV is inactive.