### PR TITLE
handle system storage events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ install-requires:
 
 test: check-requires
 	@echo "*** Running unittests with $(PYTHON) ***"
-	PYTHONPATH=.:tests/ $(PYTHON) -m unittest discover -v -s tests/ -p '*_test.py'
+	PYTHONPATH=. $(PYTHON) -m unittest discover -v -s tests/ -p '*_test.py'
 
 coverage: check-requires
 	@echo "*** Running unittests with $(COVERAGE) for $(PYTHON) ***"

--- a/blivet/actionlist.py
+++ b/blivet/actionlist.py
@@ -28,6 +28,8 @@ from .deviceaction import action_type_from_string, action_object_from_string
 from .devicelibs import lvm
 from .devices import PartitionDevice
 from .errors import DiskLabelCommitError, StorageError
+from .events.changes import data as event_data
+from .events.changes import ActionCanceled
 from .flags import flags
 from . import tsort
 from .threads import blivet_lock, SynchronizedMeta
@@ -80,6 +82,7 @@ class ActionList(object, metaclass=SynchronizedMeta):
 
         action.cancel()
         self._actions.remove(action)
+        event_data.changes.append(ActionCanceled(action=action))
         log.info("canceled action %s", action)
 
     def find(self, device=None, action_type=None, object_type=None,

--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -642,18 +642,19 @@ class DeviceFactory(object):
             raise
 
         self.storage.create_device(device)
-        e = None
+        err = None
         try:
             self._post_create()
         except (StorageError, blockdev.BlockDevError) as e:
             log.error("device post-create method failed: %s", e)
+            err = str(e)
         else:
             if not device.size:
-                e = StorageError("failed to create device")
+                err = "failed to create device"
 
-        if e:
+        if err:
             self.storage.destroy_device(device)
-            raise StorageError(e)
+            raise StorageError(err)
 
         ret = device
         if self.encrypted:

--- a/blivet/devices/__init__.py
+++ b/blivet/devices/__init__.py
@@ -19,15 +19,15 @@
 # Red Hat Author(s): David Lehman <dlehman@redhat.com>
 #
 
-from .lib import get_device_majors, device_path_to_name, device_name_to_disk_by_path, ParentList
+from .lib import device_path_to_name, device_name_to_disk_by_path, ParentList
 from .device import Device
 from .storage import StorageDevice
 from .disk import DiskDevice, DiskFile, DMRaidArrayDevice, MultipathDevice, iScsiDiskDevice, FcoeDiskDevice, DASDDevice, ZFCPDiskDevice
 from .partition import PartitionDevice
-from .dm import DMDevice, DMLinearDevice, DMCryptDevice
+from .dm import DMDevice, DMLinearDevice, DMCryptDevice, DM_MAJORS
 from .luks import LUKSDevice
 from .lvm import LVMVolumeGroupDevice, LVMLogicalVolumeDevice
-from .md import MDBiosRaidArrayDevice, MDContainerDevice, MDRaidArrayDevice
+from .md import MDBiosRaidArrayDevice, MDContainerDevice, MDRaidArrayDevice, MD_MAJORS
 from .btrfs import BTRFSDevice, BTRFSVolumeDevice, BTRFSSubVolumeDevice, BTRFSSnapShotDevice
 from .file import FileDevice, DirectoryDevice, SparseFileDevice
 from .loop import LoopDevice

--- a/blivet/devices/btrfs.py
+++ b/blivet/devices/btrfs.py
@@ -76,7 +76,7 @@ class BTRFSDevice(StorageDevice):
         self.sysfs_path = self.parents[0].sysfs_path
         log.debug("%s sysfs_path set to %s", self.name, self.sysfs_path)
 
-    def update_size(self):
+    def update_size(self, newsize=None):
         pass
 
     def _post_create(self):

--- a/blivet/devices/container.py
+++ b/blivet/devices/container.py
@@ -191,5 +191,5 @@ class ContainerDevice(StorageDevice):
         if member in self.parents:
             self.parents.remove(member)
 
-    def update_size(self):
+    def update_size(self, newsize=None):
         pass

--- a/blivet/devices/dm.py
+++ b/blivet/devices/dm.py
@@ -37,7 +37,9 @@ import logging
 log = logging.getLogger("blivet")
 
 from .storage import StorageDevice
-from .lib import LINUX_SECTOR_SIZE
+from .lib import LINUX_SECTOR_SIZE, get_majors_by_device_type
+
+DM_MAJORS = get_majors_by_device_type("device-mapper")
 
 
 class DMDevice(StorageDevice):

--- a/blivet/devices/file.py
+++ b/blivet/devices/file.py
@@ -83,8 +83,8 @@ class FileDevice(StorageDevice):
 
         return os.path.normpath("%s%s" % (root, self.name))
 
-    def _get_size(self):
-        size = self._size
+    def read_current_size(self):
+        size = Size(0)
         if self.exists and os.path.exists(self.path):
             st = os.stat(self.path)
             size = Size(st[stat.ST_SIZE])

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -239,6 +239,7 @@ class LVMVolumeGroupDevice(ContainerDevice):
     def _post_create(self):
         self._complete = True
         super(LVMVolumeGroupDevice, self)._post_create()
+        self.format.exists = True
 
     def _pre_destroy(self):
         StorageDevice._pre_destroy(self)

--- a/blivet/devices/md.py
+++ b/blivet/devices/md.py
@@ -234,12 +234,12 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
 
         return size
 
-    def update_size(self):
+    def update_size(self, newsize=None):
         # container size is determined by the member disks, so there is nothing
         # to update in that case
         if self.type != "mdcontainer":
             # pylint: disable=bad-super-call
-            super(ContainerDevice, self).update_size()
+            super(ContainerDevice, self).update_size(newsize=newsize)
 
     @property
     def description(self):

--- a/blivet/devices/md.py
+++ b/blivet/devices/md.py
@@ -42,6 +42,9 @@ log = logging.getLogger("blivet")
 from .storage import StorageDevice
 from .container import ContainerDevice
 from .raid import RaidDevice
+from .lib import get_majors_by_device_type
+
+MD_MAJORS = get_majors_by_device_type("md")
 
 
 class MDRaidArrayDevice(ContainerDevice, RaidDevice):

--- a/blivet/devices/nfs.py
+++ b/blivet/devices/nfs.py
@@ -71,7 +71,7 @@ class NFSDevice(StorageDevice, NetworkStorageDevice):
         """ Destroy the device. """
         log_method_call(self, self.name, status=self.status)
 
-    def update_size(self):
+    def update_size(self, newsize=None):
         pass
 
     def is_name_valid(self, name):

--- a/blivet/devices/nodev.py
+++ b/blivet/devices/nodev.py
@@ -72,7 +72,7 @@ class NoDevice(StorageDevice):
         log_method_call(self, self.name, status=self.status)
         self._pre_destroy()
 
-    def update_size(self):
+    def update_size(self, newsize=None):
         pass
 
 

--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -66,7 +66,7 @@ class PartitionDevice(StorageDevice):
     _resizable = True
     default_size = DEFAULT_PART_SIZE
 
-    def __init__(self, name, fmt=None,
+    def __init__(self, name, fmt=None, uuid=None,
                  size=None, grow=False, maxsize=None, start=None, end=None,
                  major=None, minor=None, bootable=None,
                  sysfs_path='', parents=None, exists=False,
@@ -85,6 +85,7 @@ class PartitionDevice(StorageDevice):
 
             For existing partitions only:
 
+            :keyword str uuid: partition UUID (not filesystem UUID)
             :keyword major: the device major
             :type major: long
             :keyword minor: the device minor
@@ -142,7 +143,7 @@ class PartitionDevice(StorageDevice):
             else:
                 size = self.default_size
 
-        StorageDevice.__init__(self, name, fmt=fmt, size=size,
+        StorageDevice.__init__(self, name, fmt=fmt, uuid=uuid, size=size,
                                major=major, minor=minor, exists=exists,
                                sysfs_path=sysfs_path, parents=parents)
 

--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -588,9 +588,24 @@ class StorageDevice(Device):
             self._current_size = self.read_current_size()
         return self._current_size
 
-    def update_size(self):
-        """ Update size, current_size, and target_size to actual size. """
-        self._current_size = Size(0)
+    def update_size(self, newsize=None):
+        """ Update size, current_size, and target_size to actual size.
+
+            :keyword :class:`~.size.Size` newsize: new size for device
+
+            .. note::
+
+                Most callers will not pass a new size. It is for special cases
+                like outside resize of inactive LVs, which precludes updating
+                the size from /sys.
+        """
+        if newsize is None:
+            self._currentSize = Size(0)
+        elif isinstance(newsize, Size):
+            self._currentSize = newsize
+        else:
+            raise ValueError("new size must be an instance of class Size")
+
         new_size = self.current_size
         self._size = new_size
         self._target_size = new_size  # bypass setter checks

--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -300,23 +300,6 @@ class StorageDevice(Device):
                 (self.format.type is None or self.format.resizable or
                  not self.format.exists))
 
-    def notify_kernel(self):
-        """ Send a 'change' uevent to the kernel for this device. """
-        log_method_call(self, self.name, status=self.status)
-        if not self.exists:
-            log.debug("not sending change uevent for non-existent device")
-            return
-
-        if not self.status:
-            log.debug("not sending change uevent for inactive device")
-            return
-
-        path = os.path.normpath(self.sysfs_path)
-        try:
-            util.notify_kernel(path, action="change")
-        except (ValueError, IOError) as e:
-            log.warning("failed to notify kernel of change: %s", e)
-
     @property
     def fstab_spec(self):
         spec = self.path

--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -140,8 +140,10 @@ class StorageDevice(Device):
 
         self.device_links = []
 
-        if self.exists and self.status:
-            self.update_size()
+        if self.exists:
+            self.update_sysfs_path()
+            if self.status:
+                self.update_size()
 
     def __str__(self):
         exist = "existing"

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -204,11 +204,12 @@ class DeviceTreeBase(object, metaclass=SynchronizedMeta):
                  dev.name,
                  dev.id)
 
-    def recursive_remove(self, device, actions=True, remove_device=True):
+    def recursive_remove(self, device, actions=True, remove_device=True, modparent=True):
         """ Remove a device after removing its dependent devices.
 
             :param :class:`~.devices.StorageDevice` device: the device to remove
             :keyword bool actions: whether to schedule actions for the removal
+            :keyword bool modparent: whether to update parent device upon removal
             :keyword bool remove_device: whether to remove the root device
 
             If the device is not a leaf, all of its dependents are removed
@@ -240,7 +241,7 @@ class DeviceTreeBase(object, metaclass=SynchronizedMeta):
                 else:
                     if not leaf.format_immutable:
                         leaf.format = None
-                    self._remove_device(leaf)
+                    self._remove_device(leaf, modparent=modparent)
 
                 devices.remove(leaf)
 
@@ -254,7 +255,7 @@ class DeviceTreeBase(object, metaclass=SynchronizedMeta):
             if actions:
                 self.actions.add(ActionDestroyDevice(device))
             else:
-                self._remove_device(device)
+                self._remove_device(device, modparent=modparent)
 
     #
     # Actions

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -36,6 +36,7 @@ from .devices import BTRFSDevice, NoDevice, PartitionDevice
 from .devices import LVMLogicalVolumeDevice, LVMVolumeGroupDevice
 from . import formats
 from .devicelibs import lvm
+from .events.handler import EventHandlerMixin
 from . import util
 from .populator import PopulatorMixin
 from .storage_log import log_method_call, log_method_return
@@ -925,10 +926,11 @@ class DeviceTreeBase(object, metaclass=SynchronizedMeta):
                     self.hide(disk)
 
 
-class DeviceTree(DeviceTreeBase, PopulatorMixin):
+class DeviceTree(DeviceTreeBase, PopulatorMixin, EventHandlerMixin):
     def __init__(self, conf=None, passphrase=None, luks_dict=None):
         DeviceTreeBase.__init__(self, conf=conf)
         PopulatorMixin.__init__(self, passphrase=passphrase, luks_dict=luks_dict)
+        EventHandlerMixin.__init__(self)
 
     # pylint: disable=arguments-differ
     def reset(self, conf=None, passphrase=None, luks_dict=None):

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -204,11 +204,12 @@ class DeviceTreeBase(object, metaclass=SynchronizedMeta):
                  dev.name,
                  dev.id)
 
-    def recursive_remove(self, device, actions=True):
+    def recursive_remove(self, device, actions=True, remove_device=True):
         """ Remove a device after removing its dependent devices.
 
             :param :class:`~.devices.StorageDevice` device: the device to remove
             :keyword bool actions: whether to schedule actions for the removal
+            :keyword bool remove_device: whether to remove the root device
 
             If the device is not a leaf, all of its dependents are removed
             recursively until it is a leaf device. At that point the device is
@@ -249,7 +250,7 @@ class DeviceTreeBase(object, metaclass=SynchronizedMeta):
             else:
                 device.format = None
 
-        if not device.is_disk:
+        if remove_device and not device.is_disk:
             if actions:
                 self.actions.add(ActionDestroyDevice(device))
             else:

--- a/blivet/errors.py
+++ b/blivet/errors.py
@@ -261,6 +261,13 @@ class DeviceFactoryError(StorageError):
 class AvailabilityError(StorageError):
 
     """ Raised if problem determining availability of external resource. """
+
+
+class EventManagerError(StorageError):
+    pass
+
+
+class EventParamError(StorageError):
     pass
 
 # external dependencies

--- a/blivet/errors.py
+++ b/blivet/errors.py
@@ -279,3 +279,8 @@ class DependencyError(StorageError):
 
 class EventHandlingError(StorageError):
     pass
+
+
+class ThreadError(StorageError):
+    """ An error occurred in a non-main thread. """
+    pass

--- a/blivet/errors.py
+++ b/blivet/errors.py
@@ -276,3 +276,6 @@ class EventParamError(StorageError):
 class DependencyError(StorageError):
     """Raised when an external dependency is missing or not available"""
     pass
+
+class EventHandlingError(StorageError):
+    pass

--- a/blivet/events/changes.py
+++ b/blivet/events/changes.py
@@ -1,0 +1,78 @@
+# events/changes.py
+# Per-thread change accounting data structures.
+#
+# Copyright (C) 2016  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU Lesser General Public License v.2, or (at your option) any later
+# version. This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY expressed or implied, including the implied
+# warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+# the GNU Lesser General Public License for more details.  You should have
+# received a copy of the GNU Lesser General Public License along with this
+# program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+# Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat trademarks
+# that are incorporated in the source code or documentation are not subject
+# to the GNU Lesser General Public License and may only be used or
+# replicated with the express permission of Red Hat, Inc.
+#
+# Red Hat Author(s): David Lehman <dlehman@redhat.com>
+#
+
+from threading import local
+
+from .. import util
+
+
+data = local()
+""" Thread-local data for event handler threads. """
+
+data.changes = list()  # Saves checking if the list exists in the main thread.
+
+
+""" Accounting for changes made in response to an event.
+
+    We want to end up with a single, ordered list containing every change
+    that was made in response to a specific event.
+"""
+_DeviceAdded = util.default_namedtuple("DeviceAdded", ["device"])
+_DeviceRemoved = util.default_namedtuple("DeviceRemoved", ["device"])
+_ActionCanceled = util.default_namedtuple("ActionCanceled", ["action"])
+_ParentAdded = util.default_namedtuple("ListItemAdded", ["device", "item"])
+_ParentRemoved = util.default_namedtuple("ListItemRemoved", ["device", "item"])
+_AttributeChanged = util.default_namedtuple("AttrChanged", ["device", ("fmt", None), "attr", "old", "new"])
+
+
+class DeviceAdded(_DeviceAdded):
+    def __str__(self):
+        return "add device '%s'" % str(self.device)
+
+
+class DeviceRemoved(_DeviceRemoved):
+    def __str__(self):
+        return "remove device %s" % self.device.name
+
+
+class ActionCanceled(_ActionCanceled):
+    def __str__(self):
+        return "cancel action '%s'" % str(self.action)
+
+
+class ParentAdded(_ParentAdded):
+    def __str__(self):
+        return "add parent %s to %s" % (self.item.name, self.device.name)
+
+
+class ParentRemoved(_ParentRemoved):
+    def __str__(self):
+        return "remove parent %s from %s" % (self.item.name, self.device.name)
+
+
+class AttributeChanged(_AttributeChanged):
+    def __str__(self):
+        return "change attribute %s of %s%s from '%s' to '%s'" % (self.attr,
+                                                                  self.device.name,
+                                                                  " format" if self.fmt else "",
+                                                                  str(self.old),
+                                                                  str(self.new))

--- a/blivet/events/handler.py
+++ b/blivet/events/handler.py
@@ -119,6 +119,11 @@ class EventHandlerMixin(metaclass=SynchronizedMeta):
         if device is None:
             device = self.get_device_by_uuid(event.info.get("UUID_SUB", udev.device_get_uuid(event.info)),
                                              hidden=True)
+            if device is None and udev.device_is_dm_luks(event.info):
+                # Special case for first-time decrypted LUKS devices since we do not add a
+                # device for the decrypted/mapped device until it has been opened.
+                self.handle_device(event.info)
+                device = self.get_device_by_name(udev.device_get_name(event.info), hidden=True)
 
         # XXX Don't change anything (except simple attributes?) if actions are being executed.
         if device is None and self._event_device_is_physical_disk(event):

--- a/blivet/events/handler.py
+++ b/blivet/events/handler.py
@@ -1,0 +1,226 @@
+# events/handler.py
+# Event handler mixin class.
+#
+# Copyright (C) 2015-2016  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU Lesser General Public License v.2, or (at your option) any later
+# version. This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY expressed or implied, including the implied
+# warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+# the GNU Lesser General Public License for more details.  You should have
+# received a copy of the GNU Lesser General Public License along with this
+# program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+# Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat trademarks
+# that are incorporated in the source code or documentation are not subject
+# to the GNU Lesser General Public License and may only be used or
+# replicated with the express permission of Red Hat, Inc.
+#
+# Red Hat Author(s): David Lehman <dlehman@redhat.com>
+#
+
+from ..errors import DeviceError, EventHandlingError
+from ..devices import DM_MAJORS, MD_MAJORS
+from .. import udev
+from ..threads import SynchronizedMeta
+
+from .manager import event_manager
+
+import logging
+log = logging.getLogger("blivet")
+event_log = logging.getLogger("blivet.event")
+
+
+class EventHandlerMixin(metaclass=SynchronizedMeta):
+    def __init__(self):
+        event_manager.handler_cb = self.handle_event
+
+    def handle_event(self, event):
+        """ Handle an event on a block device.
+
+            :param :class:`~.event.Event` event: information about the event
+
+            TODO: Rename all this stuff so it's explicit that it only handles uevents.
+        """
+        # delegate event to appropriate handler
+        handlers = {"add": self._handle_add_event,
+                    "change": self._handle_change_event,
+                    "remove": self._handle_remove_event}
+
+        handler = handlers.get(event.action)
+        if handler is not None:
+            handler(event)
+
+    def _event_device_is_dm(self, event):
+        """ Return True if event operand is a dm device.
+
+            Since this may be run on add events it does not require the dm/
+            subdirectory be present in the device's sysfs root, unlike
+            udev.device_is_dm.
+
+            XXX Should this replace udev.device_is_dm?
+        """
+        return udev.device_get_major(event.info) in DM_MAJORS
+
+    def _event_device_is_md(self, event):
+        """ Return True if event operand is a dm device.
+
+            Since this may be run on add events it does not require the md/
+            subdirectory be present in the device's sysfs root, unlike
+            udev.device_is_md.
+
+            XXX Should this replace udev.device_is_md?
+        """
+        return udev.device_get_major(event.info) in MD_MAJORS
+
+    def _should_ignore_add_event(self, event):
+        """ Return True if event is an add event that should be ignored.
+
+            add events on md and dm devices should be ignored in general. When the
+            operation is complete there will be a change event.
+        """
+        # udev.device_is_md and udev.device_is_dm are not sufficient for this purpose
+        # because there are sometimes events when dm/ or md/ subdir does not exist.
+        return (event.action == "add" and
+                (self._event_device_is_dm(event) or self._event_device_is_md(event)))
+
+    def _event_device_is_physical_disk(self, event):
+        """ Return True if event device is a physical disk. """
+        # udev.device_is_md and udev.device_is_dm are not sufficient for this purpose
+        # because there are sometimes events when dm/ or md/ subdir does not exist.
+        return (self._udev_device_is_disk(event.info) and
+                not self._event_device_is_dm(event) and
+                not self._event_device_is_md(event))
+
+    def _handle_add_event(self, event):
+        """ Handle an "add" event.
+
+            Add events should correlate to activation rather than creation in
+            most cases. When a device is added, there is generally a change
+            event on the new device's parent(s). The obvious exception to this
+            rule is the addition of a new disk, which has no parents.
+        """
+        # ignore add on dm and md devices
+        if self._should_ignore_add_event(event):
+            return
+
+        # Try to look up the device. Do not look it up by sysfs path since in all
+        # likelihood blivet thinks the device is not active and therefore has no
+        # sysfs path.
+        # XXX We need an existing device here, so we should also be checking destroy actions.
+        device = self.get_device_by_name(udev.device_get_name(event.info), hidden=True)
+        if device is None:
+            device = self.get_device_by_uuid(event.info.get("UUID_SUB", udev.device_get_uuid(event.info)),
+                                             hidden=True)
+
+        # XXX Don't change anything (except simple attributes?) if actions are being executed.
+        if device is None and self._event_device_is_physical_disk(event):
+            log.info("disk %s was added", udev.device_get_name(event.info))
+            self.handle_device(event.info)
+        elif device is not None and device.exists:
+            log.info("device %s was activated", device.name)
+            # device was activated from outside, so update the sysfs path
+            device.sysfs_path = udev.device_get_sysfs_path(event.info)
+
+    def _handle_format_change(self, event, device):
+        helper_class = self._get_format_helper(event.info, device)  # pylint: disable=no-member
+        helper = helper_class(self, event.info, device=device)
+        new_type = helper.type_spec
+        old_type = device.format.type
+
+        new_uuid = helper._get_kwargs().get("uuid")
+        old_uuid = device.format.uuid
+
+        # If the type has changed it has been reformatted. Easy.
+        # If the type is unchanged and the UUID has changed, it could be a change to
+        # the UUID or a reformat. Is it worthwhile to try to differentiate?
+        log.debug("old_type=%-8s ; old_uuid=%-16s", old_type, old_uuid)
+        log.debug("new_type=%-8s ; new_uuid=%-16s", new_type, new_uuid)
+        if new_type == old_type and new_uuid == old_uuid and not self.actions.processing:
+            helper.update()
+            return
+
+        if self.actions.processing:
+            return
+
+        self.cancel_disk_actions(device.disks)
+
+        # The device was reformatted, but we can't blindly remove all children since
+        # it could have been a member of a still-intact container.
+        if getattr(device.format, "container_uuid", None):
+            container = device.children[0]
+            if len(container.parents) > 1:
+                try:
+                    container.parents.remove(device)
+                except DeviceError as e:
+                    log.error("error removing member %s from container %s: %s",
+                              device.name, container.name, str(e))
+                    raise EventHandlingError("reformatted container member")
+
+        self.recursive_remove(device, actions=False, remove_device=False)
+
+        helper.run()
+
+    def _handle_change_event(self, event):
+        """ Handle a "change" event.
+
+            This could be any number of things, including activation of md/dm
+            devices.
+        """
+        name = udev.device_get_name(event.info)
+        if (name.startswith("dm-") or name.startswith("md")) and name == event.info.sys_name:
+            log.debug("ignoring event on virtual device %s with no symbolic name", name)
+            return
+
+        if self._event_device_is_md(event) or self._event_device_is_dm(event):
+            self._handle_add_event(event)
+
+        # Try to look up the device in the devicetree.
+        # We're expecting the device to already be active, so we try the lookup
+        # by sysfs path first.
+        device = self.get_device_by_sysfs_path(udev.device_get_sysfs_path(event.info))
+        if device is None:
+            # Lookup by sysfs path failed. Try looking it up by name.
+            device = self.get_device_by_name(udev.device_get_name(event.info))
+
+        if device is None:
+            log.debug("failed to look up device")
+            return
+
+        if not device.exists:
+            log.debug("device lookup returned a non-existent device")
+            return
+
+        log.info("device %s was changed", device.name)
+
+        helper_class = self._get_device_helper(event.info)  # pylint: disable=no-member
+        if helper_class is not None:
+            helper = helper_class(self, event.info, device=device)
+            helper.update()
+
+        # check for metadata changes, but do not make changes to the devicetree
+        # during action processing
+        self._handle_format_change(event, device)
+
+    def _handle_remove_event(self, event):
+        """ Handle a "remove" event.
+
+            Remove events correlate to deactivation or removal, but we will
+            use change events on parent devices to detect removal.
+        """
+        # XXX We need an existing device here.
+        device = self.get_device_by_sysfs_path(udev.device_get_sysfs_path(event.info))
+        if device is None:
+            device = self.get_device_by_name(udev.device_get_name(event.info))
+
+        if device is None:
+            return
+
+        if self._event_device_is_physical_disk(event):
+            log.info("disk %s was removed", device.name)
+            self._remove_device(device)
+        else:
+            log.info("device %s was deactivated", device.name)
+            # device was deactivated from outside, so clear the sysfs path
+            device.sysfs_path = ''

--- a/blivet/events/handler.py
+++ b/blivet/events/handler.py
@@ -38,10 +38,11 @@ class EventHandlerMixin(metaclass=SynchronizedMeta):
     def __init__(self):
         event_manager.handler_cb = self.handle_event
 
-    def handle_event(self, event):
+    def handle_event(self, event, notify_cb):
         """ Handle an event on a block device.
 
             :param :class:`~.event.Event` event: information about the event
+            :param callable notify_cb: notification callback
 
             TODO: Rename all this stuff so it's explicit that it only handles uevents.
         """
@@ -53,6 +54,9 @@ class EventHandlerMixin(metaclass=SynchronizedMeta):
         handler = handlers.get(event.action)
         if handler is not None:
             handler(event)
+
+        if notify_cb is not None:
+            notify_cb(event=event, changes=event_data.changes)
 
     def _event_device_is_dm(self, event):
         """ Return True if event operand is a dm device.

--- a/blivet/events/manager.py
+++ b/blivet/events/manager.py
@@ -256,7 +256,9 @@ class EventManager(object, metaclass=abc.ABCMeta):
             return
 
         try:
-            self.handler_cb(event)  # pylint: disable=not-callable
+            # Pass the notify callback to the handler so it can run the
+            # callback and pass thread-local data to it.
+            self.handler_cb(event=event, notify_cb=self.notify_cb)  # pylint: disable=not-callable
         except Exception:  # pylint: disable=broad-except
             event_log.error(traceback.format_exc())
             exc_info = sys.exc_info()

--- a/blivet/events/manager.py
+++ b/blivet/events/manager.py
@@ -21,7 +21,7 @@
 #
 
 import abc
-from threading import RLock, Thread, current_thread
+from threading import current_thread, RLock, Thread
 import pyudev
 import sys
 import time
@@ -32,6 +32,8 @@ from .. import udev
 from .. import util
 from ..errors import EventManagerError, EventParamError
 from ..flags import flags
+
+from .changes import data
 
 import logging
 event_log = logging.getLogger("blivet.event")
@@ -247,6 +249,9 @@ class EventManager(object, metaclass=abc.ABCMeta):
 
     def _run_event_handler(self, event):
         """ Run the event handler and account for unhandled exceptions. """
+        # initialize thread-local data attribute for change accounting
+        data.changes = list()
+
         if self.handler_cb is None:
             return
 

--- a/blivet/events/manager.py
+++ b/blivet/events/manager.py
@@ -1,0 +1,252 @@
+# events/manager.py
+# Event management classes.
+#
+# Copyright (C) 2015-2016  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU Lesser General Public License v.2, or (at your option) any later
+# version. This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY expressed or implied, including the implied
+# warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+# the GNU Lesser General Public License for more details.  You should have
+# received a copy of the GNU Lesser General Public License along with this
+# program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+# Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat trademarks
+# that are incorporated in the source code or documentation are not subject
+# to the GNU Lesser General Public License and may only be used or
+# replicated with the express permission of Red Hat, Inc.
+#
+# Red Hat Author(s): David Lehman <dlehman@redhat.com>
+#
+
+import abc
+from threading import RLock, Thread
+import pyudev
+import time
+
+from .. import udev
+from .. import util
+from ..errors import EventManagerError, EventParamError
+from ..flags import flags
+from ..threads import blivet_lock
+
+import logging
+event_log = logging.getLogger("blivet.event")
+
+
+#
+# Event
+#
+class Event(util.ObjectID):
+    """ An external event. """
+    def __init__(self, action, device, info=None):
+        """
+            :param str action: a string describing the type of event
+            :param str device: (friendly) basename of device event operated on
+            :param info: information about the device
+        """
+        self.initialized = time.time()
+        self.action = action
+        self.device = device
+        self.info = info
+
+    def __str__(self):
+        return "%s %s [%d]" % (self.action, self.device, self.id)
+
+
+class EventMask(util.ObjectID):
+    """ Specification of events to ignore. """
+    def __init__(self, device=None, action=None, partitions=False):
+        """
+            :keyword str device: basename of device to mask events on
+            :keyword str action: action type to mask events of
+            :keyword bool partitions: also match events on child partitions
+        """
+        self.device = device
+        self.action = action
+        self._partitions = partitions
+
+    def _device_match(self, event):
+        if self.device is None:
+            return True
+
+        if self.device == event.device:
+            return True
+
+        if (not self._partitions or
+                not (udev.device_is_partition(event.info) or udev.device_is_dm_partition(event.info))):
+            return False
+
+        disk = udev.device_get_partition_disk(event.info)
+        return disk and self.device == disk
+
+    def _action_match(self, event):
+        return self.action is None or self.action == event.action
+
+    def match(self, event):
+        """ Return True if this mask applies to the specified event.
+
+            ..note::
+
+                A mask whose device is a partitioned disk will match events
+                on its partitions.
+        """
+        return self._device_match(event) and self._action_match(event)
+
+
+#
+# EventManager
+#
+class EventManager(object, metaclass=abc.ABCMeta):
+    def __init__(self, handler_cb=None, notify_cb=None):
+        self._handler_cb = None
+        self._notify_cb = None
+
+        if handler_cb is not None:
+            self.handler_cb = handler_cb
+
+        if notify_cb is not None:
+            self.notify_cb = notify_cb
+
+        self._mask_list = list()
+        """List of masks specifying events that should be ignored."""
+
+        self._lock = RLock()
+        """Re-entrant lock to serialize access to mask list."""
+
+    @property
+    def handler_cb(self):
+        """ the main event handler """
+        return self._handler_cb
+
+    @handler_cb.setter
+    def handler_cb(self, cb):
+        if not callable(cb):
+            raise EventParamError("handler must be callable")
+
+        self._handler_cb = cb
+
+    @property
+    def notify_cb(self):
+        """ notification handler that runs after the main event handler """
+        return self._notify_cb
+
+    @notify_cb.setter
+    def notify_cb(self, cb):
+        if not callable(cb) or cb.func_code.argcount < 1:
+            raise EventParamError("callback function must accept at least one arg")
+
+        self._notify_cb = cb
+
+    @abc.abstractproperty
+    def enabled(self):
+        return False
+
+    @abc.abstractmethod
+    def enable(self):
+        """ Enable monitoring and handling of events.
+
+            :raises: :class:`~.errors.EventManagerError` if no callback defined
+        """
+        if self.handler_cb is None:
+            raise EventManagerError("cannot enable handler with no callback")
+
+        event_log.info("enabling event handling")
+
+    @abc.abstractmethod
+    def disable(self):
+        """ Disable monitoring and handling of events. """
+        event_log.info("disabling event handling")
+
+    def _mask_event(self, event):
+        """ Return True if this event should be ignored """
+        with self._lock:
+            return next((m for m in self._mask_list if m.match(event)), None) is not None
+
+    def add_mask(self, device=None, action=None, partitions=False):
+        """ Add an event mask and return the new :class:`EventMask`.
+
+            :keyword str device: ignore events on the named device
+            :keyword str action: ignore events of the specified type
+            :keyword bool partitions: also match events on child partitions
+
+            device of None means mask events on all devices
+            action of None means mask all event types
+        """
+        em = EventMask(device=device, action=action, partitions=partitions)
+        with self._lock:
+            self._mask_list.append(em)
+        return em
+
+    def remove_mask(self, mask):
+        try:
+            with self._lock:
+                self._mask_list.remove(mask)
+        except ValueError:
+            pass
+
+    @abc.abstractmethod
+    def _create_event(self, *args, **kwargs):
+        pass
+
+    def handle_event(self, *args, **kwargs):
+        """ Handle an event by running the registered handler.
+
+            Currently the handler is run in a separate thread. This removes any
+            threading-related expectations about the behavior of whatever is
+            telling us about the events.
+        """
+        event = self._create_event(*args, **kwargs)
+        event_log.debug("new event: %s", event)
+
+        if self._mask_event(event):
+            event_log.debug("ignoring masked event %s", event)
+            return
+
+        t = Thread(target=self.handler_cb,
+                   name="event%d" % event.id,
+                   kwargs={"event": event},
+                   daemon=True)
+        t.start()
+
+
+class UdevEventManager(EventManager):
+    def __init__(self, handler_cb=None, notify_cb=None):
+        super().__init__(handler_cb=handler_cb, notify_cb=notify_cb)
+        self._pyudev_observer = None
+
+    @property
+    def enabled(self):
+        return self._pyudev_observer and self._pyudev_observer.monitor.started
+
+    def enable(self):
+        """ Enable monitoring and handling of block device uevents. """
+        super().enable()
+        monitor = pyudev.Monitor.from_netlink(udev.global_udev)
+        monitor.filter_by("block")
+        self._pyudev_observer = pyudev.MonitorObserver(monitor,
+                                                       callback=self.handle_event,
+                                                       name="monitor")
+        self._pyudev_observer.start()
+        with blivet_lock:
+            flags.uevents = True
+
+    def disable(self):
+        """ Disable monitoring and handling of block device uevents. """
+        super().disable()
+        if self.enabled:
+            self._pyudev_observer.stop()
+
+        self._pyudev_observer = None
+        with blivet_lock:
+            flags.uevents = False
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+    def _create_event(self, *args, **kwargs):
+        return Event(args[0].action, udev.device_get_name(args[0]), args[0])
+
+
+event_manager = UdevEventManager()

--- a/blivet/flags.py
+++ b/blivet/flags.py
@@ -34,6 +34,11 @@ class Flags(object):
         self.debug = False
 
         #
+        # minor modes
+        #
+        self.uevents = False
+
+        #
         # minor modes (installer-specific)
         #
         self.automated_install = False

--- a/blivet/formats/disklabel.py
+++ b/blivet/formats/disklabel.py
@@ -49,6 +49,7 @@ class DiskLabel(DeviceFormat):
         """
             :keyword device: full path to the block device node
             :type device: str
+            :keyword str uuid: disklabel UUID
             :keyword label_type: type of disklabel to create
             :type label_type: str
             :keyword exists: whether the formatting exists

--- a/blivet/formats/disklabel.py
+++ b/blivet/formats/disklabel.py
@@ -243,12 +243,6 @@ class DiskLabel(DeviceFormat):
         # other problems.
         self.commit()
 
-    def _destroy(self, **kwargs):
-        """ Wipe the disklabel from the device. """
-        log_method_call(self, device=self.device,
-                        type=self.type, status=self.status)
-        self.parted_device.clobber()
-
     def commit(self):
         """ Commit the current partition table to disk and notify the OS. """
         log_method_call(self, device=self.device,

--- a/blivet/formats/disklabel.py
+++ b/blivet/formats/disklabel.py
@@ -120,6 +120,11 @@ class DiskLabel(DeviceFormat):
                   "grain_size": self.get_alignment().grainSize})
         return d
 
+    def update_parted_disk(self):
+        """ re-read the disklabel from the device """
+        self._parted_disk = None
+        self.update_orig_parted_disk()
+
     def update_orig_parted_disk(self):
         self._orig_parted_disk = self.parted_disk.duplicate()
 

--- a/blivet/formats/disklabel.py
+++ b/blivet/formats/disklabel.py
@@ -27,6 +27,7 @@ import parted
 import _ped
 from ..errors import DiskLabelCommitError, InvalidDiskLabelError, AlignmentError
 from .. import arch
+from ..events.manager import event_manager
 from .. import udev
 from .. import util
 from ..flags import flags
@@ -124,7 +125,10 @@ class DiskLabel(DeviceFormat):
     def update_parted_disk(self):
         """ re-read the disklabel from the device """
         self._parted_disk = None
+        mask = event_manager.add_mask(device=os.path.basename(self.device), partitions=True)
         self.update_orig_parted_disk()
+        udev.settle()
+        event_manager.remove_mask(mask)
 
     def update_orig_parted_disk(self):
         self._orig_parted_disk = self.parted_disk.duplicate()

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -986,6 +986,14 @@ class BTRFS(FS):
         # Don't try to mount it if there's no mountpoint.
         return bool(self.mountpoint or kwargs.get("mountpoint"))
 
+    @property
+    def container_uuid(self):
+        return self.vol_uuid
+
+    @container_uuid.setter
+    def container_uuid(self, uuid):
+        self.vol_uuid = uuid
+
 register_device_format(BTRFS)
 
 

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -515,7 +515,6 @@ class FS(DeviceFormat):
 
         # XXX must be a smarter way to do this
         self._size = self.target_size
-        self.notify_kernel()
 
     def do_check(self):
         """ Run a filesystem check.
@@ -747,7 +746,6 @@ class FS(DeviceFormat):
             raise FSError("device does not exist")
 
         self._writelabel.do_task()
-        self.notify_kernel()
 
     @property
     def utils_available(self):
@@ -1229,10 +1227,6 @@ class NoDevFS(FS):
     @property
     def type(self):
         return self.device
-
-    def notify_kernel(self):
-        # NoDevFS should not need to tell the kernel anything.
-        pass
 
 register_device_format(NoDevFS)
 

--- a/blivet/formats/lvmpv.py
+++ b/blivet/formats/lvmpv.py
@@ -159,4 +159,12 @@ class LVMPhysicalVolume(DeviceFormat):
     def free(self, value):
         self._free = value
 
+    @property
+    def container_uuid(self):
+        return self.vg_uuid
+
+    @container_uuid.setter
+    def container_uuid(self, uuid):
+        self.vg_uuid = uuid
+
 register_device_format(LVMPhysicalVolume)

--- a/blivet/formats/lvmpv.py
+++ b/blivet/formats/lvmpv.py
@@ -117,12 +117,6 @@ class LVMPhysicalVolume(DeviceFormat):
 
         # Consider use of -Z|--zero
         # -f|--force or -y|--yes may be required
-
-        # lvm has issues with persistence of metadata, so here comes the
-        # hammer...
-        # XXX This format doesn't exist yet, so bypass the precondition checking
-        #     for destroy by calling _destroy directly.
-        DeviceFormat._destroy(self, **kwargs)
         blockdev.lvm.pvscan(self.device)
         blockdev.lvm.pvcreate(self.device, data_alignment=self.data_alignment)
         blockdev.lvm.pvscan(self.device)

--- a/blivet/formats/mdraid.py
+++ b/blivet/formats/mdraid.py
@@ -104,6 +104,14 @@ class MDRaidMember(DeviceFormat):
     def hidden(self):
         return super(MDRaidMember, self).hidden or self.biosraid
 
+    @property
+    def container_uuid(self):
+        return self.md_uuid
+
+    @container_uuid.setter
+    def container_uuid(self, uuid):
+        self.md_uuid = uuid
+
 # nodmraid -> Wether to use BIOS RAID or not
 # Note the anaconda cmdline has not been parsed yet when we're first imported,
 # so we can not use flags.dmraid here

--- a/blivet/populator/helpers/__init__.py
+++ b/blivet/populator/helpers/__init__.py
@@ -10,7 +10,7 @@ from .disklabel import DiskLabelFormatPopulator
 from .dm import DMDevicePopulator
 from .dmraid import DMRaidFormatPopulator
 from .loop import LoopDevicePopulator
-from .luks import LUKSFormatPopulator
+from .luks import LUKSDevicePopulator, LUKSFormatPopulator
 from .lvm import LVMDevicePopulator, LVMFormatPopulator
 from .mdraid import MDDevicePopulator, MDFormatPopulator
 from .multipath import MultipathDevicePopulator

--- a/blivet/populator/helpers/devicepopulator.py
+++ b/blivet/populator/helpers/devicepopulator.py
@@ -21,6 +21,7 @@
 #
 
 from .populatorhelper import PopulatorHelper
+from ... import udev
 
 
 # pylint: disable=abstract-method
@@ -33,3 +34,19 @@ class DevicePopulator(PopulatorHelper):
     @classmethod
     def match(cls, data):
         return False
+
+    def _handle_rename(self):
+        name = udev.device_get_name(self.data)
+        if self.device.name != name:
+            self.device.name = name
+        # TODO: update name registry -- better yet, generate the name list on demand
+
+    def _handle_resize(self):
+        old_size = self.device.current_size
+        self.device.update_size()
+        if old_size != self.device.current_size:
+            self._devicetree.cancel_disk_actions(self.device.disks)
+
+    def update(self):
+        self._handle_rename()
+        self._handle_resize()

--- a/blivet/populator/helpers/disklabel.py
+++ b/blivet/populator/helpers/disklabel.py
@@ -91,6 +91,7 @@ class DiskLabelFormatPopulator(FormatPopulator):
         try:
             fmt = formats.get_format("disklabel",
                                      device=self.device.path,
+                                     uuid=udev.device_get_disklabel_uuid(self.data),
                                      exists=True)
         except InvalidDiskLabelError as e:
             log.info("no usable disklabel on %s", self.device.name)

--- a/blivet/populator/helpers/dm.py
+++ b/blivet/populator/helpers/dm.py
@@ -37,6 +37,7 @@ class DMDevicePopulator(DevicePopulator):
     def match(cls, data):
         return (udev.device_is_dm(data) and
                 not udev.device_is_dm_partition(data) and
+                not udev.device_is_dm_luks(data) and
                 not udev.device_is_dm_lvm(data) and
                 not udev.device_is_dm_mpath(data) and
                 not udev.device_is_dm_raid(data))

--- a/blivet/populator/helpers/formatpopulator.py
+++ b/blivet/populator/helpers/formatpopulator.py
@@ -20,6 +20,8 @@
 # Red Hat Author(s): David Lehman <dlehman@redhat.com>
 #
 
+from ...events.changes import data as event_data
+from ...events.changes import AttributeChanged
 from ... import formats
 from ... import udev
 from ...errors import FSError
@@ -81,6 +83,7 @@ class FormatPopulator(PopulatorHelper):
         """ Create a format instance and associate it with the device instance. """
         kwargs = self._get_kwargs()
         type_spec = self.type_spec
+        old_fmt = self.device.format
         try:
             log.info("type detected on '%s' is '%s'", self.device.name, type_spec)
             self.device.format = formats.get_format(type_spec, **kwargs)
@@ -88,8 +91,15 @@ class FormatPopulator(PopulatorHelper):
             log.warning("type '%s' on '%s' invalid, assuming no format",
                         type_spec, self.device.name)
             self.device.format = formats.DeviceFormat(device=self.device.path, exists=True)
-            return
+
+        if old_fmt.type != self.device.format.type or old_fmt.uuid != self.device.format.uuid:
+            event_data.changes.append(AttributeChanged(device=self.device, attr="format",
+                                                       old=old_fmt, new=self.device.format))
 
     def update(self):
-        if hasattr(self.device.format, "label"):
-            self.device.format.label = udev.device_get_label(self.data)
+        label = udev.device_get_label(self.data)
+        if hasattr(self.device.format, "label") and self.device.format.label != label:
+            old_label = self.device.format.label
+            self.device.format.label = label
+            event_data.changes.append(AttributeChanged(device=self.device, fmt=self.device.format,
+                                                       attr="label", old=old_label, new=label))

--- a/blivet/populator/helpers/formatpopulator.py
+++ b/blivet/populator/helpers/formatpopulator.py
@@ -89,3 +89,7 @@ class FormatPopulator(PopulatorHelper):
                         type_spec, self.device.name)
             self.device.format = formats.DeviceFormat(device=self.device.path, exists=True)
             return
+
+    def update(self):
+        if hasattr(self.device.format, "label"):
+            self.device.format.label = udev.device_get_label(self.data)

--- a/blivet/populator/helpers/formatpopulator.py
+++ b/blivet/populator/helpers/formatpopulator.py
@@ -78,14 +78,19 @@ class FormatPopulator(PopulatorHelper):
                   "exists": True}
         return kwargs
 
-    def run(self):
-        """ Create a format instance and associate it with the device instance. """
-        kwargs = self._get_kwargs()
+    @property
+    def type_spec(self):
         if self._type_specifier is not None:
             type_spec = self._type_specifier
         else:
-            type_spec = udev.device_get_format(self.data)
+            type_spec = udev.device_get_format(self.data) or None
 
+        return type_spec
+
+    def run(self):
+        """ Create a format instance and associate it with the device instance. """
+        kwargs = self._get_kwargs()
+        type_spec = self.type_spec
         try:
             log.info("type detected on '%s' is '%s'", self.device.name, type_spec)
             self.device.format = formats.get_format(type_spec, **kwargs)

--- a/blivet/populator/helpers/formatpopulator.py
+++ b/blivet/populator/helpers/formatpopulator.py
@@ -34,16 +34,6 @@ class FormatPopulator(PopulatorHelper):
     priority = 0
     _type_specifier = None
 
-    def __init__(self, devicetree, data, device):
-        """
-            :param :class:`blivet.devicetree.DeviceTree` devicetree: the calling devicetree
-            :param :class:`pyudev.Device` data: udev data describing a device
-            :param device: device instance corresponding to the udev data
-            :type device: :class:`~.devices.StorageDevice`
-        """
-        super().__init__(devicetree, data)
-        self.device = device
-
     @classmethod
     def match(cls, data, device):  # pylint: disable=arguments-differ,unused-argument
         """ Return True if this helper is appropriate for the given device.

--- a/blivet/populator/helpers/luks.py
+++ b/blivet/populator/helpers/luks.py
@@ -29,10 +29,26 @@ from ... import udev
 from ...devices import LUKSDevice
 from ...errors import DeviceError, LUKSError
 from ...flags import flags
+from .devicepopulator import DevicePopulator
 from .formatpopulator import FormatPopulator
 
 import logging
 log = logging.getLogger("blivet")
+
+
+class LUKSDevicePopulator(DevicePopulator):
+    @classmethod
+    def match(cls, data):
+        return udev.device_is_dm_luks(data)
+
+    def run(self):
+        parents = self._devicetree._add_slave_devices(self.data)
+        device = LUKSDevice(udev.device_get_name(self.data),
+                            sysfs_path=udev.device_get_sysfs_path(self.data),
+                            parents=parents,
+                            exists=True)
+        self._devicetree._add_device(device)
+        return device
 
 
 class LUKSFormatPopulator(FormatPopulator):

--- a/blivet/populator/helpers/lvm.py
+++ b/blivet/populator/helpers/lvm.py
@@ -65,6 +65,17 @@ class LVMDevicePopulator(DevicePopulator):
 
         return self._devicetree.get_device_by_name(name)
 
+    def _handle_rename(self):
+        name = self.data.get("DM_LV_NAME")
+        if not name:
+            return
+
+        # device.name is of the form "%s-%s" % (vg_name, lv_name), while
+        # device.lvname is the name of the lv without the vg name.
+        if self.device.lvname != name:
+            self.device.name = name
+        # TODO: update name registry
+
 
 class LVMFormatPopulator(FormatPopulator):
     priority = 100
@@ -93,13 +104,29 @@ class LVMFormatPopulator(FormatPopulator):
 
         return kwargs
 
-    def _handle_vg_lvs(self, vg_device):
-        """ Handle setup of the LV's in the vg_device. """
+    def _get_vg_device(self):
+        return self._devicetree.get_device_by_uuid(self.device.format.container_uuid, incomplete=True)
+
+    def _update_lvs(self):
+        """ Handle setup of the LVs in the vg_device. """
+        log_method_call(self, pv=self.device.name)
+        vg_device = self._get_vg_device()
+        if vg_device is None:
+            # orphan pv
+            return
+
         vg_name = vg_device.name
         lv_info = dict((k, v) for (k, v) in iter(self._devicetree.lv_info.items())
                        if v.vg_name == vg_name)
 
+        # FIXME: This should account for added/removed LVs.
         self._devicetree.names.extend(n for n in lv_info.keys() if n not in self._devicetree.names)
+
+        for lv_device in vg_device.lvs[:]:
+            if lv_device.name not in lv_info:
+                log.info("lv %s was removed", lv_device.name)
+                self._devicetree.cancel_disk_actions(vg_device.disks)
+                self._devicetree.recursive_remove(lv_device, actions=False)
 
         if not vg_device.complete:
             log.warning("Skipping LVs for incomplete VG %s", vg_name)
@@ -149,9 +176,17 @@ class LVMFormatPopulator(FormatPopulator):
             lv_kwargs = {}
             name = "%s-%s" % (vg_name, lv_name)
 
-            if self._devicetree.get_device_by_name(name):
+            lv_device = self._devicetree.get_device_by_name(name)
+            if lv_device is not None:
                 # some lvs may have been added on demand below
                 log.debug("already added %s", name)
+                if lv_size != lv_device.current_size:
+                    # lvresize can operate on an inactive lv, in which case
+                    # the only notification we will receive is a change uevent
+                    # for the pv(s)
+                    lv_device.update_size(newsize=lv_size)
+                    self._devicetree.cancel_disk_actions(vg_device.disks)
+
                 return
 
             if lv_attr[0] in 'Ss':
@@ -302,8 +337,7 @@ class LVMFormatPopulator(FormatPopulator):
             else:
                 log.warning("Failed to determine parent LV for an internal LV '%s'", lv.name)
 
-    def run(self):
-        super().run()
+    def _add_vg_device(self):
         pv_info = self._devicetree.pv_info.get(self.device.path, None)
         if pv_info:
             vg_name = pv_info.vg_name
@@ -317,9 +351,9 @@ class LVMFormatPopulator(FormatPopulator):
             return
 
         vg_device = self._devicetree.get_device_by_uuid(vg_uuid, incomplete=True)
-        if vg_device:
+        if vg_device and self.device not in vg_device.parents:
             vg_device.parents.append(self.device)
-        else:
+        elif vg_device is None:
             same_name = self._devicetree.get_device_by_name(vg_name)
             if isinstance(same_name, LVMVolumeGroupDevice):
                 raise DuplicateVGError("multiple LVM volume groups with the same name (%s)" % vg_name)
@@ -347,4 +381,61 @@ class LVMFormatPopulator(FormatPopulator):
                                              exists=True)
             self._devicetree._add_device(vg_device)
 
