### PR TITLE
Fix makebumpver for new conf.py

### DIFF
--- a/scripts/makebumpver
+++ b/scripts/makebumpver
@@ -529,8 +529,7 @@ def main(argv):
     # Files to replace version strings in
     version_files = [(os.path.realpath(cwd+"/setup.py"), "version='%s'"),
                      (os.path.realpath(cwd+"/blivet/__init__.py"), "__version__ = '%s'"),
-                     (os.path.realpath(cwd+"/doc/conf.py"), "version = '%s'"),
-                     (os.path.realpath(cwd+"/doc/conf.py"), "release = '%s'")]
+                     (os.path.realpath(cwd+"/doc/conf.py"), "version = '%s'")]
 
     mbv = MakeBumpVer(name=name, version=version, release=release,
                       ignore=ignore, bugmap=bugmap, spec=spec, skip_acks=skip_acks,


### PR DESCRIPTION
In conf.py release and version are the same thing, only version needs to
be updated with the new version string.