### PR TITLE
Let Device know about its children

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -61,10 +61,10 @@ import logging
 log = logging.getLogger("blivet")
 
 
-def empty_device(device, devicetree):
+def empty_device(device):
     empty = True
     if device.partitioned:
-        partitions = devicetree.get_children(device)
+        partitions = device.children
         empty = all([p.is_magic for p in partitions])
     else:
         empty = (device.format.type is None)
@@ -539,7 +539,7 @@ class Blivet(object):
             if not self.config.initialize_disks or not device.is_disk:
                 return False
 
-            if not empty_device(device, self.devicetree):
+            if not empty_device(device):
                 return False
 
         if isinstance(device, PartitionDevice):
@@ -564,7 +564,7 @@ class Blivet(object):
                 # if clear_part_type is not CLEARPART_TYPE_ALL but we'll still be
                 # removing every partition from the disk, return True since we
                 # will want to be able to create a new disklabel on this disk
-                if not empty_device(device, self.devicetree):
+                if not empty_device(device):
                     return False
 
             # Never clear disks with hidden formats
@@ -577,7 +577,7 @@ class Blivet(object):
             # initialize disks as needed
             if (clear_part_type == CLEARPART_TYPE_LINUX and
                 not ((self.config.initialize_disks and
-                      empty_device(device, self.devicetree)) or
+                      empty_device(device)) or
                      (not device.partitioned and device.format.linux_native))):
                 return False
 
@@ -659,7 +659,7 @@ class Blivet(object):
             if magic:
                 expected = 1
                 # remove the magic partition
-                for part in self.devicetree.get_children(disk):
+                for part in disk.children:
                     if part.parted_partition.number == magic:
                         log.debug("removing %s", part.name)
                         # We can't schedule the magic partition for removal

--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -756,7 +756,8 @@ class DeviceFactory(object):
             self.storage.create_device(luks_device)
             self.device = luks_device
             if parent_container:
-                parent_container.parents.replace(orig_device, self.device)
+                parent_container.parents.append(self.device)
+                parent_container.parents.remove(orig_device)
 
     def _set_name(self):
         if not self.device_name:
@@ -1076,7 +1077,8 @@ class PartitionSetFactory(PartitionFactory):
                                            get_format(self.fstype))
                 members.append(member.slave)
                 if container:
-                    container.parents.replace(member, member.slave)
+                    container.parents.append(member.slave)
+                    container.parents.remove(member)
 
                 continue
 
@@ -1090,7 +1092,8 @@ class PartitionSetFactory(PartitionFactory):
                 self.storage.create_device(luks_member)
                 members.append(luks_member)
                 if container:
-                    container.parents.replace(member, luks_member)
+                    container.parents.append(luks_member)
+                    container.parents.remove(member)
 
                 continue
 

--- a/blivet/devices/btrfs.py
+++ b/blivet/devices/btrfs.py
@@ -197,7 +197,7 @@ class BTRFSVolumeDevice(BTRFSDevice, ContainerDevice, RaidDevice):
             # Could not set the levels, so set loose the parents that were
             # added in superclass constructor.
             for dev in self.parents:
-                dev.remove_child()
+                dev.remove_child(self)
             raise e
 
         self.subvolumes = []
@@ -535,7 +535,7 @@ class BTRFSSubVolumeDevice(BTRFSDevice):
 
     def setup_parents(self, orig=False):
         """ Run setup method of all parent devices. """
-        log_method_call(self, name=self.name, orig=orig, kids=self.kids)
+        log_method_call(self, name=self.name, orig=orig)
         self.volume.setup(orig=orig)
 
     def _create(self):

--- a/blivet/devices/dm.py
+++ b/blivet/devices/dm.py
@@ -127,14 +127,14 @@ class DMDevice(StorageDevice):
         return blockdev.dm.node_from_name(self.name)
 
     def setup_partitions(self):
-        log_method_call(self, name=self.name, kids=self.kids)
+        log_method_call(self, name=self.name)
         rc = util.run_program(["kpartx", "-a", "-s", self.path])
         if rc:
             raise errors.DMError("partition activation failed for '%s'" % self.name)
         udev.settle()
 
     def teardown_partitions(self):
-        log_method_call(self, name=self.name, kids=self.kids)
+        log_method_call(self, name=self.name)
         rc = util.run_program(["kpartx", "-d", "-s", self.path])
         if rc:
             raise errors.DMError("partition deactivation failed for '%s'" % self.name)

--- a/blivet/devices/lib.py
+++ b/blivet/devices/lib.py
@@ -169,25 +169,3 @@ class ParentList(object):
 
         self.removefunc(y)
         self.items.remove(y)