-        self._handle_vg_lvs(vg_device)
+    def run(self):
+        log_method_call(self, pv=self.device.name)
+        super().run()
+        self._add_vg_device()
+        self._update_lvs()
+
+    def _handle_vg_rename(self):
+        vg_device = self._get_vg_device()
+        if vg_device is None:
+            return
+
+        pv_info = self._devicetree.pv_info.get(self.device.path, None)
+        if not pv_info or not pv_info.vg_name:
+            return
+
+        vg_name = pv_info.vg_name
+        if vg_device.name != vg_name:
+            vg_device.name = vg_name
+        # TODO: update name registry
+
+    def _update_pv_format(self):
+        pv_info = self._devicetree.pv_info.get(self.device.path, None)
+        if not pv_info:
+            return
+
+        self.device.format.vg_name = pv_info.vg_name
+        self.device.format.vg_uuid = pv_info.vg_uuid
+        self.device.format.pe_start = Size(pv_info.pe_start)
+        self.device.format.pe_free = Size(pv_info.pv_free)
+
+    def update(self):
+        self._devicetree.drop_lvm_cache()
+        self._update_pv_format()
+        pv_info = self._devicetree.pv_info.get(self.device.path, None)
+        vg_device = self._get_vg_device()
+        if vg_device is None:
+            # The VG device isn't in the tree. The PV might have just been
+            # added to a VG.
+            if pv_info and pv_info.vg_name:
+                # Handle adding orphan pv to a vg.
+                self._add_vg_device()
+            elif self.device.children:
+                # The PV was removed from its VG or the VG was removed.
+                vg_device = self.device.children[0]
+                if len(vg_device.parents) > 1:
+                    vg_device.parents.remove(self.device)
+                else:
+                    self._devicetree.recursive_remove(vg_device, actions=False)
+                return
+        else:
+            # The VG device is in the tree. Check if the PV still belongs to it.
+            if pv_info and pv_info.vg_name:
+                # This is the "normal" case: the pv is still part of the
+                # vg it was part of last time we looked.
+                self._handle_vg_rename()
+
+        # handles vg rename, lv add, lv remove, lv resize (inactive lv)
+        self._update_lvs()

