### PR TITLE
LUKS resize

### DIFF
--- a/blivet/devicelibs/crypto.py
+++ b/blivet/devicelibs/crypto.py
@@ -25,5 +25,6 @@ from ..tasks import availability
 
 LUKS_METADATA_SIZE = Size("2 MiB")
 MIN_CREATE_ENTROPY = 256  # bits
+SECTOR_SIZE = Size("512 B")
 
 EXTERNAL_DEPENDENCIES = [availability.BLOCKDEV_CRYPTO_PLUGIN]

--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -664,9 +664,6 @@ class PartitionDevice(StorageDevice):
         if not self.exists:
             raise errors.DeviceError("device has not been created", self.name)
 
-        if not self.isleaf and not self.is_extended:
-            raise errors.DeviceError("Cannot destroy non-leaf device", self.name)
-
         self.teardown()
 
         if not self.sysfs_path:

--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -664,7 +664,11 @@ class PartitionDevice(StorageDevice):
         if not self.exists:
             raise errors.DeviceError("device has not been created", self.name)
 
-        self.teardown()
+        # don't teardown when resizing luks
+        if self.format.type == "luks" and self.children:
+            self.children[0].format.teardown()
+        else:
+            self.teardown()
 
         if not self.sysfs_path:
             return

--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -38,6 +38,7 @@ log = logging.getLogger("blivet")
 from .device import Device
 from .network import NetworkStorageDevice
 from .lib import LINUX_SECTOR_SIZE
+from ..devicelibs.crypto import LUKS_METADATA_SIZE
 
 
 class StorageDevice(Device):
@@ -616,7 +617,15 @@ class StorageDevice(Device):
     @property
     def min_size(self):
         """ The minimum size this device can be. """
-        return self.align_target_size(self.format.min_size) if self.resizable else self.current_size
+        if self.format.type == "luks" and self.children:
+            if self.resizable:
+                min_size = self.children[0].min_size + LUKS_METADATA_SIZE
+            else:
+                min_size = self.current_size
+        else:
+            min_size = self.align_target_size(self.format.min_size) if self.resizable else self.current_size
+
+        return min_size
 
     @property
     def max_size(self):

--- a/blivet/errors.py
+++ b/blivet/errors.py
@@ -86,6 +86,13 @@ class FormatTeardownError(DeviceFormatError):
     pass
 
 
+class FormatResizeError(DeviceFormatError):
+
+    def __init__(self, message, details):
+        DeviceFormatError.__init__(self, message)
+        self.details = details
+
+
 class DMRaidMemberError(DeviceFormatError):
     pass
 

--- a/blivet/formats/__init__.py
+++ b/blivet/formats/__init__.py
@@ -35,8 +35,17 @@ from ..util import ObjectID
 from ..storage_log import log_method_call
 from ..errors import DeviceFormatError, FormatCreateError, FormatDestroyError, FormatSetupError
 from ..i18n import N_
-from ..size import Size
+from ..size import Size, ROUND_DOWN, unit_str
 from ..threads import SynchronizedMeta
+from ..flags import flags
+
+from ..errors import FSError, FSResizeError #FIXME
+
+from ..tasks import fsinfo
+from ..tasks import fsresize
+from ..tasks import fssize
+from ..tasks import fsck
+from ..tasks import fsminsize
 
 import logging
 log = logging.getLogger("blivet")
@@ -174,6 +183,11 @@ class DeviceFormat(ObjectID, metaclass=SynchronizedMeta):
     _hidden = False                     # hide devices with this formatting?
     _ks_mountpoint = None
 
