### PR TITLE
Use _netdev mount option as needed. (#1290046)

### DIFF
--- a/blivet/__init__.py
+++ b/blivet/__init__.py
@@ -2849,7 +2849,7 @@ class FSSet(object):
             for netdev in netdevs:
                 if device.dependsOn(netdev):
                     options = options + ",_netdev"
-                    if root_on_netdev and mountpoint == "/var":
+                    if root_on_netdev and mountpoint not in ["/", "/usr"]:
                         options = options + ",x-initrd.mount"
                     break
             if device.encrypted:

--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -416,11 +416,6 @@ class PartitionDevice(StorageDevice):
         """ Is this device directly accessible? """
         return self.isleaf and not self.isExtended
 
-    def _setFormat(self, fmt):
-        """ Set the Device's format. """
-        log_method_call(self, self.name)
-        StorageDevice._setFormat(self, fmt)
-
     def _setBootable(self, bootable):
         """ Set the bootable flag for this partition. """
         if self.partedPartition:

--- a/tests/devices_test.py
+++ b/tests/devices_test.py
@@ -22,6 +22,7 @@ from blivet.devices import LVMThinLogicalVolumeDevice
 from blivet.devices import LVMThinSnapShotDevice
 from blivet.devices import LVMVolumeGroupDevice
 from blivet.devices import MDRaidArrayDevice
+from blivet.devices import NetworkStorageDevice
 from blivet.devices import OpticalDevice
 from blivet.devices import PartitionDevice
 from blivet.devices import StorageDevice
@@ -844,6 +845,35 @@ class DeviceNameTestCase(unittest.TestCase):
 
         for name in bad_names:
             self.assertFalse(LVMLogicalVolumeDevice.isNameValid(name))
+
+class FakeNetDev(StorageDevice, NetworkStorageDevice):
+    _type = "fakenetdev"
+
+class NetDevMountOptionTestCase(unittest.TestCase):
+    def testNetDevSetting(self):
+        """ Verify netdev mount option setting after format assignment. """
+        netdev = FakeNetDev("net1")
+        dev = StorageDevice("dev1", fmt=getFormat("ext4"))
+        self.assertFalse("_netdev" in dev.format.options.split(","))
+
+        dev.parents.append(netdev)
+        dev.format = getFormat("ext4")
+        self.assertTrue("_netdev" in dev.format.options.split(","))
+
+    def testNetDevUpdate(self):
+        """ Verify netdev mount option setting after device creation. """
+        netdev = FakeNetDev("net1")
+        dev = StorageDevice("dev1", fmt=getFormat("ext4"))
+        self.assertFalse("_netdev" in dev.format.options.split(","))
+
+        dev.parents.append(netdev)
+
+        # these create methods shouldn't write anything to disk
+        netdev.create()
+        dev.create()
+
+        self.assertTrue("_netdev" in dev.format.options.split(","))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The intention is to pass the option as needed when mounting filesystems
in addition to putting it in /etc/fstab.

(cherry picked from commit 39bbea13f22c6137625d55cd4902f09be6dc032c)

Resolves: rhbz#1290046