--- a/blivet/populator/helpers/mdraid.py
+++ b/blivet/populator/helpers/mdraid.py
@@ -205,3 +205,7 @@ class MDFormatPopulator(FormatPopulator):
                     return
 
                 self._devicetree.handle_device(array_info, update_orig_fmt=True)
+
+    def update(self):
+        # update array based on current md data
+        pass

--- a/blivet/populator/helpers/partition.py
+++ b/blivet/populator/helpers/partition.py
@@ -105,6 +105,7 @@ class PartitionDevicePopulator(DevicePopulator):
         device = None
         try:
             device = PartitionDevice(name, sysfs_path=sysfs_path,
+                                     uuid=udev.device_get_partition_uuid(self.data),
                                      major=udev.device_get_major(self.data),
                                      minor=udev.device_get_minor(self.data),
                                      exists=True, parents=[disk])

--- a/blivet/populator/helpers/populatorhelper.py
+++ b/blivet/populator/helpers/populatorhelper.py
@@ -27,13 +27,16 @@ class PopulatorHelper:
     priority = 100
     """ Higher priority value gets checked for match first. """
 
-    def __init__(self, devicetree, data):
+    def __init__(self, devicetree, data, device=None):
         """
             :param :class:`~.DeviceTree` devicetree: the calling devicetree
             :param :class:`pyudev.Device` data: udev data describing a device
+            :keyword device: device instance corresponding to the udev data
+            :type device: :class:`~.devices.StorageDevice`
         """
         self._devicetree = devicetree
         self.data = data
