### PR TITLE
Kickstart missing bootloader partitions (#1256249)

### DIFF
--- a/blivet/__init__.py
+++ b/blivet/__init__.py
@@ -2006,9 +2006,15 @@ class Blivet(object):
                  MDRaidArrayDevice: ("RaidData", "raid"),
                  BTRFSDevice: ("BTRFSData", "btrfs")}
 
+        # list comprehension that builds device ancestors should not get None as a member
+        # when searching for bootloader devices
+        bootLoaderDevices = []
+        if self.bootLoaderDevice is not None:
+            bootLoaderDevices.append(self.bootLoaderDevice)
+
         # make a list of ancestors of all used devices
-        devices = list(set(a for d in list(self.mountpoints.values()) + self.swaps
-                                for a in d.ancestors))
+        devices = list(set(a for d in list(self.mountpoints.values()) + self.swaps + bootLoaderDevices
+                           for a in d.ancestors))
 
         # devices which share information with their distinct raw device
         complementary_devices = [d for d in devices if d.raw_device is not d]

--- a/tests/blivet_test.py
+++ b/tests/blivet_test.py
@@ -1,0 +1,39 @@
+import unittest
+from mock import patch
+from mock import PropertyMock
+from pykickstart.version import returnClassForVersion
+from blivet import Blivet
+from blivet.devices import PartitionDevice
+from blivet import formats
+from blivet.size import Size
+
+
+class BlivetTestCase(unittest.TestCase):
+    '''
+    Define tests for the Blivet class
+    '''
+    def test_bootloader_in_kickstart(self):
+        '''
+        test that a bootloader such as prepboot/biosboot shows up
+        in the kickstart data
+        '''
+
+        with patch('blivet.Blivet.bootLoaderDevice', new_callable=PropertyMock) as mockBootLoaderDevice:
+            with patch('blivet.Blivet.mountpoints', new_callable=PropertyMock) as mockMountpoints:
+                # set up prepboot partition
+                bootloader_device_obj = PartitionDevice("test_partition_device")
+                bootloader_device_obj.size = Size('5MiB')
+                bootloader_device_obj.format = formats.getFormat("prepboot")
+
+                blivet_obj = Blivet()
+
+                # mountpoints must exist for updateKSData to run
+                mockBootLoaderDevice.return_value = bootloader_device_obj
+                mockMountpoints.values.return_value = []
+
+                # initialize ksdata
+                test_ksdata = returnClassForVersion()()
+                blivet_obj.ksdata = test_ksdata
+                blivet_obj.updateKSData()
+
+        self.assertTrue("part prepboot" in str(blivet_obj.ksdata))


### PR DESCRIPTION
Blivet generates the information about user defined custom partitioning
that is used in the kickstart file. The output was missing the biosboot
and prepboot data rendering the kickstart unusable for automated
installation using the generated file.

Added code and unit tests to add and verify the presence of the
bootloader device in the generated kickstart data.

Resolves: rhbz#1256249
Resolves: rhbz#1242666