### PR TITLE
Two docs related fixes

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -3,8 +3,8 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
-SPHINXAPIDOC  = sphinx-apidoc
+SPHINXBUILD   = sphinx-build-3
+SPHINXAPIDOC  = sphinx-apidoc-3
 PAPER         =
 BUILDDIR      = _build
 SOURCEDIR     = ../blivet

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -42,7 +42,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Blivet'
-copyright = u'2013-2014, Red Hat, Inc.'     # pylint: disable=redefined-builtin
+copyright = u'2013-2016, Red Hat, Inc.'     # pylint: disable=redefined-builtin
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -292,7 +292,7 @@ epub_copyright = u'2013, David Lehman'
 #extensions.extend(('sphinx.ext.inheritance_diagram', 'sphinx.ext.graphviz'))
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/2': None}
+intersphinx_mapping = {'https://docs.python.org/3': None}
 
 # This was taken directly from here:
 # http://read-the-docs.readthedocs.org/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -13,49 +13,47 @@ Building Blocks
 ===============
 
 Individual block devices are represented by the various subclasses of
-:class:`~.devices.StorageDevice`, while the formatting of the data they contain
+:class:`~.devices.storage.StorageDevice`, while the formatting of the data they contain
 is represented by the various subclasses of :class:`~.formats.DeviceFormat`.
 The hierarchy of devices is represented by :class:`~.devicetree.DeviceTree`.
 
-:class:`~.devices.DiskDevice`, :class:`~.devices.PartitionDevice`,
-:class:`~.devices.LVMLogicalVolumeDevice`, and
-:class:`~.devices.MDRaidArrayDevice` are some of the most important examples of
-:class:`~.devices.StorageDevice` subclasses.
+:class:`~.devices.disk.DiskDevice`, :class:`~.devices.partition.PartitionDevice`,
+:class:`~.devices.lvm.LVMLogicalVolumeDevice`, and
+:class:`~.devices.md.MDRaidArrayDevice` are some of the most important examples of
+:class:`~.devices.storage.StorageDevice` subclasses.
 
 Some examples of :class:`~.formats.DeviceFormat` subclasses include
 :class:`~.formats.swap.SwapSpace`, :class:`~.formats.disklabel.DiskLabel`,
 and subclasses of :class:`~.formats.fs.FS` such as :class:`~.formats.fs.Ext4FS`
 and :class:`~.formats.fs.XFS`.
 
-Every :class:`~.devices.StorageDevice` instance has a :attr:`~.devices.StorageDevice.format` that contains an instance of some :class:`~.formats.DeviceFormat`
+Every :class:`~.devices.storage.StorageDevice` instance has a :attr:`~.devices.storage.StorageDevice.format` that contains an instance of some :class:`~.formats.DeviceFormat`
 subclass -- even if it is "blank" or "unformatted" (in which case it is an instance of :class:`~.formats.DeviceFormat` itself).
 
 Every :class:`~.formats.DeviceFormat` has a
 :attr:`~.formats.DeviceFormat.device` attribute that is a string representing
 the path to the device node for the block device containing the formatting.
-:class:`~.devices.StorageDevice` and :class:`~.formats.DeviceFormat` can
+:class:`~.devices.storage.StorageDevice` and :class:`~.formats.DeviceFormat` can
 represent either existent or non-existent devices and formatting.
 
-:class:`~.devices.StorageDevice` and :class:`~.formats.DeviceFormat` share a similar API, which consists of methods to control existing devices/formats
-(:meth:`~.devices.StorageDevice.setup`,
-:meth:`~.devices.StorageDevice.teardown`), methods to create or modify
-devices/formats (:meth:`~.devices.StorageDevice.create`,
-:meth:`~.devices.StorageDevice.destroy`, :meth:`~.devices.StorageDevice.resize`)
+:class:`~.devices.storage.StorageDevice` and :class:`~.formats.DeviceFormat` share a similar API, which consists of methods to control existing devices/formats
+(:meth:`~.devices.storage.StorageDevice.setup`,
+:meth:`~.devices.storage.StorageDevice.teardown`), methods to create or modify
+devices/formats (:meth:`~.devices.storage.StorageDevice.create`,
+:meth:`~.devices.storage.StorageDevice.destroy`, :meth:`~.devices.storage.StorageDevice.resize`)
 , and attributes to store critical data
-(:attr:`~.devices.StorageDevice.status`, :attr:`~.devices.StorageDevice.exists`)
-. Some useful attributes of :class:`~.devices.StorageDevice` that are not found
+(:attr:`~.devices.storage.StorageDevice.status`, :attr:`~.devices.storage.StorageDevice.exists`)
+. Some useful attributes of :class:`~.devices.storage.StorageDevice` that are not found
 in :class:`~.formats.DeviceFormat` include
-:attr:`~.devices.Device.parents`, :attr:`~.devices.Device.isleaf`,
-:attr:`~.devices.Device.ancestors`, and :attr:`~.devices.StorageDevice.disks`.
+:attr:`~.devices.device.Device.parents`, :attr:`~.devices.device.Device.isleaf`,
+:attr:`~.devices.device.Device.ancestors`, and :attr:`~.devices.storage.StorageDevice.disks`.
 
 :class:`~.devicetree.DeviceTree` provides
-:attr:`~.devicetree.DeviceTree.devices` which is a list of
-:class:`~.devices.StorageDevice` instances representing the current state of the
+:attr:`~.devicetree.DeviceTreeBase.devices` which is a list of
+:class:`~.devices.storage.StorageDevice` instances representing the current state of the
 system as configured within blivet. It also provides some methods for looking up
-devices (:meth:`~.devicetree.DeviceTree.getDeviceByName`), for listing devices
-that build upon a device (:meth:`~.devicetree.DeviceTree.getDependentDevices`),
-and for listing direct descendants of a given device
-(:meth:`~.devicetree.DeviceTree.getChildren`).
+devices (:meth:`~.devicetree.DeviceTreeBase.get_device_by_name`) and for listing devices
+that build upon a device (:meth:`~.devicetree.DeviceTreeBase.get_dependent_devices`).
 
 Getting Started
 ===============


### PR DESCRIPTION
1. Use "sphinx-build-3" and "sphinx-apidoc-3", it fixes the problem with "empty" documentation (not sure if it help with readthedocs, but it fixes the problem when building locally).

2. Fix "class:`~..." links in intro. Blivet 2.0 API change, devices split up and other changes broke them.