+        self.device = device
 
     @classmethod
     def match(cls, data):

--- a/blivet/populator/helpers/populatorhelper.py
+++ b/blivet/populator/helpers/populatorhelper.py
@@ -58,3 +58,11 @@ class PopulatorHelper:
             perform all processing related to the device's formatting.
         """
         raise NotImplementedError()
+
+    def update(self):
+        """ Handle changes associated with an event.
+
+            This method should handle any changes to an existing format instance.
+            It should not handle reformatting.
+        """
+        pass

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -576,4 +576,3 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
                 n = len([d for d in self.devices if d.format.type == fstype])
                 device._name += ".%d" % n
                 self._add_device(device)
-

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -347,18 +347,6 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
 
         log.info("got format: %s", device.format)
 
-    def update_format(self, device):
-        log.info("updating format of device: %s", device)
-        try:
-            util.notify_kernel(device.sysfs_path)
-        except (ValueError, IOError) as e:
-            log.warning("failed to notify kernel of change: %s", e)
-
-        udev.settle()
-        info = udev.get_device(device.sysfs_path)
-
-        self.handle_format(info, device)
-
     def _handle_inconsistencies(self):
         for vg in [d for d in self.devices if d.type == "lvmvg"]:
             if vg.complete:

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -268,6 +268,12 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
                     if parent.name not in self.exclusive_disks:
                         self.exclusive_disks.append(parent.name)
 
+    def _get_format_helper(self, info, device=None):
+        return get_format_helper(info, device=device)
+
+    def _get_device_helper(self, info):
+        return get_device_helper(info)
+
     def handle_device(self, info, update_orig_fmt=False):
         """
             :param :class:`pyudev.Device` info: udev info for the device
