### PR TITLE
Kickstart missing bootloader partitions (#1256249)

### DIFF
--- a/blivet/osinstall.py
+++ b/blivet/osinstall.py
@@ -1389,7 +1389,11 @@ class InstallerStorage(Blivet):
                   BTRFSDevice: ("BTRFSData", "btrfs")}
 
         # make a list of ancestors of all used devices
-        devices = list(set(a for d in list(self.mountpoints.values()) + self.swaps
+        bootloader_devices = []
+        if self.bootloader_device is not None:
+            bootloader_devices.append(self.bootloader_device)
+
+        devices = list(set(a for d in list(self.mountpoints.values()) + self.swaps + bootloader_devices
                            for a in d.ancestors))
 
         # devices which share information with their distinct raw device

--- a/tests/blivet_test.py
+++ b/tests/blivet_test.py
@@ -1,0 +1,42 @@
+import unittest
+from unittest.mock import Mock
+from pykickstart.version import returnClassForVersion
+from blivet.osinstall import InstallerStorage
+from blivet.devices import PartitionDevice
+from blivet import formats
+import re
+
+class BlivetTestCase(unittest.TestCase):
+    '''
+    Define tests for the Blivet class
+    '''
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_bootloader_in_kickstart(self):
+        '''
+        test that a bootloader such as prepboot/biosboot shows up
+        in the kickstart data
+        '''
+
+        with patch('blivet.Blivet.bootLoaderDevice', new_callable=PropertyMock) as mock_bootloader_device:
+            with patch('blivet.Blivet.mountpoints', new_callaable=PropertyMock) as mock_mountpoints:
+                # set up prepboot partition
+                bootloader_device_obj = PartitionDevice("test_partition_device")
+                bootloader_device_obj.format = formats.getFormat("prepboot")
+
+                blivet_obj = InstallerStorage()
+
+                # mountpoints must exist for update_ksdata to run
+                mock_bootloader_device.return_value = bootloader_device_obj
+                mock_mountpoints.values.return_value = []
+
+                # initialize ksdata
+                test_ksdata = returnClassForVersion()()
+                blivet_obj.ksdata = test_ksdata
+                blivet_obj.update_ksdata()
+
+        self.assertTrue("part prepboot" in str(blivet_obj.ksdata))


### PR DESCRIPTION
Blivet generates the information about user defined custom partitioning
that is used in the kickstart file. The output was missing the biosboot
and prepboot data rendering the kickstart unusable for automated
installation using the generated file.

Added code and unit tests to add and verify the presence of the
bootloader device in the generated kickstart data.

Resolves: rhbz#1256249
Resolves: rhbz#1242666