+    _resize_class = fsresize.UnimplementedFSResize
+    _size_info_class = fssize.UnimplementedFSSize
+    _info_class = fsinfo.UnimplementedFSInfo
+    _minsize_class = fsminsize.UnimplementedFSMinSize
+
     def __init__(self, **kwargs):
         """
             :keyword device: The path to the device node.
@@ -201,6 +215,22 @@ class DeviceFormat(ObjectID, metaclass=SynchronizedMeta):
         self.exists = kwargs.get("exists", False)
         self.options = kwargs.get("options")
         self._create_options = kwargs.get("create_options")
+
+        # Create task objects
+        self._info = self._info_class(self)
+        self._resize = self._resize_class(self)
+        # These two may depend on info class, so create them after
+        self._minsize = self._minsize_class(self)
+        self._size_info = self._size_info_class(self)
+
+        # format size does not necessarily equal device size
+        self._size = kwargs.get("size", Size(0))
+        self._target_size = self._size
+        self._min_instance_size = Size(0)    # min size of this DeviceFormat instance
+
+        # Resize operations are limited to error-free formats whose current
+        # size is known.
+        self._resizable = False
 
     def __repr__(self):
         s = ("%(classname)s instance (%(id)s) object id %(object_id)d--\n"
@@ -351,6 +381,138 @@ class DeviceFormat(ObjectID, metaclass=SynchronizedMeta):
     @property
     def type(self):
         return self._type
+
+    def _set_target_size(self, newsize):
+        """ Set the target size for this filesystem.
+
+            :param :class:`~.size.Size` newsize: the newsize
+        """
+        if not isinstance(newsize, Size):
+            raise ValueError("new size must be of type Size")
+
+        if not self.exists:
+            raise FSError("filesystem has not been created")
+
+        if not self.resizable:
+            raise FSError("filesystem is not resizable")
+
+        if newsize < self.min_size:
+            raise ValueError("requested size %s must be at least minimum size %s" % (newsize, self.min_size))
+
+        if self.max_size and newsize >= self.max_size:
+            raise ValueError("requested size %s must be less than maximum size %s" % (newsize, self.max_size))
+
+        self._target_size = newsize
+
+    def _get_target_size(self):
+        """ Get this filesystem's target size. """
+        return self._target_size
+
+    target_size = property(_get_target_size, _set_target_size,
+                           doc="Target size for this filesystem")
+
+    def _get_size(self):
+        """ Get this filesystem's size. """
+        return self.target_size if self.resizable else self._size
+
+    size = property(_get_size, doc="This filesystem's size, accounting "
+                    "for pending changes")
+
+    @property
+    def min_size(self):
+        # If self._min_instance_size is not 0, then it should be no less than
+        # self._min_size, by definition, and since a non-zero value indicates
+        # that it was obtained, it is the preferred value.
+        # If self._min_instance_size is less than self._min_size,
+        # but not 0, then there must be some mistake, so better to use
+        # self._min_size.
+        return max(self._min_instance_size, self._min_size)
+
+    def update_size_info(self):
+        """ Update this format's current and minimum size (for resize). """
+        pass
+
+    def do_resize(self):
+        """ Resize this filesystem based on this instance's target_size attr.
+
+            :raises: FSResizeError, FSError
+        """
+        if not self.exists:
+            raise FSResizeError("filesystem does not exist", self.device)
+
+        if not self.resizable:
+            raise FSResizeError("filesystem not resizable", self.device)
+
+        if self.target_size == self.current_size:
+            return
+
+        if not self._resize.available:
+            return
+
+        # tmpfs mounts don't need an existing device node
+        if not self.device == "tmpfs" and not os.path.exists(self.device):
+            raise FSResizeError("device does not exist", self.device)
+
+        # The first minimum size can be incorrect if the fs was not
+        # properly unmounted. After do_check the minimum size will be correct
+        # so run the check one last time and bump up the size if it was too
+        # small.
+        self.update_size_info()
+
+        # Check again if resizable is True, as update_size_info() can change that
+        if not self.resizable:
+            raise FSResizeError("filesystem not resizable", self.device)
+
+        if self.target_size < self.min_size:
+            self.target_size = self.min_size
+            log.info("Minimum size changed, setting target_size on %s to %s",
+                     self.device, self.target_size)
+
+        # Bump target size to nearest whole number of the resize tool's units.
+        # We always round down because the fs has to fit on whatever device
+        # contains it. To round up would risk quietly setting a target size too
+        # large for the device to hold.
+        rounded = self.target_size.round_to_nearest(self._resize.unit,
+                                                    rounding=ROUND_DOWN)
+
+        # 1. target size was between the min size and max size values prior to
+        #    rounding (see _set_target_size)
+        # 2. we've just rounded the target size down (or not at all)
+        # 3. the minimum size is already either rounded (see _get_min_size) or is
+        #    equal to the current size (see update_size_info)
+        # 5. the minimum size is less than or equal to the current size (see
+        #    _get_min_size)
+        #
+        # This, I think, is sufficient to guarantee that the rounded target size
+        # is greater than or equal to the minimum size.
+
+        # It is possible that rounding down a target size greater than the
+        # current size would move it below the current size, thus changing the
+        # direction of the resize. That means the target size was less than one
+        # unit larger than the current size, and we should do nothing and return
+        # early.
+        if self.target_size > self.current_size and rounded < self.current_size:
+            log.info("rounding target size down to next %s obviated resize of "
+                     "filesystem on %s", unit_str(self._resize.unit), self.device)
+            return
+        else:
+            self.target_size = rounded
+
+        try:
+            self._resize.do_task()
+        except FSError as e:
+            raise FSResizeError(e, self.device)
+
+        self._post_resize()
+
+    def _post_resize(self):
+        # XXX must be a smarter way to do this
+        self._size = self.target_size
+
+    @property
+    def current_size(self):
+        """ The filesystem's current actual size. """
+        return self._size if self.exists else Size(0)
 
     def create(self, **kwargs):
         """ Write the formatting to the specified block device.
@@ -577,17 +739,6 @@ class DeviceFormat(ObjectID, metaclass=SynchronizedMeta):
     def max_size(self):
         """ Maximum size for this format type. """
         return self._max_size
-
-    @property
-    def min_size(self):
-        """ Minimum size for this format instance.
-
-            :returns: the minimum size for this format instance
-            :rtype: :class:`~.size.Size`
-
-            A value of 0 indicates an unknown size.
-        """
-        return self._min_size
 
     @property
     def hidden(self):

--- a/blivet/osinstall.py
+++ b/blivet/osinstall.py
@@ -35,7 +35,7 @@ from . import get_sysroot, get_target_physical_root, error_handler, ERROR_RAISE
 
 from .storage_log import log_exception_info
 from .devices import FileDevice, NFSDevice, NoDevice, OpticalDevice, NetworkStorageDevice, DirectoryDevice, MDRaidArrayDevice
-from .errors import FSTabTypeMismatchError, UnrecognizedFSTabEntryError, StorageError, FSResizeError, UnknownSourceDeviceError
+from .errors import FSTabTypeMismatchError, UnrecognizedFSTabEntryError, StorageError, FSResizeError, FormatResizeError, UnknownSourceDeviceError
 from .formats import get_device_format_class
 from .formats import get_format
 from .flags import flags
@@ -1109,7 +1109,7 @@ def turn_on_filesystems(storage, mount_only=False, callbacks=None):
 
         try:
             storage.do_it(callbacks)
-        except FSResizeError as e:
+        except (FSResizeError, FormatResizeError) as e:
             if error_handler.cb(e) == ERROR_RAISE:
                 raise
         except Exception as e:

--- a/blivet/tasks/dfresize.py
+++ b/blivet/tasks/dfresize.py
@@ -25,11 +25,13 @@ from six import add_metaclass
 
 from . import task
 
+
 @add_metaclass(abc.ABCMeta)
 class DFResizeTask(task.Task):
     """ The abstract properties that any resize task must have. """
 
     unit = abc.abstractproperty(doc="Resize unit.")
+
 
 class UnimplementedDFResize(task.UnimplementedTask, DFResizeTask):
 

--- a/blivet/tasks/dfresize.py
+++ b/blivet/tasks/dfresize.py
@@ -1,0 +1,45 @@
+# dfresize.py
+# DeviceFormat resizing classes.
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Anne Mulhern <amulhern@redhat.com>
+
+import abc
+
+from six import add_metaclass
+
+from . import task
+
+@add_metaclass(abc.ABCMeta)
+class DFResizeTask(task.Task):
+    """ The abstract properties that any resize task must have. """
+
+    unit = abc.abstractproperty(doc="Resize unit.")
+
+class UnimplementedDFResize(task.UnimplementedTask, DFResizeTask):
+
+    def __init__(self, a_df):
+        """ Initializer.
+
+            :param DeviceFormat a_df: a device format object
+        """
+        self.df = a_df
+
+    @property
+    def unit(self):
+        raise NotImplementedError()

--- a/blivet/tasks/fsresize.py
+++ b/blivet/tasks/fsresize.py
@@ -29,11 +29,12 @@ from ..import util
 
 from . import availability
 from . import task
+from . import fstask
 from . import dfresize
 
 
 @add_metaclass(abc.ABCMeta)
-class FSResizeTask(dfresize.DFResizeTask):
+class FSResizeTask(fstask.FSTask):
     """ The abstract properties that any resize task must have. """
 
     size_fmt = abc.abstractproperty(doc="Size format string.")

--- a/blivet/tasks/fsresize.py
+++ b/blivet/tasks/fsresize.py
@@ -28,16 +28,14 @@ from ..size import B, KiB, MiB, GiB, KB, MB, GB
 from ..import util
 
 from . import availability
-from . import fstask
 from . import task
+from . import dfresize
 
 
 @add_metaclass(abc.ABCMeta)
-class FSResizeTask(fstask.FSTask):
-
+class FSResizeTask(dfresize.DFResizeTask):
     """ The abstract properties that any resize task must have. """
 
-    unit = abc.abstractproperty(doc="Resize unit.")
     size_fmt = abc.abstractproperty(doc="Size format string.")
 
 
@@ -135,11 +133,7 @@ class TmpFSResize(FSResize):
         return ['-o', ",".join(options), self.fs._type, self.fs.system_mountpoint]
 
 
-class UnimplementedFSResize(task.UnimplementedTask, FSResizeTask):
-
-    @property
-    def unit(self):
-        raise NotImplementedError()
+class UnimplementedFSResize(dfresize.UnimplementedDFResize, FSResizeTask):
 
     @property
     def size_fmt(self):

--- a/blivet/tasks/lukstasks.py
+++ b/blivet/tasks/lukstasks.py
@@ -19,6 +19,9 @@
 #
 # Red Hat Author(s): Anne Mulhern <amulhern@redhat.com>
 
+import gi
+gi.require_version("BlockDev", "1.0")
+
 from gi.repository import BlockDev as blockdev
 
 from .. import util
@@ -30,6 +33,7 @@ from ..size import Size
 from . import availability
 from . import task
 from . import dfresize
+
 
 class LUKSResize(task.BasicApplication, dfresize.DFResizeTask):
     """ Handle resize of LUKS device. """
@@ -48,9 +52,9 @@ class LUKSResize(task.BasicApplication, dfresize.DFResizeTask):
         """
         self.luks = a_luks
 
