### PR TITLE
Teardown all descendants devices before tearing disk images down

### DIFF
--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -1048,6 +1048,9 @@ class DeviceTree(object):
 
     def teardown_disk_images(self):
         """ Tear down any disk image stacks. """
+        # teardown all devices first so that there's nothing active running on
+        # top of disk images when we try to tear those down
+        self.teardown_all()
         self._populator.teardown_disk_images()
 
     @property


### PR DESCRIPTION
DM maps cannot be removed while they are in use so in order to make them
removable, we need to teardown all devices "built" on top of them first. This
makes our examples (and possibly some tests) better clean after themselves.