### PR TITLE
Update the getattr calls with PEP8 property/attribute names

### DIFF
--- a/blivet/autopart.py
+++ b/blivet/autopart.py
@@ -257,7 +257,7 @@ def _schedule_partitions(storage, disks, implicit_devices, min_luks_entropy=0, r
             continue
         elif request.fstype == "biosboot":
             is_gpt = (stage1_device and
-                      getattr(stage1_device.format, "labelType", None) == "gpt")
+                      getattr(stage1_device.format, "label_type", None) == "gpt")
             has_bios_boot = (stage1_device and
                              any([p.format.type == "biosboot"
                                   for p in storage.partitions

--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -319,7 +319,7 @@ class Blivet(object):
             used_devices.extend(new.ancestors)
 
         for device in self.partitions:
-            if getattr(device, "isLogical", False):
+            if getattr(device, "is_logical", False):
                 extended = device.disk.format.extended_partition.path
                 used_devices.append(self.devicetree.get_device_by_path(extended))
 

--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -523,7 +523,7 @@ class DeviceFactory(object):
                           if allow_existing or not c.exists]
             if containers:
                 # XXX All containers should have a "free" attribute
-                containers.sort(key=lambda c: getattr(c, "freeSpace", c.size),
+                containers.sort(key=lambda c: getattr(c, "free_space", c.size),
                                 reverse=True)
                 container = containers[0]
 
@@ -1449,7 +1449,7 @@ class LVMThinPFactory(LVMFactory):
     @property
     def _pesize(self):
         """ The extent size of our vg or the default if we have no vg. """
-        return getattr(self.container, "peSize", lvm.LVM_PE_SIZE)
+        return getattr(self.container, "pe_size", lvm.LVM_PE_SIZE)
 
     def _get_device_space(self):
         """ Calculate and return the total disk space needed for the device.

--- a/blivet/osinstall.py
+++ b/blivet/osinstall.py
@@ -455,8 +455,8 @@ class FSSet(object):
 
         # make sure, if we're using a device from the tree, that
         # the device's format we found matches what's in the fstab
-        ftype = getattr(fmt, "mountType", fmt.type)
-        dtype = getattr(device.format, "mountType", device.format.type)
+        ftype = getattr(fmt, "mount_type", fmt.type)
+        dtype = getattr(device.format, "mount_type", device.format.type)
         if hasattr(fmt, "testMount") and fstype != "auto" and ftype != dtype:
             log.info("fstab says %s at %s is %s", dtype, mountpoint, ftype)
             if fmt.test_mount():     # pylint: disable=no-member
@@ -829,7 +829,7 @@ class FSSet(object):
             if isinstance(device, OpticalDevice):
                 continue
 
-            fstype = getattr(device.format, "mountType", device.format.type)
+            fstype = getattr(device.format, "mount_type", device.format.type)
             if fstype == "swap":
                 mountpoint = "swap"
                 options = device.format.options

--- a/blivet/populator.py
+++ b/blivet/populator.py
@@ -94,19 +94,19 @@ class Populator(object):
         # indicates whether or not the tree has been fully populated
         self.populated = False
 
-        self.exclusive_disks = getattr(conf, "exclusiveDisks", [])
-        self.ignored_disks = getattr(conf, "ignoredDisks", [])
+        self.exclusive_disks = getattr(conf, "exclusive_disks", [])
+        self.ignored_disks = getattr(conf, "ignored_disks", [])
         self.iscsi = iscsi
         self.dasd = dasd
 
         self.disk_images = {}
-        images = getattr(conf, "diskImages", {})
+        images = getattr(conf, "disk_images", {})
         if images:
             # this will overwrite self.exclusive_disks
             self.set_disk_images(images)
 
         # protected device specs as provided by the user
-        self.protected_dev_specs = getattr(conf, "protectedDevSpecs", [])
+        self.protected_dev_specs = getattr(conf, "protected_dev_specs", [])
         self.live_backing_device = None
 
         # names of protected devices at the time of tree population


### PR DESCRIPTION
In order to have a nicer code we have recently moved from camelCase names to
split_words names. While the change covered all the direct accesses (pylint
would catch any problematic ones), it didn't cover the cases where we access the
items indirectly via the getattr() call. This fixes all the getattr() calls that
tried to access any camelCase items.