### PR TITLE
Make blivet thread-safe

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -28,7 +28,6 @@ import time
 import parted
 import functools
 
-
 from pykickstart.constants import AUTOPART_TYPE_LVM, CLEARPART_TYPE_ALL, CLEARPART_TYPE_LINUX, CLEARPART_TYPE_LIST, CLEARPART_TYPE_NONE
 
 from .storage_log import log_method_call, log_exception_info
@@ -53,6 +52,7 @@ from . import fcoe
 from . import zfcp
 from . import devicefactory
 from . import get_bootloader, get_sysroot, short_product_name, __version__
+from .threads import SynchronizedMeta
 from .util import open  # pylint: disable=redefined-builtin
 
 from .i18n import _
@@ -108,7 +108,7 @@ class StorageDiscoveryConfig(object):
         self.zero_mbr = ksdata.zerombr.zerombr
 
 
-class Blivet(object):
+class Blivet(object, metaclass=SynchronizedMeta):
 
     """ Top-level class for managing storage configuration. """
 

--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -20,9 +20,7 @@
 # Red Hat Author(s): Dave Lehman <dlehman@redhat.com>
 #
 
-
 from . import util
-
 from . import udev
 from .util import get_current_entropy
 from .devices import StorageDevice
@@ -34,6 +32,7 @@ from .callbacks import CreateFormatPreData, CreateFormatPostData
 from .callbacks import ResizeFormatPreData, ResizeFormatPostData
 from .callbacks import WaitForEntropyData, ReportProgressData
 from .size import Size
+from .threads import SynchronizedMeta
 
 import logging
 log = logging.getLogger("blivet")
@@ -100,7 +99,7 @@ def resize_type_from_string(type_string):
             return k
 
 
-class DeviceAction(util.ObjectID):
+class DeviceAction(util.ObjectID, metaclass=SynchronizedMeta):
 
     """ An action that will be carried out in the future on a Device.
 

--- a/blivet/devices/container.py
+++ b/blivet/devices/container.py
@@ -26,6 +26,7 @@ from six import add_metaclass
 from .. import errors
 from ..storage_log import log_method_call
 from ..formats import get_device_format_class
+from ..threads import SynchronizedABCMeta
 
 import logging
 log = logging.getLogger("blivet")
@@ -33,7 +34,7 @@ log = logging.getLogger("blivet")
 from .storage import StorageDevice
 
 
-@add_metaclass(abc.ABCMeta)
+@add_metaclass(SynchronizedABCMeta)
 class ContainerDevice(StorageDevice):
 
     """ A device that aggregates a set of member devices.

--- a/blivet/devices/device.py
+++ b/blivet/devices/device.py
@@ -24,6 +24,7 @@ import pprint
 
 from .. import util
 from ..storage_log import log_method_call
+from ..threads import SynchronizedMeta
 
 import logging
 log = logging.getLogger("blivet")
@@ -31,7 +32,7 @@ log = logging.getLogger("blivet")
 from .lib import ParentList
 
 
-class Device(util.ObjectID):
+class Device(util.ObjectID, metaclass=SynchronizedMeta):
 
     """ A generic device.
 

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -42,6 +42,7 @@ from ..storage_log import log_method_call
 from .. import udev
 from ..size import Size, KiB, MiB, ROUND_UP, ROUND_DOWN
 from ..tasks import availability
+from ..threads import SynchronizedABCMeta
 
 import logging
 log = logging.getLogger("blivet")
@@ -1002,7 +1003,7 @@ class LVMLogicalVolumeDevice(DMDevice):
         self._cache = LVMCache(self, size=cache_pool_lv.size, exists=True)
 
 
-@add_metaclass(abc.ABCMeta)
+@add_metaclass(SynchronizedABCMeta)
 class LVMInternalLogicalVolumeDevice(LVMLogicalVolumeDevice):
 
     """Abstract base class for internal LVs
@@ -1262,7 +1263,7 @@ class LVMCachePoolLogicalVolumeDevice(LVMInternalLogicalVolumeDevice):
 _INTERNAL_LV_CLASSES.append(LVMCachePoolLogicalVolumeDevice)
 
 
-@add_metaclass(abc.ABCMeta)
+@add_metaclass(SynchronizedABCMeta)
 class LVMSnapShotBase(object):
 
     """ Abstract base class for lvm snapshots

--- a/blivet/devices/raid.py
+++ b/blivet/devices/raid.py
@@ -25,11 +25,12 @@ from six import add_metaclass
 
 from .. import errors
 from ..i18n import _, P_
+from ..threads import SynchronizedABCMeta
 
 from .storage import StorageDevice
 
 
-@add_metaclass(abc.ABCMeta)
+@add_metaclass(SynchronizedABCMeta)
 class RaidDevice(StorageDevice):
 
     """ Metaclass for devices that support RAID in some form. """

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -39,6 +39,7 @@ from .devicelibs import lvm
 from . import util
 from .populator import PopulatorMixin
 from .storage_log import log_method_call, log_method_return
+from .threads import SynchronizedMeta
 
 import logging
 log = logging.getLogger("blivet")
@@ -47,7 +48,6 @@ _LVM_DEVICE_CLASSES = (LVMLogicalVolumeDevice, LVMVolumeGroupDevice)
 
 
 class DeviceTreeBase(object):
-
     """ A quasi-tree that represents the devices in the system.
 
         The tree contains a list of :class:`~.devices.StorageDevice` instances,