-
-    def replace(self, x, y):
-        """ Replace the first instance of x with y, bypassing callbacks.
-
-            .. note::
-
-                This method does update the child counts for the two devices.
-
-            .. note::
-
-                It is usually a bad idea to bypass the callbacks. This is
-                intended for specific circumstances like toggling encryption of
-                container member devices in the devicefactory classes.
-
-        """
-        if x not in self.items:
-            raise ValueError("item to be replaced is not in the list")
-
-        idx = self.items.index(x)
-        self.items[idx] = y
-        x.remove_child()
-        y.add_child()

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -718,7 +718,10 @@ class LVMLogicalVolumeDevice(DMDevice):
 
     def _get_name(self):
         """ This device's name. """
-        return "%s-%s" % (self.vg.name, self._name)
+        if self.vg is not None:
+            return "%s-%s" % (self.vg.name, self._name)
+        else:
+            return super()._get_name()
 
     @property
     def lvname(self):

--- a/blivet/devices/md.py
+++ b/blivet/devices/md.py
@@ -118,7 +118,7 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
             # Could not set the level, so set loose the parents that were
             # added in superclass constructor.
             for dev in self.parents:
-                dev.remove_child()
+                dev.remove_child(self)
             raise e
 
         self.uuid = uuid

--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -503,7 +503,7 @@ class StorageDevice(Device):
     #
     def setup_parents(self, orig=False):
         """ Run setup method of all parent devices. """
-        log_method_call(self, name=self.name, orig=orig, kids=self.kids)
+        log_method_call(self, name=self.name, orig=orig)
         for parent in self.parents:
             parent.setup(orig=orig)
             if orig:
@@ -521,14 +521,14 @@ class StorageDevice(Device):
 
             :keyword bool modparent: whether to account for removal in parents
 
-            Parent child counts are adjusted regardless of modparent's value.
+            Parents' list of child devices is updated regardless of modparent.
             The intended use of modparent is to prevent doing things like
             removing a parted.Partition from the disk that contains it as part
             of msdos extended partition management. In general, you should not
             override the default value of modparent in new code.
         """
         for parent in self.parents:
-            parent.remove_child()
+            parent.remove_child(self)
 
     def add_hook(self, new=True):
         """ Perform actions related to adding a device to the devicetree.
@@ -541,7 +541,7 @@ class StorageDevice(Device):
         """
         if not new:
             for p in self.parents:
-                p.add_child()
+                p.add_child(self)
 
     #
     # size manipulations

--- a/blivet/populator/helpers/luks.py
+++ b/blivet/populator/helpers/luks.py
@@ -88,7 +88,7 @@ class LUKSFormatPopulator(FormatPopulator):
                 luks_device.setup()
             except (LUKSError, blockdev.CryptoError, DeviceError) as e:
                 log.info("setup of %s failed: %s", self.device.format.map_name, e)
-                self.device.remove_child()
+                self.device.remove_child(luks_device)
             else:
                 luks_device.update_sysfs_path()
                 self._devicetree._add_device(luks_device)

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -238,7 +238,7 @@ class PopulatorMixin(object):
         if device.format and device.format.type != "multipath_member":
             log.debug("%s newly detected as multipath member, dropping old format and removing kids", device.name)
             # remove children from tree so that we don't stumble upon them later
-            for child in self.get_children(device):
+            for child in device.children:
                 self.recursive_remove(child, actions=False)
 
             device.format = None

--- a/tests/devicefactory_test.py
+++ b/tests/devicefactory_test.py
@@ -380,6 +380,16 @@ class LVMFactoryTestCase(DeviceFactoryTestCase):
         device = self._factory_device(device_type, size, **kwargs)
         self._validate_factory_device(device, device_type, size, **kwargs)
 
+        # limit the vg to the first disk
+        kwargs["disks"] = self.b.disks[:1]
+        device = self._factory_device(device_type, size, **kwargs)
+        self._validate_factory_device(device, device_type, size, **kwargs)
+
+        # expand it back to all disks
+        kwargs["disks"] = self.b.disks
+        device = self._factory_device(device_type, size, **kwargs)
+        self._validate_factory_device(device, device_type, size, **kwargs)
+
     def _get_size_delta(self, devices=None):
         if not devices:
             delta = Size("2 MiB") * len(self.b.disks)


### PR DESCRIPTION
Instead of a simple child device counter, these patches add a list of children to each `Device` instance. This makes `Device` more complete and makes `DeviceTree.get_children` unnecessary.