### PR TITLE
Remove references to the interruptible-system-call check

### DIFF
--- a/scripts/makebumpver
+++ b/scripts/makebumpver
@@ -20,8 +20,6 @@
 #
 # Author: David Cantrell <dcantrell@redhat.com>
 
-# pylint: disable=interruptible-system-call
-
 import logging
 logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger("bugzilla")

--- a/scripts/makeupdates
+++ b/scripts/makeupdates
@@ -20,8 +20,6 @@
 #
 # Author: David Cantrell <dcantrell@redhat.com>
 
-# pylint: disable=interruptible-system-call
-
 import getopt
 import os
 import shutil

--- a/scripts/merge-pr
+++ b/scripts/merge-pr
@@ -47,8 +47,6 @@
 # request against f22-branch but you don't have f22-branch locally, it won't
 # work.
 
-# pylint: disable=interruptible-system-call
-
 import argparse
 import subprocess
 import sys

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python2
-# pylint: disable=interruptible-system-call
 
 from distutils.core import setup
 from distutils import filelist


### PR DESCRIPTION
The check is no more, since it is no longer relevant in python 3.5. This
leaves the usage of the eintr_retry_call, since that is still relevant
in Python 2.