### PR TITLE
Add xfs to default filesystems (#1256249)

### DIFF
--- a/blivet/formats/__init__.py
+++ b/blivet/formats/__init__.py
@@ -46,13 +46,13 @@ def register_device_format(fmt_class):
     log.debug("registered device format class %s as %s", fmt_class.__name__,
                                                          fmt_class._type)
 
-default_fstypes = ("ext4", "ext3", "ext2")
+default_fstypes = ("ext4", "xfs",  "ext3", "ext2")
 def get_default_filesystem_type():
     for fstype in default_fstypes:
         try:
-            supported = get_device_format_class(fstype).supported
+            supported = getFormat(fstype).supported
         except AttributeError:
-            supported = None
+            supported = False
 
         if supported:
             return fstype


### PR DESCRIPTION
Running blivet tests as a non-root user leads to failed instantiation of
the core Blivet class if the ext4 kernel module is not loaded on the
test system. Added xfs to the list of acceptable default file systems.

Related: rhbz#1256249