-    def doTask(self):
+    def do_task(self):
         """ Resizes the LUKS format. """
         try:
-            blockdev.crypto.luks_resize(self.luks.mapName, self.luks.targetSize.convertTo(self.unit))
+            blockdev.crypto.luks_resize(self.luks.map_name, self.luks.target_size.convert_to(self.unit))
         except blockdev.CryptoError as e:
             raise LUKSError(e)

--- a/blivet/tasks/lukstasks.py
+++ b/blivet/tasks/lukstasks.py
@@ -1,0 +1,56 @@
+# lukstasks.py
+# Tasks for a LUKS format.
+#
+# Copyright (C) 2015  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU General Public License v.2, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY expressed or implied, including the implied warranties of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+# Public License for more details.  You should have received a copy of the
+# GNU General Public License along with this program; if not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+# source code or documentation are not subject to the GNU General Public
+# License and may only be used or replicated with the express permission of
+# Red Hat, Inc.
+#
+# Red Hat Author(s): Anne Mulhern <amulhern@redhat.com>
+
+from gi.repository import BlockDev as blockdev
+
+from .. import util
+
+from ..devicelibs import crypto
+from ..errors import LUKSError
+from ..size import Size
+
+from . import availability
+from . import task
+from . import dfresize
+
+class LUKSResize(task.BasicApplication, dfresize.DFResizeTask):
+    """ Handle resize of LUKS device. """
+
+    description = "resize luks device"
+
+    ext = availability.BLOCKDEV_CRYPTO_PLUGIN
+
+    # units for specifying new size
+    unit = crypto.SECTOR_SIZE
+
+    def __init__(self, a_luks):
+        """ Initializer.
+
+            :param :class:`~.formats.luks.LUKS` a_luks: a LUKS format object
+        """
+        self.luks = a_luks
+
+    def doTask(self):
+        """ Resizes the LUKS format. """
+        try:
+            blockdev.crypto.luks_resize(self.luks.mapName, self.luks.targetSize.convertTo(self.unit))
+        except blockdev.CryptoError as e:
+            raise LUKSError(e)

