### PR TITLE
Only prepend the root to get the ondisk path if there is some

### DIFF
--- a/blivet/util.py
+++ b/blivet/util.py
@@ -58,7 +58,10 @@ class Path(str):
         """ Path.ondisk evaluates as the real filesystem path of the path,
             including the path's root in the data.
         """
-        return normalize_path_slashes(Path(self.root) + Path(self.path))
+        if self.root:
+            return normalize_path_slashes(Path(self.root) + Path(self.path))
+        else:
+            return Path(self.path)
 
     @property
     def path(self):


### PR DESCRIPTION
Otherwise we get things like this:
'/home/user/sources/blivet/None/sys/devices/.../block/sda/size'

which is not really what we want.

@vathpela, could you please add unit tests for the ``Path`` class?