@@ -300,7 +306,7 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
         if device:
             device_added = False
         else:
-            helper_class = get_device_helper(info)
+            helper_class = self._get_device_helper(info)
 
         if helper_class is not None:
             device = helper_class(self, info).run()
@@ -338,7 +344,7 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
             log.debug("no type or existing type for %s, bailing", name)
             return
 
-        helper_class = get_format_helper(info, device=device)
+        helper_class = self._get_format_helper(info, device=device)
         if helper_class is not None:
             helper_class(self, info, device).run()
 

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -235,13 +235,10 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
             return
 
         # newly added device (eg iSCSI) could make this one a multipath member
-        if device.format and device.format.type != "multipath_member":
+        if device.format.type != "multipath_member":
             log.debug("%s newly detected as multipath member, dropping old format and removing kids", device.name)
             # remove children from tree so that we don't stumble upon them later
-            for child in device.children:
-                self.recursive_remove(child, actions=False)
-
-            device.format = None
+            self.recursive_remove(device, actions=False, remove_device=False)
 
     def _mark_readonly_device(self, info, device):
         # If this device is read-only, mark it as such now.

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -338,7 +338,7 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
             log.debug("no type or existing type for %s, bailing", name)
             return
 
-        helper_class = get_format_helper(info, device)
+        helper_class = get_format_helper(info, device=device)
         if helper_class is not None:
             helper_class(self, info, device).run()
 

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -576,3 +576,4 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
                 n = len([d for d in self.devices if d.format.type == fstype])
                 device._name += ".%d" % n
                 self._add_device(device)
