### PR TITLE
Kickstart missing bootloader partitions (#1256249)

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -1816,7 +1816,10 @@ class Blivet(object, metaclass=SynchronizedMeta):
                   BTRFSDevice: ("BTRFSData", "btrfs")}
 
         # make a list of ancestors of all used devices
-        devices = list(set(a for d in list(self.mountpoints.values()) + self.swaps
+        bootloader_devices = []
+        if self.bootloader_device is not None:
+            bootloader_devices.append(self.bootloader_device)
+        devices = list(set(a for d in list(self.mountpoints.values()) + self.swaps + bootloader_devices
                            for a in d.ancestors))
 
         # devices which share information with their distinct raw device

--- a/tests/blivet_test.py
+++ b/tests/blivet_test.py
@@ -1,0 +1,53 @@
+import unittest
+from unittest.mock import Mock
+from pykickstart.version import returnClassForVersion
+from blivet import Blivet
+from blivet.devices import PartitionDevice
+from blivet import formats
+from blivet.size import Size
+import re
+
+class BlivetTestCase(unittest.TestCase):
+    '''
+    Define tests for the Blivet class
+    '''
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_bootloader_in_kickstart(self):
+        '''
+        test that a bootloader such as prepboot/biosboot shows up
+        in the kickstart data
+        '''
+        # set up arbitrary partition to pass mountpoints check
+        my_root_device = PartitionDevice("test_mount_device")
+        my_root_device.size = Size('100 MiB')
+        my_root_device.format = formats.get_format("ext4", mountpoint="/")
+
+        # set up prepboot partition
+        my_bootloader_device = PartitionDevice("test_partition_device")
+        my_bootloader_device.size = Size('5 MiB')
+        my_bootloader_device.format = formats.get_format("prepboot")
+
+        # Mock _bootloader to get it to recognize device
+        my_blivet = Blivet()
+        my_blivet._bootloader = Mock()
+        my_blivet._bootloader.stage1_device = my_bootloader_device
+
+        # initialize ksdata
+        my_ksdata = returnClassForVersion()()
+        my_blivet.ksdata = my_ksdata
+
+        # add device and update ksdata
+        my_blivet.devicetree._add_device(my_bootloader_device)
+        my_blivet.devicetree._add_device(my_root_device)
+
+        my_blivet.update_ksdata()
+
+        my_result = re.search('part prepboot --fstype="prepboot" --size=5',
+                              str(my_blivet.ksdata))
+
+        self.assertTrue(my_result is not None)


### PR DESCRIPTION
Blivet generates the information about user defined custom partitioning
that is used in the kickstart file. The output was missing the biosboot
and prepboot data rendering the kickstart unusable for automated
installation using the generated file.

Added code and unit tests to add and verify the presence of the
bootloader device in the generated kickstart data.

Resolves: rhbz#1256249
Resolves: rhbz#1242666