### PR TITLE
Add xfs to default filesystems (#1256249)

### DIFF
--- a/blivet/formats/__init__.py
+++ b/blivet/formats/__init__.py
@@ -62,7 +62,7 @@ def register_device_format(fmt_class):
     log.debug("registered device format class %s as %s", fmt_class.__name__,
               fmt_class._type)
 
-default_fstypes = ("ext4", "ext3", "ext2")
+default_fstypes = ("ext4", "ext3", "ext2", "xfs")
 
 
 def get_default_filesystem_type():


### PR DESCRIPTION
Running blivet tests as a non-root user leads to failed instantiation of
the core Blivet class if the ext4 kernel module is not loaded on the
test system. Added xfs to the list of acceptable default file systems.

Related: rhbz#1256249