+

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -50,7 +50,8 @@ def get_device(sysfs_path):
 
 
 def get_devices(subsystem="block"):
-    settle()
+    if not flags.uevents:
+        settle()
     return [d for d in global_udev.list_devices(subsystem=subsystem)
             if not __is_blacklisted_blockdev(d.sys_name)]
 

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -644,6 +644,14 @@ def device_get_disklabel_type(info):
 
     return info.get("ID_PART_TABLE_TYPE")
 
+
+def device_get_disklabel_uuid(info):
+    return info.get("ID_PART_TABLE_UUID")
+
+
+def device_get_partition_uuid(info):
+    return info.get("ID_PART_ENTRY_UUID")
+
 # iscsi disks' ID_PATH form depends on the driver:
 # for software iscsi:
 # ip-${iscsi_address}:${iscsi_port}-iscsi-${iscsi_tgtname}-lun-${lun}

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -32,6 +32,7 @@ import logging
 log = logging.getLogger("blivet")
 program_log = logging.getLogger("program")
 testdata_log = logging.getLogger("testdata")
+console_log = logging.getLogger("blivet.console")
 
 from threading import Lock
 # this will get set to anaconda's program_log_lock in enable_installer_mode
@@ -718,12 +719,13 @@ def dedup_list(alist):
 ##
 
 
