### PR TITLE
Fixes for cached LV VG space used

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -495,7 +495,14 @@ class LVMVolumeGroupDevice(ContainerDevice):
 
         """
         # TODO: report correctly/better for existing VGs
-        return max([lv.metadata_size for lv in self.lvs] + [Size(0)])
+
+        # gather metadata sizes for all LVs including their potential caches
+        md_sizes = set((Size(0),))
+        for lv in self.lvs:
+            md_sizes.add(lv.metadata_size)
+            if lv.cached:
+                md_sizes.add(lv.cache.md_size)
+        return max(md_sizes)
 
     @property
     def complete(self):
@@ -687,10 +694,7 @@ class LVMLogicalVolumeBase(DMDevice, RaidDevice):
                       if int_lv.is_internal_lv and int_lv.int_lv_type == LVMInternalLVtype.meta)
             return Size(sum(lv.size for lv in md_lvs))
 
-        ret = self._metadata_size
-        if self.cached:
-            ret += self.cache.md_size
-        return ret
+        return self._metadata_size
 
     @property
     def dict(self):
@@ -709,31 +713,32 @@ class LVMLogicalVolumeBase(DMDevice, RaidDevice):
     @property
     def vg_space_used(self):
         """ Space occupied by this LV, not including snapshots. """
+        return self.data_vg_space_used + self.metadata_vg_space_used
+
+    @property
+    def data_vg_space_used(self):
+        """ Space occupied by the data part of this LV, not including snapshots """
         if self.cached:
             cache_size = self.cache.size
         else:
             cache_size = Size(0)
 
-        return self.data_vg_space_used + self.metadata_vg_space_used + cache_size
-
-    @property
-    def data_vg_space_used(self):
-        """ Space occupied by the data part of this LV, not including snapshots """
         rounded_size = self.vg.align(self.size, roundup=True)
         if self.is_raid_lv:
             zero_superblock = lambda x: Size(0)
             try:
-                return self._raid_level.get_space(rounded_size, self._num_raid_pvs,
-                                                  superblock_size_func=zero_superblock)
+                raided_size = self._raid_level.get_space(rounded_size, self._num_raid_pvs,
+                                                         superblock_size_func=zero_superblock)
+                return raided_size + cache_size
             except errors.RaidError:
                 # Too few PVs for the segment type (RAID level), we must have
                 # incomplete information about the current LVM
                 # configuration. Let's just default to the basic size for
                 # now. Later calls to this property will provide better results.
                 # TODO: add pv_count field to blockdev.LVInfo and this class
-                return rounded_size
+                return rounded_size + cache_size
         else:
-            return rounded_size
+            return rounded_size + cache_size
 
     @property
     def metadata_vg_space_used(self):
@@ -745,21 +750,28 @@ class LVMLogicalVolumeBase(DMDevice, RaidDevice):
                       if int_lv.is_internal_lv and int_lv.int_lv_type == LVMInternalLVtype.meta)
             return Size(sum(lv.size for lv in md_lvs))
 
+        # otherwise we need to do the calculations
+        if self.cached:
+            cache_md = self.cache.md_size
+        else:
+            cache_md = Size(0)
         non_raid_base = self.metadata_size + self.log_size
         if non_raid_base and self.is_raid_lv:
             zero_superblock = lambda x: Size(0)
             try:
-                return self._raid_level.get_space(non_raid_base, self._num_raid_pvs,
-                                                  superblock_size_func=zero_superblock)
+                raided_space = self._raid_level.get_space(non_raid_base, self._num_raid_pvs,
+                                                          superblock_size_func=zero_superblock)
+                return raided_space + cache_md
+
             except errors.RaidError:
                 # Too few PVs for the segment type (RAID level), we must have
                 # incomplete information about the current LVM
                 # configuration. Let's just default to the basic size for
                 # now. Later calls to this property will provide better results.
                 # TODO: add pv_count field to blockdev.LVInfo and this class
-                return non_raid_base
+                return non_raid_base + cache_md
 
-        return non_raid_base
+        return non_raid_base + cache_md
 
     @property
     def pv_space_used(self):

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -1402,7 +1402,6 @@ class LVMThinPoolMixin(object):
     def vg_space_used(self):
         # TODO: what about cached thin pools?
         space = self.data_vg_space_used + self.metadata_vg_space_used
-        space += Size(blockdev.lvm.get_thpool_padding(space, self.vg.pe_size))
         return space
 
     def _create(self):

--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -1039,7 +1039,7 @@ class LVRequest(Request):
 
         # Round up to nearest pe. For growable requests this will mean that
         # first growth is to fill the remainder of any unused extent.
-        self.base = int(lv.data_vg_space_used // lv.vg.pe_size)
+        self.base = int(lv.size // lv.vg.pe_size)
 
         if lv.req_grow:
             limits = [int(l // lv.vg.pe_size) for l in
@@ -1059,8 +1059,7 @@ class LVRequest(Request):
         reserve = super(LVRequest, self).reserve_request
         if lv.cached:
             reserve += int(lv.vg.align(lv.cache.size, roundup=True) / lv.vg.pe_size)
-        if lv.metadata_size:
-            reserve += int(lv.vg.align(lv.metadata_vg_space_used, roundup=True) / lv.vg.pe_size)
+        reserve += int(lv.vg.align(lv.metadata_vg_space_used, roundup=True) / lv.vg.pe_size)
         return reserve
 
 

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -882,6 +882,22 @@ def power_of_two(value):
     return True
 
 
+def walk(root, desc_attr):
+    """
+    Recursively walk the object tree from root in a depth-first manner.
+
+    :param object root: root object to start the recursive walk from
+    :param str desc_attr: the attribute to use for descending in the tree
+                          (i.e. to get child nodes)
+    :returns: generator of walked nodes
+    """
+    yield root
+    children = getattr(root, desc_attr)
+    for child in children:
+        for obj in walk(child, desc_attr):
+            yield obj
+
+
 def indent(text, spaces=4):
     """ Indent text by a specified number of spaces.
 

--- a/tests/devices_test/lvm_test.py
+++ b/tests/devices_test/lvm_test.py
@@ -93,7 +93,8 @@ class LVMDeviceTest(unittest.TestCase):
                                     fmt=blivet.formats.get_format("xfs"),
                                     exists=False, cache_request=cache_req)
 
-        # the cache reserves space for the 8MiB pmspare internal LV
+        # the cache reserves space for its metadata from the requested size, but
+        # it may require (and does in this case) a pmspare LV to be allocated
         self.assertEqual(lv.vg_space_used, Size("504 MiB"))
 
         # check that the LV behaves like a cached LV

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -113,3 +113,18 @@ class TestRequiresProperty(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             t.bad_news
+
+
+class Node(object):
+    def __init__(self, children, id):
+        self.children = children
+        self.id = id
+
+
+class TestWalk(unittest.TestCase):
+    def test_walk(self):
+        root = Node([Node([], 1), Node([Node([Node([], 4)], 3)], 2), Node([], 5)], 0)
+
+        lst = [item.id for item in util.walk(root, "children")]
+        self.assertEqual(lst, sorted(lst))
+        self.assertEqual(len(lst), 6)


### PR DESCRIPTION
These fixes some inconsistencies and problems @vojtechtrefny found when working on LVM cache and LVM RAID support in *blivet-gui*.