### PR TITLE
Fix blivet constructor fs support check (#1242666)

### DIFF
--- a/blivet/formats/__init__.py
+++ b/blivet/formats/__init__.py
@@ -46,13 +46,13 @@ def register_device_format(fmt_class):
     log.debug("registered device format class %s as %s", fmt_class.__name__,
                                                          fmt_class._type)
 
-default_fstypes = ("ext4", "ext3", "ext2")
+default_fstypes = ("xfs", "ext4", "ext3", "ext2")
 def get_default_filesystem_type():
     for fstype in default_fstypes:
         try:
-            supported = get_device_format_class(fstype).supported
+            supported = getFormat(fstype).supported
         except AttributeError:
-            supported = None
+            supported = False
 
         if supported:
             return fstype


### PR DESCRIPTION
Users who run blivet tests without root permissions would get test
failures if they did not have the ext4 kernel modules loaded and did not
have permission to load kernel modules.

Fixed the guard to check the boolean value of the property rather than
checking for the existence of the pointer. Added xfs as a default
filesystem as it is another commonly used filesystem.

Related: rhbz#1242666