### PR TITLE
Add _netdev when mounting network devices during installation (#1290046)

### DIFF
--- a/blivet/__init__.py
+++ b/blivet/__init__.py
@@ -2599,6 +2599,8 @@ class FSSet(object):
             devices.append(self.efivars)
         devices.sort(key=lambda d: getattr(d.format, "mountpoint", None))
 
+        netdevs = self.devicetree.getDevicesByInstance(NetworkStorageDevice)
+
         for device in devices:
             if not device.format.mountable or not device.format.mountpoint:
                 continue
@@ -2638,6 +2640,11 @@ class FSSet(object):
 
             if readOnly:
                 options = "%s,%s" % (options, readOnly)
+
+            for netdev in netdevs:
+                if device.dependsOn(netdev):
+                    options = options + ",_netdev"
+                    break
 
             try:
                 device.format.setup(options=options,


### PR DESCRIPTION
systemd needs to know that a filesystem depends on the network,
otherwise it will pull the plug before properly unmounting the device.

Resolves: rhbz#1290046