--- a/release_notes.rst
+++ b/release_notes.rst
@@ -168,3 +168,8 @@ All code in blivet now conforms to
 names in the ``camelCase`` style have been renamed to the
 ``lower_case_with_underscores`` style. This applies to methods within classes,
 but not to the names of the classes themselves -- they still use ``CamelCase``.
+
+LUKS resize support
+-------------------
+
+Blivet now supports shrinking and growing existing LUKS encrypted devices.

--- a/tests/formats_test/luks_test.py
+++ b/tests/formats_test/luks_test.py
@@ -1,0 +1,47 @@
+from blivet.formats.luks import LUKS
+
+from blivet.size import Size
+
+from tests import loopbackedtestcase
+
+
+class LUKSTestCase(loopbackedtestcase.LoopBackedTestCase):
+
+    def __init__(self, methodName='run_test'):
+        super().__init__(methodName=methodName, device_spec=[Size("100 MiB")])
+        self.fmt = LUKS(passphrase="password")
+
+    def test_size(self):
+        self.fmt.device = self.loop_devices[0]
+
+        # create and open the luks format
+        self.fmt.create()
+        self.fmt.setup()
+
+        # without update_size_info size should be 0
+        self.assertEqual(self.fmt.current_size, Size(0))
+
+        # get current size
+        self.fmt.update_size_info()
+        self.assertGreater(self.fmt.current_size, Size(0))
+
+    def test_resize(self):
+        self.fmt.device = self.loop_devices[0]
+
+        # create and open the luks format
+        self.fmt.create()
+        self.fmt.setup()
+
+        # get current size to make format resizable
+        self.assertFalse(self.fmt.resizable)
+        self.fmt.update_size_info()
+        self.assertTrue(self.fmt.resizable)
+
+        # resize the format
+        new_size = Size("50 MiB")
+        self.fmt.target_size = new_size
+        self.fmt.do_resize()
+
+        # get current size
+        self.fmt.update_size_info()
+        self.assertEqual(self.fmt.current_size, new_size)


### PR DESCRIPTION
LUKS encrypted partitions resize support.

Known issues:
 - `LUKSFormat` has "wrong" `min_size` -- because minimal size depends on minimal size of LUKS device's format, it's not possible to set it for LUKS format. Slave device, LUKS device and filesystem have correct min_size.
 - Both `LUKSFormat` and `LUKSDevice` don't have `max_size` -- it depends on the slave device. We don't set max_size for formats (just limits), so it probably makes sense to set the max size correctly just for the slave device. But it would be easy to set the max_size correctly for the LUKS device.
 - Tasks -- I just took code from mulhern's original pull request and made changes to make pep8 and pylint happy. It works, but I don't have idea how :)
 - `FSError` and `FSResizeError` -- original `do_resize` and `_set_target_size` raised only these exceptions but it doesn't make sense for "non-filesystems". I've tried to change it to raise `DeviceFormatError` and `FormatResizeError` where it makes sense. Not sure if this is the best way.
 - There are no tests. I will add some next week.