@@ -66,7 +66,6 @@ class DeviceTreeBase(object):
         :class:`~.deviceaction.DeviceAction` instances can only be registered
         for leaf devices, except for resize actions.
     """
-
     def __init__(self, conf=None):
         """
             :keyword conf: storage discovery configuration
@@ -895,7 +894,7 @@ class DeviceTreeBase(object):
                     self.hide(disk)
 
 
-class DeviceTree(DeviceTreeBase, PopulatorMixin):
+class DeviceTree(DeviceTreeBase, PopulatorMixin, metaclass=SynchronizedMeta):
     def __init__(self, conf=None, passphrase=None, luks_dict=None):
         DeviceTreeBase.__init__(self, conf=conf)
         PopulatorMixin.__init__(self, passphrase=passphrase, luks_dict=luks_dict)

--- a/blivet/flags.py
+++ b/blivet/flags.py
@@ -73,6 +73,7 @@ class Flags(object):
 
         self.update_from_boot_cmdline()
         self.allow_imperfect_devices = True
+        self.debug_threads = False
 
     def get_boot_cmdline(self):
         buf = open("/proc/cmdline").read().strip()

--- a/blivet/formats/__init__.py
+++ b/blivet/formats/__init__.py
@@ -37,6 +37,7 @@ from ..storage_log import log_method_call
 from ..errors import DeviceFormatError, FormatCreateError, FormatDestroyError, FormatSetupError
 from ..i18n import N_
 from ..size import Size
+from ..threads import SynchronizedMeta
 
 import logging
 log = logging.getLogger("blivet")
@@ -149,7 +150,7 @@ def get_device_format_class(fmt_type):
     return fmt
 
 
-class DeviceFormat(ObjectID):
+class DeviceFormat(ObjectID, metaclass=SynchronizedMeta):
 
     """ Generic device format.
 

--- a/blivet/threads.py
+++ b/blivet/threads.py
@@ -1,0 +1,73 @@
+# threads.py
+# Utilities related to multithreading.
+#
+# Copyright (C) 2014,2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU Lesser General Public License v.2, or (at your option) any later
+# version. This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY expressed or implied, including the implied
+# warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+# the GNU Lesser General Public License for more details.  You should have
+# received a copy of the GNU Lesser General Public License along with this
+# program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+# Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat trademarks
+# that are incorporated in the source code or documentation are not subject
+# to the GNU Lesser General Public License and may only be used or
+# replicated with the express permission of Red Hat, Inc.
+#
+# Red Hat Author(s): David Lehman <dlehman@redhat.com>
+#
+
+from threading import RLock
+from functools import wraps
+from types import FunctionType
+from abc import ABCMeta
+
+from .flags import flags
+
+blivet_lock = RLock(verbose=flags.debug_threads)
+
+
+def exclusive(m):
+    """ Run a callable while holding the global lock. """
+    @wraps(m)
+    def run_with_lock(*args, **kwargs):
+        with blivet_lock:
+            return m(*args, **kwargs)
+
+    return run_with_lock
+
+
+class SynchronizedMeta(type):
+    """ Metaclass that wraps all methods with the exclusive decorator.
+
+        To prevent specific methods from being wrapped, add the method name(s)
+        to a class attribute called _unsynchronized_methods (list of str).
+    """
+    def __new__(cls, name, bases, dct):
+        wrapped = {}
+        blacklist = dct.get('_unsynchronized_methods', [])
+
+        for n in dct:
+            if n in blacklist:
+                continue
+
+            obj = dct[n]
+            # Do not decorate class or static methods.
+            if isinstance(obj, FunctionType):
+                obj = exclusive(obj)
+            elif isinstance(obj, property):
+                obj = property(fget=exclusive(obj.__get__),
+                               fset=exclusive(obj.__set__),
+                               fdel=exclusive(obj.__delattr__),
+                               doc=obj.__doc__)
+
+            wrapped[n] = obj
+
+        return super(SynchronizedMeta, cls).__new__(cls, name, bases, wrapped)
+
+
+class SynchronizedABCMeta(SynchronizedMeta, ABCMeta):
+    pass

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -733,7 +733,7 @@ def set_up_logging(log_dir="/tmp", log_prefix="blivet"):
         log_file = os.path.realpath(log_file)
         handler = logging.FileHandler(log_file)
         handler.setLevel(level)
-        formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+        formatter = logging.Formatter("%(asctime)s %(levelname)s %(name)s/%(threadName)s: %(message)s")
         handler.setFormatter(formatter)
         return handler
 


### PR DESCRIPTION
The idea here is to make blivet thread-safe without making a ton of changes. This adds a global reentrant lock and a metaclass. The metaclass wraps every method call with a decorator that acquires the global lock prior to calling the method.