-def set_up_logging(log_dir="/tmp", log_prefix="blivet"):
+def set_up_logging(log_dir="/tmp", log_prefix="blivet", console_logs=None):
     """ Configure the blivet logger to write out a log file.
 
-        :keyword str log_file: path to the log file (default: /tmp/blivet.log)
+        :keyword str log_dir: path to directory where log files are
+        :keyword str log_prefix: prefix for log file names
+        :keyword list console_logs: list of log names to output on the console
     """
-
     log.setLevel(logging.DEBUG)
     program_log.setLevel(logging.DEBUG)
 
@@ -744,12 +746,27 @@ def set_up_logging(log_dir="/tmp", log_prefix="blivet"):
     warning_log = logging.getLogger("py.warnings")
     warning_log.addHandler(handler)
 
+    if console_logs:
+        set_up_console_log(log_names=console_logs)
+
     log.info("sys.argv = %s", sys.argv)
 
     prefix = "%s-testdata" % (log_prefix,)
     handler = make_handler(log_dir, prefix, logging.DEBUG)
     testdata_log.setLevel(logging.DEBUG)
     testdata_log.addHandler(handler)
+
+
+def set_up_console_log(log_names=None):
+    log_names = log_names or []
+    handler = logging.StreamHandler()
+    console_log.setLevel(logging.DEBUG)
+    handler.setLevel(logging.DEBUG)
+    formatter = logging.Formatter("%(threadName)s: %(message)s")
+    handler.setFormatter(formatter)
+    console_log.addHandler(handler)
+    for name in log_names:
+        logging.getLogger(name).addHandler(handler)
 
 
 def create_sparse_tempfile(name, size):

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -323,22 +323,6 @@ def total_memory():
 ##
 
 
