### PR TITLE
Pass devices arg when calling actions.process

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -168,7 +168,7 @@ class Blivet(object):
 
         """
 
-        self.devicetree.actions.process(callbacks=callbacks)
+        self.devicetree.actions.process(callbacks=callbacks, devices=self.devices)
         if not flags.installer_mode:
             return
 


### PR DESCRIPTION
Lost when switching from `devicetree.processActions` to `actions.process` in `do_it`.