-def notify_kernel(path, action="change"):
-    """ Signal the kernel that the specified device has changed.
-
-        Exceptions raised: ValueError, IOError
-    """
-    log.debug("notifying kernel of '%s' event on device %s", action, path)
-    path = os.path.join(path, "uevent")
-    if not path.startswith("/sys/") or not os.access(path, os.W_OK):
-        log.debug("sysfs path '%s' invalid", path)
-        raise ValueError("invalid sysfs path")
-
-    f = open(path, "a")
-    f.write("%s\n" % action)
-    f.close()
-
-
 def normalize_path_slashes(path):
     """ Normalize the slashes in a filesystem path.
         Does not actually examine the filesystme in any way.

--- a/examples/uevents.py
+++ b/examples/uevents.py
@@ -1,0 +1,26 @@
+import time
+
+from examples.common import print_devices
+
+import blivet
+from blivet.events.manager import event_manager
+from blivet.util import set_up_logging
+
+
+def print_changes(event, changes):
+    print("***", event)
+    for change in changes:
+        print("***", change)
+    print("***")
+    print()
+
+set_up_logging(console_logs=["blivet.event"])
+b = blivet.Blivet()  # create an instance of Blivet
+b.reset()  # detect system storage configuration
+print_devices(b)
+
+event_manager.notify_cb = print_changes
+event_manager.enable()
+
+while True:
+    time.sleep(0.5)

--- a/tests/devicelibs_test/edd_test.py
+++ b/tests/devicelibs_test/edd_test.py
@@ -6,7 +6,7 @@ import logging
 import copy
 
 from blivet.devicelibs import edd
-import lib
+from tests import lib
 
 
 class FakeDevice(object):

--- a/tests/devices_test/device_properties_test.py
+++ b/tests/devices_test/device_properties_test.py
@@ -696,7 +696,7 @@ class BTRFSDeviceTestCase(DeviceStateTestCase):
         with self.assertRaisesRegex(ValueError, "btrfs snapshot source must be a btrfs subvolume"):
             BTRFSSnapShotDevice("snap1", parents=[vol], source=parents[0])
 
-        parents2 = [StorageDevice("p1", fmt=blivet.formats.get_format("btrfs"), size=BTRFS_MIN_MEMBER_SIZE)]
+        parents2 = [StorageDevice("p1", fmt=blivet.formats.get_format("btrfs"), size=BTRFS_MIN_MEMBER_SIZE, exists=True)]
         vol2 = BTRFSVolumeDevice("test2", parents=parents2, exists=True)
         with self.assertRaisesRegex(ValueError, ".*snapshot and source must be in the same volume"):
             BTRFSSnapShotDevice("snap1", parents=[vol], source=vol2)

--- a/tests/events_test.py
+++ b/tests/events_test.py
@@ -1,6 +1,6 @@
 
 from unittest import TestCase
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from blivet.events.manager import Event, EventManager
 
@@ -22,7 +22,8 @@ class FakeEventManager(EventManager):
 class EventManagerTest(TestCase):
     def testEventMask(self):
         handler_cb = Mock()
-        mgr = FakeEventManager(handler_cb=handler_cb)
+        with patch("blivet.events.manager.validate_cb", return_value=True):
+            mgr = FakeEventManager(handler_cb=handler_cb)
 
         device = "sdc"
         action = "add"

--- a/tests/events_test.py
+++ b/tests/events_test.py
@@ -1,0 +1,73 @@
+
+from unittest import TestCase
+from unittest.mock import Mock
+
+from blivet.events.manager import Event, EventManager
+
+
+class FakeEventManager(EventManager):
+    def enabled(self):
+        return False
+
+    def enable(self):
+        pass
+
+    def disable(self):
+        pass
+
+    def _create_event(self, *args, **kwargs):
+        return Event(*args, **kwargs)
+
+
+class EventManagerTest(TestCase):
+    def testEventMask(self):
+        handler_cb = Mock()
+        mgr = FakeEventManager(handler_cb=handler_cb)
+
+        device = "sdc"
+        action = "add"
+        mgr.handle_event(action, device)
+        self.assertEqual(handler_cb.call_count, 1)
+        event = handler_cb.call_args[1]["event"]  # pylint: disable=unsubscriptable-object
+        self.assertEqual(event.device, device)
+        self.assertEqual(event.action, action)
+
+        # mask matches device but not action -> event is handled
+        handler_cb.reset_mock()
+        mask = mgr.add_mask(device=device, action=action + 'x')
+        mgr.handle_event(action, device)
+        self.assertEqual(handler_cb.call_count, 1)
+        event = handler_cb.call_args[1]["event"]  # pylint: disable=unsubscriptable-object
+        self.assertEqual(event.device, device)
+        self.assertEqual(event.action, action)
+
+        # mask matches action but not device -> event is handled
+        handler_cb.reset_mock()
+        mask = mgr.add_mask(device=device + 'x', action=action)
+        mgr.handle_event(action, device)
+        self.assertEqual(handler_cb.call_count, 1)
+        event = handler_cb.call_args[1]["event"]  # pylint: disable=unsubscriptable-object
+        self.assertEqual(event.device, device)
+        self.assertEqual(event.action, action)
+
+        # mask matches device and action -> event is ignored
+        handler_cb.reset_mock()
+        mgr.remove_mask(mask)
+        mask = mgr.add_mask(device=device, action=action)
+        mgr.handle_event(action, device)
+        self.assertEqual(handler_cb.call_count, 0)
+
+        # device-only mask matches -> event is ignored
+        handler_cb.reset_mock()
+        mgr.remove_mask(mask)
+        mask = mgr.add_mask(device=device)
+        mgr.handle_event(action, device)
+        self.assertEqual(handler_cb.call_count, 0)
+
+        # action-only mask matches -> event is ignored
+        handler_cb.reset_mock()
+        mgr.remove_mask(mask)
+        mask = mgr.add_mask(action=action)
+        mgr.handle_event(action, device)
+        self.assertEqual(handler_cb.call_count, 0)
+        mgr.remove_mask(mask)

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -131,6 +131,7 @@ class DMDevicePopulatorTestCase(PopulatorHelperTestCase):
 
     @patch.object(DeviceTree, "get_device_by_name")
     @patch.object(DMDevice, "status", return_value=True)
+    @patch.object(DMDevice, "update_sysfs_path")
     @patch.object(DeviceTree, "_add_slave_devices")
     @patch("blivet.udev.device_is_dm_livecd", return_value=False)
     @patch("blivet.udev.device_get_name")

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -275,6 +275,7 @@ class LVMDevicePopulatorTestCase(PopulatorHelperTestCase):
     @patch("blivet.udev.device_is_dm_mpath", return_value=False)
     @patch("blivet.udev.device_is_loop", return_value=False)
     @patch("blivet.udev.device_is_md", return_value=False)
+    @patch("blivet.udev.device_is_dm_luks", return_value=False)
     @patch("blivet.udev.device_is_dm_lvm", return_value=True)
     def test_get_helper(self, *args):
         """Test get_device_helper for lvm devices."""
@@ -358,6 +359,7 @@ class OpticalDevicePopulatorTestCase(PopulatorHelperTestCase):
 
     @patch("blivet.udev.device_is_dm", return_value=False)
     @patch("blivet.udev.device_is_dm_lvm", return_value=False)
+    @patch("blivet.udev.device_is_dm_luks", return_value=False)
     @patch("blivet.udev.device_is_dm_mpath", return_value=False)
     @patch("blivet.udev.device_is_loop", return_value=False)
     @patch("blivet.udev.device_is_md", return_value=False)


### PR DESCRIPTION
These patches add support to blivet for updating the `DeviceTree` to reflect changes made to system storage from outside of blivet.

This is functionally complete, but needs some more refinement. The remaining improvements that occur to me now are:
  1. more unit tests
  2. move event handlers into a separate mixin class
  3. further auditing of existing calls to `udev.settle`
  4. move event masking from `DiskLabelFormatPopulator.update` to `DiskLabel.partedDisk` or similar

Probably the most important thing is that I need to build up good test coverage. Manually dinking around running commands on a shell in a vm while watching the output of `examples/uevents.py` is not a good long-term plan.