### PR TITLE
Installer isolation: part one

### DIFF
--- a/blivet/autopart.py
+++ b/blivet/autopart.py
@@ -110,8 +110,8 @@ def _get_candidate_disks(storage):
         for a default-sized (500MiB) partition. They must also be in
         :attr:`StorageDiscoveryConfig.clear_part_disks` if it is non-empty.
 
-        :param storage: a Blivet instance
-        :type storage: :class:`~.Blivet`
+        :param storage: an InstallerStorageConfig instance
+        :type storage: :class:`~.osinstall.InstallerStorageConfig`
         :returns: a list of partitioned disks with at least 500MiB of free space
         :rtype: list of :class:`~.devices.StorageDevice`
     """

--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -27,10 +27,10 @@ import contextlib
 import time
 import functools
 
-from pykickstart.constants import AUTOPART_TYPE_LVM, CLEARPART_TYPE_ALL, CLEARPART_TYPE_LIST, CLEARPART_TYPE_NONE
+from pykickstart.constants import AUTOPART_TYPE_LVM
 
 from .storage_log import log_method_call, log_exception_info
-from .devices import BTRFSDevice, BTRFSSubVolumeDevice, BTRFSVolumeDevice
+from .devices import BTRFSSubVolumeDevice, BTRFSVolumeDevice
 from .devices import LVMLogicalVolumeDevice, LVMVolumeGroupDevice
 from .devices import MDRaidArrayDevice, PartitionDevice, TmpFSDevice, device_path_to_name
 from .deviceaction import ActionCreateDevice, ActionCreateFormat, ActionDestroyDevice
@@ -45,7 +45,7 @@ from .formats import get_default_filesystem_type
 from .flags import flags
 from .platform import platform as _platform
 from .formats import get_format
-from .osinstall import FSSet, StorageDiscoveryConfig find_existing_installations
+from .osinstall import StorageDiscoveryConfig find_existing_installations
 from . import arch
 from .iscsi import iscsi
 from .fcoe import fcoe
@@ -53,8 +53,6 @@ from .zfcp import zfcp
 from . import devicefactory
 from . import get_bootloader, get_sysroot, short_product_name, __version__
 from .threads import SynchronizedMeta
-
-from .i18n import _
 
 import logging
 log = logging.getLogger("blivet")
@@ -105,7 +103,6 @@ class Blivet(object, metaclass=SynchronizedMeta):
                                      ignored_disks=self.ignored_disks,
                                      exclusive_disks=self.exclusive_disks,
                                      disk_images=self.disk_images)
-        self.fsset = FSSet(self.devicetree)
         self.roots = []
         self.services = set()
         self._free_space_snapshot = None
@@ -172,7 +169,6 @@ class Blivet(object, metaclass=SynchronizedMeta):
                               exclusive_disks=self.exclusive_disks,
                               disk_images=self.disk_images)
         self.devicetree.populate(cleanup_only=cleanup_only)
-        self.fsset = FSSet(self.devicetree)
         self.edd_dict = get_edd_dict(self.partitioned)
         self.devicetree.edd_dict = self.edd_dict
         if self.bootloader:
@@ -1042,32 +1038,6 @@ class Blivet(object, metaclass=SynchronizedMeta):
         self.devicetree.set_disk_images(self.disk_images)
         self.devicetree.setup_disk_images()
 
-    @property
-    def file_system_free_space(self):
-        """ Combined free space in / and /usr as :class:`~.size.Size`. """
-        mountpoints = ["/", "/usr"]
-        free = Size(0)
-        btrfs_volumes = []
-        for mountpoint in mountpoints:
-            device = self.mountpoints.get(mountpoint)
-            if not device:
-                continue
-
-            # don't count the size of btrfs volumes repeatedly when multiple
-            # subvolumes are present
-            if isinstance(device, BTRFSSubVolumeDevice):
-                if device.volume in btrfs_volumes:
-                    continue
-                else:
-                    btrfs_volumes.append(device.volume)
-
-            if device.format.exists:
-                free += device.format.free
-            else:
-                free += device.format.free_space_estimate(device.size)
-
-        return free
-
     def dump_state(self, suffix):
         """ Dump the current device list to the storage shelf. """
         key = "devices.%d.%s" % (time.time(), suffix)
@@ -1094,7 +1064,6 @@ class Blivet(object, metaclass=SynchronizedMeta):
         if not os.path.isdir("%s/etc" % get_sysroot()):
             os.mkdir("%s/etc" % get_sysroot())
 
-        self.fsset.write()
         iscsi.write(get_sysroot(), self)
         fcoe.write(get_sysroot())
         zfcp.write(get_sysroot())
@@ -1113,6 +1082,14 @@ class Blivet(object, metaclass=SynchronizedMeta):
             for dasd in dasds:
                 fields = [dasd.busid] + dasd.get_opts()
                 f.write("%s\n" % " ".join(fields),)
+
+    @property
+    def boot_device(self):
+        dev = None
+        root_device = self.mountpoints.get("/")
+
+        dev = self.mountpoints.get("/boot", root_device)
+        return dev
 
     @property
     def bootloader(self):
@@ -1162,13 +1139,6 @@ class Blivet(object, metaclass=SynchronizedMeta):
             spec = self.ksdata.bootloader.bootDrive
             disk = self.devicetree.resolve_device(spec)
         return disk
-
-    @property
-    def boot_device(self):
-        dev = None
-        if self.fsset:
-            dev = self.mountpoints.get("/boot", self.root_device)
-        return dev
 
     @property
     def bootloader_device(self):
@@ -1235,11 +1205,7 @@ class Blivet(object, metaclass=SynchronizedMeta):
 
     @property
     def mountpoints(self):
-        return self.fsset.mountpoints
-
-    @property
-    def root_device(self):
-        return self.fsset.root_device
+        return self.devicetree.mountpoints
 
     def compare_disks(self, first, second):
         if not isinstance(first, str):
@@ -1400,124 +1366,6 @@ class Blivet(object, metaclass=SynchronizedMeta):
 
         log.debug("finished Blivet copy")
         return new
-
-    def update_ksdata(self):
-        """ Update ksdata to reflect the settings of this Blivet instance. """
-        if not self.ksdata or not self.mountpoints:
-            return
-
-        # clear out whatever was there before
-        self.ksdata.partition.partitions = []
-        self.ksdata.logvol.lvList = []
-        self.ksdata.raid.raidList = []
-        self.ksdata.volgroup.vgList = []
-        self.ksdata.btrfs.btrfsList = []
-
-        # iscsi?
-        # fcoe?
-        # zfcp?
-        # dmraid?
-
-        # bootloader
-
-        # ignoredisk
-        if self.ignored_disks:
-            self.ksdata.ignoredisk.drives = self.ignored_disks[:]
-        elif self.exclusive_disks:
-            self.ksdata.ignoredisk.onlyuse = self.exclusive_disks[:]
-
-        # autopart
-        self.ksdata.autopart.autopart = self.do_autopart
-        self.ksdata.autopart.type = self.autopart_type
-        self.ksdata.autopart.encrypted = self.encrypted_autopart
-
-        # clearpart
-        self.ksdata.clearpart.type = self.config.clear_part_type
-        self.ksdata.clearpart.drives = self.config.clear_part_disks[:]
-        self.ksdata.clearpart.devices = self.config.clear_part_devices[:]
-        self.ksdata.clearpart.initAll = self.config.initialize_disks
-        if self.ksdata.clearpart.type == CLEARPART_TYPE_NONE:
-            # Make a list of initialized disks and of removed partitions. If any
-            # partitions were removed from disks that were not completely
-            # cleared we'll have to use CLEARPART_TYPE_LIST and provide a list
-            # of all removed partitions. If no partitions were removed from a
-            # disk that was not cleared/reinitialized we can use
-            # CLEARPART_TYPE_ALL.
-            self.ksdata.clearpart.devices = []
-            self.ksdata.clearpart.drives = []
-            fresh_disks = [d.name for d in self.disks if d.partitioned and
-                           not d.format.exists]
-
-            destroy_actions = self.devicetree.actions.find(action_type="destroy",
-                                                           object_type="device")
-
-            cleared_partitions = []
-            partial = False
-            for action in destroy_actions:
-                if action.device.type == "partition":
-                    if action.device.disk.name not in fresh_disks:
-                        partial = True
-
-                    cleared_partitions.append(action.device.name)
-
-            if not destroy_actions:
-                pass
-            elif partial:
-                # make a list of removed partitions
-                self.ksdata.clearpart.type = CLEARPART_TYPE_LIST
-                self.ksdata.clearpart.devices = cleared_partitions
-            else:
-                # if they didn't partially clear any disks, use the shorthand
-                self.ksdata.clearpart.type = CLEARPART_TYPE_ALL
-                self.ksdata.clearpart.drives = fresh_disks
-
-        if self.do_autopart:
-            return
-
-        self._update_custom_storage_ksdata()
-
-    def _update_custom_storage_ksdata(self):
-        """ Update KSData for custom storage. """
-
-        # custom storage
-        ks_map = {PartitionDevice: ("PartData", "partition"),
-                  TmpFSDevice: ("PartData", "partition"),
-                  LVMLogicalVolumeDevice: ("LogVolData", "logvol"),
-                  LVMVolumeGroupDevice: ("VolGroupData", "volgroup"),
-                  MDRaidArrayDevice: ("RaidData", "raid"),
-                  BTRFSDevice: ("BTRFSData", "btrfs")}
-
-        # make a list of ancestors of all used devices
-        devices = list(set(a for d in list(self.mountpoints.values()) + self.swaps
-                           for a in d.ancestors))
-
-        # devices which share information with their distinct raw device
-        complementary_devices = [d for d in devices if d.raw_device is not d]
-
-        devices.sort(key=lambda d: len(d.ancestors))
-        for device in devices:
-            cls = next((c for c in ks_map if isinstance(device, c)), None)
-            if cls is None:
-                log.info("omitting ksdata: %s", device)
-                continue
-
-            class_attr, list_attr = ks_map[cls]
-
-            cls = getattr(self.ksdata, class_attr)
-            data = cls()    # all defaults
-
-            complements = [d for d in complementary_devices if d.raw_device is device]
-
-            if len(complements) > 1:
-                log.warning("omitting ksdata for %s, found too many (%d) complementary devices", device, len(complements))
-                continue
-
-            device = complements[0] if complements else device
-
-            device.populate_ksdata(data)
-
-            parent = getattr(self.ksdata, list_attr)
-            parent.dataList().append(data)
 
     @property
     def free_space_snapshot(self):

--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -46,7 +46,7 @@ from .formats import get_default_filesystem_type
 from .flags import flags
 from .platform import platform as _platform
 from .formats import get_format
-from .osinstall import FSSet, find_existing_installations
+from .osinstall import FSSet, StorageDiscoveryConfig find_existing_installations
 from . import arch
 from .iscsi import iscsi
 from .fcoe import fcoe
@@ -70,37 +70,6 @@ def empty_device(device):
         empty = (device.format.type is None)
 
     return empty
-
-
-class StorageDiscoveryConfig(object):
-
-    """ Class to encapsulate various detection/initialization parameters. """
-
-    def __init__(self):
-        # storage configuration variables
-        self.ignore_disk_interactive = False
-        self.clear_part_type = None
-        self.clear_part_disks = []
-        self.clear_part_devices = []
-        self.initialize_disks = False
-        self.protected_dev_specs = []
-        self.zero_mbr = False
-
-        # Whether clear_partitions removes scheduled/non-existent devices and
-        # disklabels depends on this flag.
-        self.clear_non_existent = False
-
-    def update(self, ksdata):
-        """ Update configuration from ksdata source.
-
-            :param ksdata: kickstart data used as data source
-            :type ksdata: :class:`pykickstart.Handler`
-        """
-        self.clear_part_type = ksdata.clearpart.type
-        self.clear_part_disks = ksdata.clearpart.drives[:]
-        self.clear_part_devices = ksdata.clearpart.devices[:]
-        self.initialize_disks = ksdata.clearpart.initAll
-        self.zero_mbr = ksdata.zerombr.zerombr
 
 
 class Blivet(object, metaclass=SynchronizedMeta):

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -69,15 +69,23 @@ class DeviceTreeBase(object, metaclass=SynchronizedMeta):
         :class:`~.deviceaction.DeviceAction` instances can only be registered
         for leaf devices, except for resize actions.
     """
-    def __init__(self, conf=None):
+    def __init__(self, ignored_disks=None, exclusive_disks=None):
         """
-            :keyword conf: storage discovery configuration
-            :type conf: :class:`~.StorageDiscoveryConfig`
+            :keyword ignored_disks: ignored disks
+            :type ignored_disks: list
+            :keyword exclusive_disks: exclusive didks
+            :type exclusive_disks: list
         """
-        self.reset(conf)
+        self.reset(ignored_disks, exclusive_disks)
 
-    def reset(self, conf=None):
-        """ Reset the instance to its initial state. """
+    def reset(self, ignored_disks=None, exclusive_disks=None):
+        """ Reset the instance to its initial state.
+
+            :keyword ignored_disks: ignored disks
+            :type ignored_disks: list
+            :keyword exclusive_disks: exclusive didks
+            :type exclusive_disks: list
+        """
         # internal data members
         self._devices = []
         self._actions = ActionList(addfunc=self._register_action,
@@ -90,8 +98,8 @@ class DeviceTreeBase(object, metaclass=SynchronizedMeta):
 
         lvm.lvm_cc_resetFilter()
 
-        self.exclusive_disks = getattr(conf, "exclusive_disks", [])
-        self.ignored_disks = getattr(conf, "ignored_disks", [])
+        self.exclusive_disks = exclusive_disks
+        self.ignored_disks = ignored_disks
 
         self.edd_dict = {}
 
@@ -882,12 +890,12 @@ class DeviceTreeBase(object, metaclass=SynchronizedMeta):
 
 
 class DeviceTree(DeviceTreeBase, PopulatorMixin, EventHandlerMixin):
-    def __init__(self, conf=None, passphrase=None, luks_dict=None):
-        DeviceTreeBase.__init__(self, conf=conf)
-        PopulatorMixin.__init__(self, conf=conf, passphrase=passphrase, luks_dict=luks_dict)
+    def __init__(self, passphrase=None, luks_dict=None, ignored_disks=None, exclusive_disks=None, disk_images=None):
+        DeviceTreeBase.__init__(self, ignored_disks=ignored_disks, exclusive_disks=exclusive_disks)
+        PopulatorMixin.__init__(self, passphrase=passphrase, luks_dict=luks_dict, disk_images=disk_images)
         EventHandlerMixin.__init__(self)
 
     # pylint: disable=arguments-differ
-    def reset(self, conf=None, passphrase=None, luks_dict=None):
-        DeviceTreeBase.reset(self, conf=conf)
-        PopulatorMixin.reset(self, conf=conf, passphrase=passphrase, luks_dict=luks_dict)
+    def reset(self, passphrase=None, luks_dict=None, ignored_disks=None, exclusive_disks=None, disk_images=None):
+        DeviceTreeBase.reset(self, ignored_disks=ignored_disks, exclusive_disks=exclusive_disks)
+        PopulatorMixin.reset(self, passphrase=passphrase, luks_dict=luks_dict, disk_images=disk_images)

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -778,6 +778,15 @@ class DeviceTreeBase(object, metaclass=SynchronizedMeta):
 
         return labels
 
+    @property
+    def mountpoints(self):
+        """ Dict with mountpoint keys and Device values. """
+        filesystems = {}
+        for device in self.devices:
+            if device.format.mountable and device.format.mountpoint:
+                filesystems[device.format.mountpoint] = device
+        return filesystems
+
     #
     # Disk filter
     #

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -899,12 +899,12 @@ class DeviceTreeBase(object, metaclass=SynchronizedMeta):
 
 
 class DeviceTree(DeviceTreeBase, PopulatorMixin, EventHandlerMixin):
-    def __init__(self, passphrase=None, luks_dict=None, ignored_disks=None, exclusive_disks=None, disk_images=None):
+    def __init__(self, passphrase=None, luks_dict=None, ignored_disks=None, exclusive_disks=None, disk_images=None, protected_dev_specs=None):
         DeviceTreeBase.__init__(self, ignored_disks=ignored_disks, exclusive_disks=exclusive_disks)
-        PopulatorMixin.__init__(self, passphrase=passphrase, luks_dict=luks_dict, disk_images=disk_images)
+        PopulatorMixin.__init__(self, passphrase=passphrase, luks_dict=luks_dict, disk_images=disk_images, protected_dev_specs=protected_dev_specs)
         EventHandlerMixin.__init__(self)
 
     # pylint: disable=arguments-differ
-    def reset(self, passphrase=None, luks_dict=None, ignored_disks=None, exclusive_disks=None, disk_images=None):
+    def reset(self, passphrase=None, luks_dict=None, ignored_disks=None, exclusive_disks=None, disk_images=None, protected_dev_specs=None):
         DeviceTreeBase.reset(self, ignored_disks=ignored_disks, exclusive_disks=exclusive_disks)
-        PopulatorMixin.reset(self, passphrase=passphrase, luks_dict=luks_dict, disk_images=disk_images)
+        PopulatorMixin.reset(self, passphrase=passphrase, luks_dict=luks_dict, disk_images=disk_images, protected_dev_specs=protected_dev_specs)

--- a/blivet/osinstall.py
+++ b/blivet/osinstall.py
@@ -278,6 +278,37 @@ def _find_existing_installations(devicetree):
     return roots
 
 
+class StorageDiscoveryConfig(object):
+
+    """ Class to encapsulate various detection/initialization parameters. """
+
+    def __init__(self):
+        # storage configuration variables
+        self.ignore_disk_interactive = False
+        self.clear_part_type = None
+        self.clear_part_disks = []
+        self.clear_part_devices = []
+        self.initialize_disks = False
+        self.protected_dev_specs = []
+        self.zero_mbr = False
+
+        # Whether clear_partitions removes scheduled/non-existent devices and
+        # disklabels depends on this flag.
+        self.clear_non_existent = False
+
+    def update(self, ksdata):
+        """ Update configuration from ksdata source.
+
+            :param ksdata: kickstart data used as data source
+            :type ksdata: :class:`pykickstart.Handler`
+        """
+        self.clear_part_type = ksdata.clearpart.type
+        self.clear_part_disks = ksdata.clearpart.drives[:]
+        self.clear_part_devices = ksdata.clearpart.devices[:]
+        self.initialize_disks = ksdata.clearpart.init_all
+        self.zero_mbr = ksdata.zerombr.zerombr
+
+
 class FSSet(object):
 
     """ A class to represent a set of filesystems. """

--- a/blivet/osinstall.py
+++ b/blivet/osinstall.py
@@ -31,9 +31,9 @@ gi.require_version("BlockDev", "1.0")
 
 from gi.repository import BlockDev as blockdev
 
-from pykickstart.constants import CLEARPART_TYPE_NONE, CLEARPART_TYPE_LINUX, CLEARPART_TYPE_ALL, CLEARPART_TYPE_LIST
+from pykickstart.constants import AUTOPART_TYPE_LVM, CLEARPART_TYPE_NONE, CLEARPART_TYPE_LINUX, CLEARPART_TYPE_ALL, CLEARPART_TYPE_LIST
 
-from . import util
+from . import util, __version__
 from . import get_sysroot, get_target_physical_root, error_handler, ERROR_RAISE
 
 from .blivet import Blivet
@@ -41,10 +41,15 @@ from .storage_log import log_exception_info
 from .devices import FileDevice, NFSDevice, NoDevice, OpticalDevice, NetworkStorageDevice, DirectoryDevice
 from .devices import PartitionDevice, BTRFSSubVolumeDevice, TmpFSDevice, LVMLogicalVolumeDevice, LVMVolumeGroupDevice
 from .devices import MDRaidArrayDevice, BTRFSDevice
+from .devicelibs.edd import get_edd_dict
+from .devicetree import DeviceTree
 from .errors import FSTabTypeMismatchError, UnrecognizedFSTabEntryError, StorageError, FSResizeError, FormatResizeError, UnknownSourceDeviceError
 from .formats import get_device_format_class
 from .formats import get_format
 from .flags import flags
+from .iscsi import iscsi
+from .fcoe import fcoe
+from .zfcp import zfcp
 from .platform import platform as _platform
 from .platform import EFI
 from .size import Size
@@ -313,7 +318,7 @@ class StorageDiscoveryConfig(object):
         self.clear_part_type = ksdata.clearpart.type
         self.clear_part_disks = ksdata.clearpart.drives[:]
         self.clear_part_devices = ksdata.clearpart.devices[:]
-        self.initialize_disks = ksdata.clearpart.init_all
+        self.initialize_disks = ksdata.clearpart.initAll
         self.zero_mbr = ksdata.zerombr.zerombr
 
 
@@ -1232,7 +1237,7 @@ class InstallerStorageConfig(Blivet):
             # no longer in the tree
             self.bootloader.reset()
         if self.ksdata:
-             self.config.updates(self.ksdata)
+            self.config.update(self.ksdata)
         self.roots = []
         if flags.installer_mode:
             self.roots = find_existing_installations(self.devicetree)
@@ -1465,176 +1470,22 @@ class InstallerStorageConfig(Blivet):
             parent = getattr(self.ksdata, list_attr)
             parent.dataList().append(data)
 
+        self.config = StorageDiscoveryConfig()
+        self.autopart_type = AUTOPART_TYPE_LVM
+
+        self.__luks_devs = {}
+
+        # these will both be empty until our reset method gets called
+        # instantiate our own devicetree here to override the default created
+        # in Blivet so that protected_dev_specs gets handled
+        self.devicetree = DeviceTree(passphrase=self.encryption_passphrase,
+                                     luks_dict=self.__luks_devs,
+                                     ignored_disks=self.ignored_disks,
+                                     exclusive_disks=self.exclusive_disks,
+                                     disk_images=self.disk_images,
+                                     protected_dev_specs=self.config.protected_dev_specs)
         self.fsset = FSSet(self.devicetree)
-
-    def reset(self, cleanup_only=False):
-        Blivet.reset(self, cleanup_only)
-
-        self.fsset = FSSet(self.devicetree)
-
-    def write(self):
-        Blivet.write(self)
-
-        self.fsset.write()
-        self.make_mtab()
-
-    @property
-    def boot_device(self):
-        dev = None
-        if self.fsset:
-            dev = self.mountpoints.get("/boot", self.root_device)
-        return dev
-
-    @property
-    def mountpoints(self):
-        return self.fsset.mountpoints
-
-    @property
-    def root_device(self):
-        return self.fsset.root_device
-
-    @property
-    def file_system_free_space(self):
-        """ Combined free space in / and /usr as :class:`~.size.Size`. """
-        mountpoints = ["/", "/usr"]
-        free = Size(0)
-        btrfs_volumes = []
-        for mountpoint in mountpoints:
-            device = self.mountpoints.get(mountpoint)
-            if not device:
-                continue
-
-            # don't count the size of btrfs volumes repeatedly when multiple
-            # subvolumes are present
-            if isinstance(device, BTRFSSubVolumeDevice):
-                if device.volume in btrfs_volumes:
-                    continue
-                else:
-                    btrfs_volumes.append(device.volume)
-
-            if device.format.exists:
-                free += device.format.free
-            else:
-                free += device.format.free_space_estimate(device.size)
-
-        return free
-    def update_ksdata(self):
-        """ Update ksdata to reflect the settings of this Blivet instance. """
-        if not self.ksdata or not self.mountpoints:
-            return
-
-        # clear out whatever was there before
-        self.ksdata.partition.partitions = []
-        self.ksdata.logvol.lvList = []
-        self.ksdata.raid.raidList = []
-        self.ksdata.volgroup.vgList = []
-        self.ksdata.btrfs.btrfsList = []
-
-        # iscsi?
-        # fcoe?
-        # zfcp?
-        # dmraid?
-
-        # bootloader
-
-        # ignoredisk
-        if self.ignored_disks:
-            self.ksdata.ignoredisk.drives = self.ignored_disks[:]
-        elif self.exclusive_disks:
-            self.ksdata.ignoredisk.onlyuse = self.exclusive_disks[:]
-
-        # autopart
-        self.ksdata.autopart.autopart = self.do_autopart
-        self.ksdata.autopart.type = self.autopart_type
-        self.ksdata.autopart.encrypted = self.encrypted_autopart
-
-        # clearpart
-        self.ksdata.clearpart.type = self.config.clear_part_type
-        self.ksdata.clearpart.drives = self.config.clear_part_disks[:]
-        self.ksdata.clearpart.devices = self.config.clear_part_devices[:]
-        self.ksdata.clearpart.initAll = self.config.initialize_disks
-        if self.ksdata.clearpart.type == CLEARPART_TYPE_NONE:
-            # Make a list of initialized disks and of removed partitions. If any
-            # partitions were removed from disks that were not completely
-            # cleared we'll have to use CLEARPART_TYPE_LIST and provide a list
-            # of all removed partitions. If no partitions were removed from a
-            # disk that was not cleared/reinitialized we can use
-            # CLEARPART_TYPE_ALL.
-            self.ksdata.clearpart.devices = []
-            self.ksdata.clearpart.drives = []
-            fresh_disks = [d.name for d in self.disks if d.partitioned and
-                           not d.format.exists]
-
-            destroy_actions = self.devicetree.actions.find(action_type="destroy",
-                                                           object_type="device")
-
-            cleared_partitions = []
-            partial = False
-            for action in destroy_actions:
-                if action.device.type == "partition":
-                    if action.device.disk.name not in fresh_disks:
-                        partial = True
-
-                    cleared_partitions.append(action.device.name)
-
-            if not destroy_actions:
-                pass
-            elif partial:
-                # make a list of removed partitions
-                self.ksdata.clearpart.type = CLEARPART_TYPE_LIST
-                self.ksdata.clearpart.devices = cleared_partitions
-            else:
-                # if they didn't partially clear any disks, use the shorthand
-                self.ksdata.clearpart.type = CLEARPART_TYPE_ALL
-                self.ksdata.clearpart.drives = fresh_disks
-
-        if self.do_autopart:
-            return
-
-        self._update_custom_storage_ksdata()
-
-    def _update_custom_storage_ksdata(self):
-        """ Update KSData for custom storage. """
-
-        # custom storage
-        ks_map = {PartitionDevice: ("PartData", "partition"),
-                  TmpFSDevice: ("PartData", "partition"),
-                  LVMLogicalVolumeDevice: ("LogVolData", "logvol"),
-                  LVMVolumeGroupDevice: ("VolGroupData", "volgroup"),
-                  MDRaidArrayDevice: ("RaidData", "raid"),
-                  BTRFSDevice: ("BTRFSData", "btrfs")}
-
-        # make a list of ancestors of all used devices
-        devices = list(set(a for d in list(self.mountpoints.values()) + self.swaps
-                           for a in d.ancestors))
-
-        # devices which share information with their distinct raw device
-        complementary_devices = [d for d in devices if d.raw_device is not d]
-
-        devices.sort(key=lambda d: len(d.ancestors))
-        for device in devices:
-            cls = next((c for c in ks_map if isinstance(device, c)), None)
-            if cls is None:
-                log.info("omitting ksdata: %s", device)
-                continue
-
-            class_attr, list_attr = ks_map[cls]
-
-            cls = getattr(self.ksdata, class_attr)
-            data = cls()    # all defaults
-
-            complements = [d for d in complementary_devices if d.raw_device is device]
-
-            if len(complements) > 1:
-                log.warning("omitting ksdata for %s, found too many (%d) complementary devices", device, len(complements))
-                continue
-
-            device = complements[0] if complements else device
-
-            device.populate_ksdata(data)
-
-            parent = getattr(self.ksdata, list_attr)
-            parent.dataList().append(data)
+        self._free_space_snapshot = None
 
     def empty_device(self, device):
         empty = True
@@ -1874,6 +1725,18 @@ class InstallerStorageConfig(Blivet):
             os.unlink(path)
 
         os.symlink(target, path)
+
+    @property
+    def free_space_snapshot(self):
+        # if no snapshot is available, do it now and return it
+        self._free_space_snapshot = self._free_space_snapshot or self.get_free_space()
+
+        return self._free_space_snapshot
+
+    def create_free_space_snapshot(self):
+        self._free_space_snapshot = self.get_free_space()
+
+        return self._free_space_snapshot
 
     def add_fstab_swap(self, device):
         """

--- a/blivet/osinstall.py
+++ b/blivet/osinstall.py
@@ -24,17 +24,21 @@ import shlex
 import os
 import stat
 import time
+import parted
 
 import gi
 gi.require_version("BlockDev", "1.0")
 
 from gi.repository import BlockDev as blockdev
 
+from pykickstart.constants import CLEARPART_TYPE_NONE, CLEARPART_TYPE_LINUX, CLEARPART_TYPE_ALL, CLEARPART_TYPE_LIST
+
 from . import util
 from . import get_sysroot, get_target_physical_root, error_handler, ERROR_RAISE
 
+from .blivet import Blivet
 from .storage_log import log_exception_info
-from .devices import FileDevice, NFSDevice, NoDevice, OpticalDevice, NetworkStorageDevice, DirectoryDevice, MDRaidArrayDevice
+from .devices import FileDevice, NFSDevice, NoDevice, OpticalDevice, NetworkStorageDevice, DirectoryDevice, MDRaidArrayDevice, PartitionDevice
 from .errors import FSTabTypeMismatchError, UnrecognizedFSTabEntryError, StorageError, FSResizeError, FormatResizeError, UnknownSourceDeviceError
 from .formats import get_device_format_class
 from .formats import get_format
@@ -283,6 +287,7 @@ class StorageDiscoveryConfig(object):
     """ Class to encapsulate various detection/initialization parameters. """
 
     def __init__(self):
+
         # storage configuration variables
         self.ignore_disk_interactive = False
         self.clear_part_type = None
@@ -1092,6 +1097,653 @@ class CryptTab(object):
 
     def get(self, key, default=None):
         return self.mappings.get(key, default)
+
+
+class InstallerStorageConfig(Blivet):
+    """ Top-level class for managing installer-related storage configuration. """
+    def __init__(self, ksdata=None):
+        """
+            :keyword ksdata: kickstart data store
+            :type ksdata: :class:`pykickstart.Handler`
+        """
+        super().__init__(ksdata=ksdata)
+
+        self.config = StorageDiscoveryConfig()
+        self.autopart_type = AUTOPART_TYPE_LVM
+
+        self.__luks_devs = {}
+
+        # these will both be empty until our reset method gets called
+        # instantiate our own devicetree here to override the default created
+        # in Blivet so that protected_dev_specs gets handled
+        self.devicetree = DeviceTree(passphrase=self.encryption_passphrase,
+                                     luks_dict=self.__luks_devs,
+                                     ignored_disks=self.ignored_disks,
+                                     exclusive_disks=self.exclusive_disks,
+                                     disk_images=self.disk_images,
+                                     protected_dev_specs=self.config.protected_dev_specs)
+        self.fsset = FSSet(self.devicetree)
+        self._free_space_snapshot = None
+
+    def do_it(self, callbacks=None):
+        """
+        Commit queued changes to disk.
+
+        :param callbacks: callbacks to be invoked when actions are executed
+        :type callbacks: return value of the :func:`~.callbacks.create_new_callbacks_
+
+        """
+        super().do_it(callbacks=callbacks)
+
+        if not flags.installer_mode:
+            return
+
+        # now set the boot partition's flag
+        if self.bootloader and not self.bootloader.skip_bootloader:
+            if self.bootloader.stage2_bootable:
+                boot = self.boot_device
+            else:
+                boot = self.bootloader_device
+
+            if boot.type == "mdarray":
+                boot_devs = boot.parents
+            else:
+                boot_devs = [boot]
+
+            for dev in boot_devs:
+                if not hasattr(dev, "bootable"):
+                    log.info("Skipping %s, not bootable", dev)
+                    continue
+
+                # Dos labels can only have one partition marked as active
+                # and unmarking ie the windows partition is not a good idea
+                skip = False
+                if dev.disk.format.parted_disk.type == "msdos":
+                    for p in dev.disk.format.parted_disk.partitions:
+                        if p.type == parted.PARTITION_NORMAL and \
+                           p.getFlag(parted.PARTITION_BOOT):
+                            skip = True
+                            break
+
+                # GPT labeled disks should only have bootable set on the
+                # EFI system partition (parted sets the EFI System GUID on
+                # GPT partitions with the boot flag)
+                if dev.disk.format.label_type == "gpt" and \
+                   dev.format.type not in ["efi", "macefi"]:
+                    skip = True
+
+                if skip:
+                    log.info("Skipping %s", dev.name)
+                    continue
+
+                # hfs+ partitions on gpt can't be marked bootable via parted
+                if dev.disk.format.parted_disk.type != "gpt" or \
+                        dev.format.type not in ["hfs+", "macefi"]:
+                    log.info("setting boot flag on %s", dev.name)
+                    dev.bootable = True
+
+                # Set the boot partition's name on disk labels that support it
+                if dev.parted_partition.disk.supportsFeature(parted.DISK_TYPE_PARTITION_NAME):
+                    ped_partition = dev.parted_partition.getPedPartition()
+                    ped_partition.setName(dev.format.name)
+                    log.info("Setting label on %s to '%s'", dev, dev.format.name)
+
+                dev.disk.setup()
+                dev.disk.format.commit_to_disk()
+
+        if flags.installer_mode:
+            self.dump_state("final")
+
+    def reset(self, cleanup_only=False):
+        """ Reset storage configuration to reflect actual system state.
+            This will cancel any queued actions and rescan from scratch but not
+            clobber user-obtained information like passphrases, iscsi config, &c
+
+            :keyword cleanup_only: prepare the tree only to deactivate devices
+            :type cleanup_only: bool
+
+            See :meth:`devicetree.Devicetree.populate` for more information
+            about the cleanup_only keyword argument.
+        """
+        log.info("resetting Blivet (version %s) instance %s", __version__, self)
+        if flags.installer_mode:
+            # save passphrases for luks devices so we don't have to reprompt
+            self.encryption_passphrase = None
+            for device in self.devices:
+                if device.format.type == "luks" and device.format.exists:
+                    self.save_passphrase(device)
+
+        if flags.installer_mode and not flags.image_install:
+            iscsi.startup()
+            fcoe.startup()
+            zfcp.startup()
+
+        self.devicetree.reset(passphrase=self.encryption_passphrase,
+                              luks_dict=self.__luks_devs,
+                              ignored_disks=self.ignored_disks,
+                              exclusive_disks=self.exclusive_disks,
+                              disk_images=self.disk_images,
+                              protected_dev_specs=self.config.protected_dev_specs)
+        self.devicetree.populate(cleanup_only=cleanup_only)
+        self.fsset = FSSet(self.devicetree)
+        self.edd_dict = get_edd_dict(self.partitioned)
+        self.devicetree.edd_dict = self.edd_dict
+        if self.bootloader:
+            # clear out bootloader attributes that refer to devices that are
+            # no longer in the tree
+            self.bootloader.reset()
+        if self.ksdata:
+             self.config.updates(self.ksdata)
+        self.roots = []
+        if flags.installer_mode:
+            self.roots = find_existing_installations(self.devicetree)
+            self.dump_state("initial")
+
+        if not flags.installer_mode:
+            self.devicetree.handle_nodev_filesystems()
+
+        self.update_bootloader_disk_list()
+
+    def get_free_space(self, disks=None, clear_part_type=None):
+        """ Return a dict with free space info for each disk.
+
+            The dict values are 2-tuples: (disk_free, fs_free). fs_free is
+            space available by shrinking filesystems. disk_free is space not
+            allocated to any partition.
+
+            disks and clear_part_type allow specifying a set of disks other than
+            self.disks and a clear_part_type value other than
+            self.config.clear_part_type.
+
+            :keyword disks: overrides :attr:`disks`
+            :type disks: list
+            :keyword clear_part_type: overrides :attr:`self.config.clear_part_type`
+            :type clear_part_type: int
+            :returns: dict with disk name keys and tuple (disk, fs) free values
+            :rtype: dict
+
+            .. note::
+
+                The free space values are :class:`~.size.Size` instances.
+
+        """
+        if disks is None:
+            disks = self.disks
+
+        if clear_part_type is None:
+            clear_part_type = self.config.clear_part_type
+
+        free = {}
+        for disk in disks:
+            should_clear = self.should_clear(disk, clear_part_type=clear_part_type,
+                                             clear_part_disks=[disk.name])
+            if should_clear:
+                free[disk.name] = (disk.size, Size(0))
+                continue
+
+            disk_free = Size(0)
+            fs_free = Size(0)
+            if disk.partitioned:
+                disk_free = disk.format.free
+                for partition in [p for p in self.partitions if p.disk == disk]:
+                    # only check actual filesystems since lvm &c require a bunch of
+                    # operations to translate free filesystem space into free disk
+                    # space
+                    should_clear = self.should_clear(partition,
+                                                     clear_part_type=clear_part_type,
+                                                     clear_part_disks=[disk.name])
+                    if should_clear:
+                        disk_free += partition.size
+                    elif hasattr(partition.format, "free"):
+                        fs_free += partition.format.free
+            elif hasattr(disk.format, "free"):
+                fs_free = disk.format.free
+            elif disk.format.type is None:
+                disk_free = disk.size
+
+            free[disk.name] = (disk_free, fs_free)
+
+        return free
+
+    def write(self):
+        Blivet.write(self)
+
+        self.fsset.write()
+        self.make_mtab()
+        iscsi.write(get_sysroot(), self)
+        fcoe.write(get_sysroot())
+        zfcp.write(get_sysroot())
+
+    @property
+    def boot_device(self):
+        dev = None
+        if self.fsset:
+            dev = self.mountpoints.get("/boot", self.root_device)
+        return dev
+
+    @property
+    def mountpoints(self):
+        return self.fsset.mountpoints
+
+    @property
+    def root_device(self):
+        return self.fsset.root_device
+
+    @property
+    def file_system_free_space(self):
+        """ Combined free space in / and /usr as :class:`~.size.Size`. """
+        mountpoints = ["/", "/usr"]
+        free = Size(0)
+        btrfs_volumes = []
+        for mountpoint in mountpoints:
+            device = self.mountpoints.get(mountpoint)
+            if not device:
+                continue
+
+            # don't count the size of btrfs volumes repeatedly when multiple
+            # subvolumes are present
+            if isinstance(device, BTRFSSubVolumeDevice):
+                if device.volume in btrfs_volumes:
+                    continue
+                else:
+                    btrfs_volumes.append(device.volume)
+
+            if device.format.exists:
+                free += device.format.free
+            else:
+                free += device.format.free_space_estimate(device.size)
+
+        return free
+    def update_ksdata(self):
+        """ Update ksdata to reflect the settings of this Blivet instance. """
+        if not self.ksdata or not self.mountpoints:
+            return
+
+        # clear out whatever was there before
+        self.ksdata.partition.partitions = []
+        self.ksdata.logvol.lvList = []
+        self.ksdata.raid.raidList = []
+        self.ksdata.volgroup.vgList = []
+        self.ksdata.btrfs.btrfsList = []
+
+        # iscsi?
+        # fcoe?
+        # zfcp?
+        # dmraid?
+
+        # bootloader
+
+        # ignoredisk
+        if self.ignored_disks:
+            self.ksdata.ignoredisk.drives = self.ignored_disks[:]
+        elif self.exclusive_disks:
+            self.ksdata.ignoredisk.onlyuse = self.exclusive_disks[:]
+
+        # autopart
+        self.ksdata.autopart.autopart = self.do_autopart
+        self.ksdata.autopart.type = self.autopart_type
+        self.ksdata.autopart.encrypted = self.encrypted_autopart
+
+        # clearpart
+        self.ksdata.clearpart.type = self.config.clear_part_type
+        self.ksdata.clearpart.drives = self.config.clear_part_disks[:]
+        self.ksdata.clearpart.devices = self.config.clear_part_devices[:]
+        self.ksdata.clearpart.initAll = self.config.initialize_disks
+        if self.ksdata.clearpart.type == CLEARPART_TYPE_NONE:
+            # Make a list of initialized disks and of removed partitions. If any
+            # partitions were removed from disks that were not completely
+            # cleared we'll have to use CLEARPART_TYPE_LIST and provide a list
+            # of all removed partitions. If no partitions were removed from a
+            # disk that was not cleared/reinitialized we can use
+            # CLEARPART_TYPE_ALL.
+            self.ksdata.clearpart.devices = []
+            self.ksdata.clearpart.drives = []
+            fresh_disks = [d.name for d in self.disks if d.partitioned and
+                           not d.format.exists]
+
+            destroy_actions = self.devicetree.actions.find(action_type="destroy",
+                                                           object_type="device")
+
+            cleared_partitions = []
+            partial = False
+            for action in destroy_actions:
+                if action.device.type == "partition":
+                    if action.device.disk.name not in fresh_disks:
+                        partial = True
+
+                    cleared_partitions.append(action.device.name)
+
+            if not destroy_actions:
+                pass
+            elif partial:
+                # make a list of removed partitions
+                self.ksdata.clearpart.type = CLEARPART_TYPE_LIST
+                self.ksdata.clearpart.devices = cleared_partitions
+            else:
+                # if they didn't partially clear any disks, use the shorthand
+                self.ksdata.clearpart.type = CLEARPART_TYPE_ALL
+                self.ksdata.clearpart.drives = fresh_disks
+
+        if self.do_autopart:
+            return
+
+        self._update_custom_storage_ksdata()
+
+    def _update_custom_storage_ksdata(self):
+        """ Update KSData for custom storage. """
+
+        # custom storage
+        ks_map = {PartitionDevice: ("PartData", "partition"),
+                  TmpFSDevice: ("PartData", "partition"),
+                  LVMLogicalVolumeDevice: ("LogVolData", "logvol"),
+                  LVMVolumeGroupDevice: ("VolGroupData", "volgroup"),
+                  MDRaidArrayDevice: ("RaidData", "raid"),
+                  BTRFSDevice: ("BTRFSData", "btrfs")}
+
+        # make a list of ancestors of all used devices
+        devices = list(set(a for d in list(self.mountpoints.values()) + self.swaps
+                           for a in d.ancestors))
+
+        # devices which share information with their distinct raw device
+        complementary_devices = [d for d in devices if d.raw_device is not d]
+
+        devices.sort(key=lambda d: len(d.ancestors))
+        for device in devices:
+            cls = next((c for c in ks_map if isinstance(device, c)), None)
+            if cls is None:
+                log.info("omitting ksdata: %s", device)
+                continue
+
+            class_attr, list_attr = ks_map[cls]
+
+            cls = getattr(self.ksdata, class_attr)
+            data = cls()    # all defaults
+
+            complements = [d for d in complementary_devices if d.raw_device is device]
+
+            if len(complements) > 1:
+                log.warning("omitting ksdata for %s, found too many (%d) complementary devices", device, len(complements))
+                continue
+
+            device = complements[0] if complements else device
+
+            device.populate_ksdata(data)
+
+            parent = getattr(self.ksdata, list_attr)
+            parent.dataList().append(data)
+
+    def empty_device(self, device):
+        empty = True
+        if device.partitioned:
+            partitions = device.children
+            empty = all([p.is_magic for p in partitions])
+        else:
+            empty = (device.format.type is None)
+
+        return empty
+
+    @property
+    def unused_devices(self):
+        used_devices = []
+        for root in self.roots:
+            for device in list(root.mounts.values()) + root.swaps:
+                if device not in self.devices:
+                    continue
+
+                used_devices.extend(device.ancestors)
+
+        for new in [d for d in self.devicetree.leaves if not d.format.exists]:
+            if new.format.mountable and not new.format.mountpoint:
+                continue
+
+            used_devices.extend(new.ancestors)
+
+        for device in self.partitions:
+            if getattr(device, "is_logical", False):
+                extended = device.disk.format.extended_partition.path
+                used_devices.append(self.devicetree.get_device_by_path(extended))
+
+        used = set(used_devices)
+        _all = set(self.devices)
+        return list(_all.difference(used))
+
+    def should_clear(self, device, **kwargs):
+        """ Return True if a clearpart settings say a device should be cleared.
+
+            :param device: the device (required)
+            :type device: :class:`~.devices.StorageDevice`
+            :keyword clear_part_type: overrides :attr:`self.config.clear_part_type`
+            :type clear_part_type: int
+            :keyword clear_part_disks: overrides
+                                     :attr:`self.config.clear_part_disks`
+            :type clear_part_disks: list
+            :keyword clear_part_devices: overrides
+                                       :attr:`self.config.clear_part_devices`
+            :type clear_part_devices: list
+            :returns: whether or not clear_partitions should remove this device
+            :rtype: bool
+        """
+        clear_part_type = kwargs.get("clear_part_type", self.config.clear_part_type)
+        clear_part_disks = kwargs.get("clear_part_disks",
+                                      self.config.clear_part_disks)
+        clear_part_devices = kwargs.get("clear_part_devices",
+                                        self.config.clear_part_devices)
+
+        for disk in device.disks:
+            # this will not include disks with hidden formats like multipath
+            # and firmware raid member disks
+            if clear_part_disks and disk.name not in clear_part_disks:
+                return False
+
+        if not self.config.clear_non_existent:
+            if (device.is_disk and not device.format.exists) or \
+               (not device.is_disk and not device.exists):
+                return False
+
+        # the only devices we want to clear when clear_part_type is
+        # CLEARPART_TYPE_NONE are uninitialized disks, or disks with no
+        # partitions, in clear_part_disks, and then only when we have been asked
+        # to initialize disks as needed
+        if clear_part_type in [CLEARPART_TYPE_NONE, None]:
+            if not self.config.initialize_disks or not device.is_disk:
+                return False
+
+            if not self.empty_device(device):
+                return False
+
+        if isinstance(device, PartitionDevice):
+            # Never clear the special first partition on a Mac disk label, as
+            # that holds the partition table itself.
+            # Something similar for the third partition on a Sun disklabel.
+            if device.is_magic:
+                return False
+
+            # We don't want to fool with extended partitions, freespace, &c
+            if not device.is_primary and not device.is_logical:
+                return False
+
+            if clear_part_type == CLEARPART_TYPE_LINUX and \
+               not device.format.linux_native and \
+               not device.get_flag(parted.PARTITION_LVM) and \
+               not device.get_flag(parted.PARTITION_RAID) and \
+               not device.get_flag(parted.PARTITION_SWAP):
+                return False
+        elif device.is_disk:
+            if device.partitioned and clear_part_type != CLEARPART_TYPE_ALL:
+                # if clear_part_type is not CLEARPART_TYPE_ALL but we'll still be
+                # removing every partition from the disk, return True since we
+                # will want to be able to create a new disklabel on this disk
+                if not self.empty_device(device):
+                    return False
+
+            # Never clear disks with hidden formats
+            if device.format.hidden:
+                return False
+
+            # When clear_part_type is CLEARPART_TYPE_LINUX and a disk has non-
+            # linux whole-disk formatting, do not clear it. The exception is
+            # the case of an uninitialized disk when we've been asked to
+            # initialize disks as needed
+            if (clear_part_type == CLEARPART_TYPE_LINUX and
+                not ((self.config.initialize_disks and
+                      self.empty_device(device)) or
+                     (not device.partitioned and device.format.linux_native))):
+                return False
+
+        # Don't clear devices holding install media.
+        descendants = self.devicetree.get_dependent_devices(device)
+        if device.protected or any(d.protected for d in descendants):
+            return False
+
+        if clear_part_type == CLEARPART_TYPE_LIST and \
+           device.name not in clear_part_devices:
+            return False
+
+        return True
+
+    def clear_partitions(self):
+        """ Clear partitions and dependent devices from disks.
+
+            This is also where zerombr is handled.
+        """
+        # Sort partitions by descending partition number to minimize confusing
+        # things like multiple "destroy sda5" actions due to parted renumbering
+        # partitions. This can still happen through the UI but it makes sense to
+        # avoid it where possible.
+        partitions = sorted(self.partitions,
+                            key=lambda p: p.parted_partition.number,
+                            reverse=True)
+        for part in partitions:
+            log.debug("clearpart: looking at %s", part.name)
+            if not self.should_clear(part):
+                continue
+
+            self.recursive_remove(part)
+            log.debug("partitions: %s", [p.getDeviceNodeName() for p in part.parted_partition.disk.partitions])
+
+        # now remove any empty extended partitions
+        self.remove_empty_extended_partitions()
+
+        # ensure all disks have appropriate disklabels
+        for disk in self.disks:
+            zerombr = (self.config.zero_mbr and disk.format.type is None)
+            should_clear = self.should_clear(disk)
+            if should_clear:
+                self.recursive_remove(disk)
+
+            if zerombr or should_clear:
+                log.debug("clearpart: initializing %s", disk.name)
+                self.initialize_disk(disk)
+
+        self.update_bootloader_disk_list()
+
+    def format_by_default(self, device):
+        """Return whether the device should be reformatted by default."""
+        formatlist = ['/boot', '/var', '/tmp', '/usr']
+        exceptlist = ['/home', '/usr/local', '/opt', '/var/www']
+
+        if not device.format.linux_native:
+            return False
+
+        if device.format.mountable:
+            if not device.format.mountpoint:
+                return False
+
+            if device.format.mountpoint == "/" or \
+               device.format.mountpoint in formatlist:
+                return True
+
+            for p in formatlist:
+                if device.format.mountpoint.startswith(p):
+                    for q in exceptlist:
+                        if device.format.mountpoint.startswith(q):
+                            return False
+                    return True
+        elif device.format.type == "swap":
+            return True
+
+        # be safe for anything else and default to off
+        return False
+
+    def must_format(self, device):
+        """ Return a string explaining why the device must be reformatted.
+
+            Return None if the device need not be reformatted.
+        """
+        if device.format.mountable and device.format.mountpoint == "/":
+            return _("You must create a new filesystem on the root device.")
+
+        return None
+
+    def turn_on_swap(self):
+        self.fsset.turn_on_swap(root_path=get_sysroot())
+
+    def mount_filesystems(self, read_only=None, skip_root=False):
+        self.fsset.mount_filesystems(root_path=get_sysroot(),
+                                     read_only=read_only, skip_root=skip_root)
+
+    def umount_filesystems(self, swapoff=True):
+        self.fsset.umount_filesystems(swapoff=swapoff)
+
+    def parse_fstab(self, chroot=None):
+        self.fsset.parse_fstab(chroot=chroot)
+
+    def mk_dev_root(self):
+        self.fsset.mk_dev_root()
+
+    def create_swap_file(self, device, size):
+        self.fsset.create_swap_file(device, size)
+
+    def make_mtab(self):
+        path = "/etc/mtab"
+        target = "/proc/self/mounts"
+        path = os.path.normpath("%s/%s" % (get_sysroot(), path))
+
+        if os.path.islink(path):
+            # return early if the mtab symlink is already how we like it
+            current_target = os.path.normpath(os.path.dirname(path) +
+                                              "/" + os.readlink(path))
+            if current_target == target:
+                return
+
+        if os.path.exists(path):
+            os.unlink(path)
+
+        os.symlink(target, path)
+
+    def add_fstab_swap(self, device):
+        """
+        Add swap device to the list of swaps that should appear in the fstab.
+
+        :param device: swap device that should be added to the list
+        :type device: blivet.devices.StorageDevice instance holding a swap format
+
+        """
+
+        self.fsset.add_fstab_swap(device)
+
+    def remove_fstab_swap(self, device):
+        """
+        Remove swap device from the list of swaps that should appear in the fstab.
+
+        :param device: swap device that should be removed from the list
+        :type device: blivet.devices.StorageDevice instance holding a swap format
+
+        """
+
+        self.fsset.remove_fstab_swap(device)
+
+    def set_fstab_swaps(self, devices):
+        """
+        Set swap devices that should appear in the fstab.
+
+        :param devices: iterable providing devices that should appear in the fstab
+        :type devices: iterable providing blivet.devices.StorageDevice instances holding
+                       a swap format
+
+        """
+
+        self.fsset.set_fstab_swaps(devices)
 
 
 def get_containing_device(path, devicetree):

--- a/blivet/osinstall.py
+++ b/blivet/osinstall.py
@@ -38,13 +38,16 @@ from . import get_sysroot, get_target_physical_root, error_handler, ERROR_RAISE
 
 from .blivet import Blivet
 from .storage_log import log_exception_info
-from .devices import FileDevice, NFSDevice, NoDevice, OpticalDevice, NetworkStorageDevice, DirectoryDevice, MDRaidArrayDevice, PartitionDevice
+from .devices import FileDevice, NFSDevice, NoDevice, OpticalDevice, NetworkStorageDevice, DirectoryDevice
+from .devices import PartitionDevice, BTRFSSubVolumeDevice, TmpFSDevice, LVMLogicalVolumeDevice, LVMVolumeGroupDevice
+from .devices import MDRaidArrayDevice, BTRFSDevice
 from .errors import FSTabTypeMismatchError, UnrecognizedFSTabEntryError, StorageError, FSResizeError, FormatResizeError, UnknownSourceDeviceError
 from .formats import get_device_format_class
 from .formats import get_format
 from .flags import flags
 from .platform import platform as _platform
 from .platform import EFI
+from .size import Size
 
 from .i18n import _
 
@@ -402,11 +405,7 @@ class FSSet(object):
 
     @property
     def mountpoints(self):
-        filesystems = {}
-        for device in self.devices:
-            if device.format.mountable and device.format.mountpoint:
-                filesystems[device.format.mountpoint] = device
-        return filesystems
+        return self.devicetree.mountpoints
 
     def _parse_one_line(self, devspec, mountpoint, fstype, options, _dump="0", _passno="0"):
         """Parse an fstab entry for a device, return the corresponding device.
@@ -1313,6 +1312,171 @@ class InstallerStorageConfig(Blivet):
         iscsi.write(get_sysroot(), self)
         fcoe.write(get_sysroot())
         zfcp.write(get_sysroot())
+
+    @property
+    def mountpoints(self):
+        return self.fsset.mountpoints
+
+    @property
+    def root_device(self):
+        return self.fsset.root_device
+
+    @property
+    def file_system_free_space(self):
+        """ Combined free space in / and /usr as :class:`~.size.Size`. """
+        mountpoints = ["/", "/usr"]
+        free = Size(0)
+        btrfs_volumes = []
+        for mountpoint in mountpoints:
+            device = self.mountpoints.get(mountpoint)
+            if not device:
+                continue
+
+            # don't count the size of btrfs volumes repeatedly when multiple
+            # subvolumes are present
+            if isinstance(device, BTRFSSubVolumeDevice):
+                if device.volume in btrfs_volumes:
+                    continue
+                else:
+                    btrfs_volumes.append(device.volume)
+
+            if device.format.exists:
+                free += device.format.free
+            else:
+                free += device.format.free_space_estimate(device.size)
+
+        return free
+
+    def update_ksdata(self):
+        """ Update ksdata to reflect the settings of this Blivet instance. """
+        if not self.ksdata or not self.mountpoints:
+            return
+
+        # clear out whatever was there before
+        self.ksdata.partition.partitions = []
+        self.ksdata.logvol.lvList = []
+        self.ksdata.raid.raidList = []
+        self.ksdata.volgroup.vgList = []
+        self.ksdata.btrfs.btrfsList = []
+
+        # iscsi?
+        # fcoe?
+        # zfcp?
+        # dmraid?
+
+        # bootloader
+
+        # ignoredisk
+        if self.ignored_disks:
+            self.ksdata.ignoredisk.drives = self.ignored_disks[:]
+        elif self.exclusive_disks:
+            self.ksdata.ignoredisk.onlyuse = self.exclusive_disks[:]
+
+        # autopart
+        self.ksdata.autopart.autopart = self.do_autopart
+        self.ksdata.autopart.type = self.autopart_type
+        self.ksdata.autopart.encrypted = self.encrypted_autopart
+
+        # clearpart
+        self.ksdata.clearpart.type = self.config.clear_part_type
+        self.ksdata.clearpart.drives = self.config.clear_part_disks[:]
+        self.ksdata.clearpart.devices = self.config.clear_part_devices[:]
+        self.ksdata.clearpart.initAll = self.config.initialize_disks
+        if self.ksdata.clearpart.type == CLEARPART_TYPE_NONE:
+            # Make a list of initialized disks and of removed partitions. If any
+            # partitions were removed from disks that were not completely
+            # cleared we'll have to use CLEARPART_TYPE_LIST and provide a list
+            # of all removed partitions. If no partitions were removed from a
+            # disk that was not cleared/reinitialized we can use
+            # CLEARPART_TYPE_ALL.
+            self.ksdata.clearpart.devices = []
+            self.ksdata.clearpart.drives = []
+            fresh_disks = [d.name for d in self.disks if d.partitioned and
+                           not d.format.exists]
+
+            destroy_actions = self.devicetree.actions.find(action_type="destroy",
+                                                           object_type="device")
+
+            cleared_partitions = []
+            partial = False
+            for action in destroy_actions:
+                if action.device.type == "partition":
+                    if action.device.disk.name not in fresh_disks:
+                        partial = True
+
+                    cleared_partitions.append(action.device.name)
+
+            if not destroy_actions:
+                pass
+            elif partial:
+                # make a list of removed partitions
+                self.ksdata.clearpart.type = CLEARPART_TYPE_LIST
+                self.ksdata.clearpart.devices = cleared_partitions
+            else:
+                # if they didn't partially clear any disks, use the shorthand
+                self.ksdata.clearpart.type = CLEARPART_TYPE_ALL
+                self.ksdata.clearpart.drives = fresh_disks
+
+        if self.do_autopart:
+            return
+
+        self._update_custom_storage_ksdata()
+
+    def _update_custom_storage_ksdata(self):
+        """ Update KSData for custom storage. """
+
+        # custom storage
+        ks_map = {PartitionDevice: ("PartData", "partition"),
+                  TmpFSDevice: ("PartData", "partition"),
+                  LVMLogicalVolumeDevice: ("LogVolData", "logvol"),
+                  LVMVolumeGroupDevice: ("VolGroupData", "volgroup"),
+                  MDRaidArrayDevice: ("RaidData", "raid"),
+                  BTRFSDevice: ("BTRFSData", "btrfs")}
+
+        # make a list of ancestors of all used devices
+        devices = list(set(a for d in list(self.mountpoints.values()) + self.swaps
+                           for a in d.ancestors))
+
+        # devices which share information with their distinct raw device
+        complementary_devices = [d for d in devices if d.raw_device is not d]
+
+        devices.sort(key=lambda d: len(d.ancestors))
+        for device in devices:
+            cls = next((c for c in ks_map if isinstance(device, c)), None)
+            if cls is None:
+                log.info("omitting ksdata: %s", device)
+                continue
+
+            class_attr, list_attr = ks_map[cls]
+
+            cls = getattr(self.ksdata, class_attr)
+            data = cls()    # all defaults
+
+            complements = [d for d in complementary_devices if d.raw_device is device]
+
+            if len(complements) > 1:
+                log.warning("omitting ksdata for %s, found too many (%d) complementary devices", device, len(complements))
+                continue
+
+            device = complements[0] if complements else device
+
+            device.populate_ksdata(data)
+
+            parent = getattr(self.ksdata, list_attr)
+            parent.dataList().append(data)
+
+        self.fsset = FSSet(self.devicetree)
+
+    def reset(self, cleanup_only=False):
+        Blivet.reset(self, cleanup_only)
+
+        self.fsset = FSSet(self.devicetree)
+
+    def write(self):
+        Blivet.write(self)
+
+        self.fsset.write()
+        self.make_mtab()
 
     @property
     def boot_device(self):

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -63,23 +63,23 @@ def parted_exn_handler(exn_type, exn_options, exn_msg):
 
 
 class PopulatorMixin(object, metaclass=SynchronizedMeta):
-    def __init__(self, conf=None, passphrase=None, luks_dict=None):
+    def __init__(self, passphrase=None, luks_dict=None, disk_images=None):
         """
-            :keyword conf: storage discovery configuration
-            :type conf: :class:`~.StorageDiscoveryConfig`
             :keyword passphrase: default LUKS passphrase
             :keyword luks_dict: a dict with UUID keys and passphrase values
             :type luks_dict: dict
+            :keyword disk_images: dictoinary of disk images
+            :type list: dict
 
         """
-        self.reset(conf=conf, passphrase=passphrase, luks_dict=luks_dict)
+        self.reset(passphrase=passphrase, luks_dict=luks_dict, disk_images=disk_images)
 
     def reset(self, conf=None, passphrase=None, luks_dict=None):
+    def reset(self, passphrase=None, luks_dict=None, disk_images=None):
         self.disk_images = {}
-        images = getattr(conf, "disk_images", {})
-        if images:
+        if disk_images:
             # this will overwrite self.exclusive_disks
-            self.set_disk_images(images)
+            self.set_disk_images(disk_images)
 
         # protected device specs as provided by the user
         self.protected_dev_specs = getattr(conf, "protected_dev_specs", [])

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -63,7 +63,7 @@ def parted_exn_handler(exn_type, exn_options, exn_msg):
 
 
 class PopulatorMixin(object, metaclass=SynchronizedMeta):
-    def __init__(self, passphrase=None, luks_dict=None, disk_images=None):
+    def __init__(self, passphrase=None, luks_dict=None, disk_images=None, protected_dev_specs=None):
         """
             :keyword passphrase: default LUKS passphrase
             :keyword luks_dict: a dict with UUID keys and passphrase values
@@ -72,17 +72,16 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
             :type list: dict
 
         """
-        self.reset(passphrase=passphrase, luks_dict=luks_dict, disk_images=disk_images)
+        self.reset(passphrase=passphrase, luks_dict=luks_dict, disk_images=disk_images, protected_dev_specs=protected_dev_specs)
 
-    def reset(self, conf=None, passphrase=None, luks_dict=None):
-    def reset(self, passphrase=None, luks_dict=None, disk_images=None):
+    def reset(self, passphrase=None, luks_dict=None, disk_images=None, protected_dev_specs=None):
         self.disk_images = {}
         if disk_images:
             # this will overwrite self.exclusive_disks
             self.set_disk_images(disk_images)
 
         # protected device specs as provided by the user
-        self.protected_dev_specs = getattr(conf, "protected_dev_specs", [])
+        self.protected_dev_specs = protected_dev_specs
         self.live_backing_device = None
 
         # names of protected devices at the time of tree population

--- a/doc/api/blivet.rst
+++ b/doc/api/blivet.rst
@@ -22,8 +22,6 @@ blivet
 * :mod:`blivet.blivet`
     * :class:`~blivet.blivet.Blivet`
         * :attr:`~blivet.blivet.Blivet.btrfs_volumes`
-        * :meth:`~blivet.blivet.Blivet.clear_partitions`
-        * :attr:`~blivet.blivet.Blivet.config`
         * :meth:`~blivet.blivet.Blivet.copy`
         * :meth:`~blivet.blivet.Blivet.create_device`
         * :meth:`~blivet.blivet.Blivet.default_fstype`
@@ -67,7 +65,6 @@ blivet
         * :attr:`~blivet.blivet.Blivet.swaps`
         * :attr:`~blivet.blivet.Blivet.thinlvs`
         * :attr:`~blivet.blivet.Blivet.thinpools`
-        * :meth:`~blivet.blivet.Blivet.update_ksdata`
         * :attr:`~blivet.blivet.Blivet.vgs`
 
 * :mod:`blivet.deviceaction`
@@ -120,6 +117,7 @@ blivet
         * :meth:`~blivet.devicetree.DeviceTreeBase.hide`
         * :attr:`~blivet.devicetree.DeviceTreeBase.labels`
         * :attr:`~blivet.devicetree.DeviceTreeBase.leaves`
+        * :attr:`~blivet.devicetree.DeviceTreeBase.mountpoints`
         * :meth:`~blivet.populator.populator.PopulatorMixin.populate`
         * :meth:`~blivet.devicetree.DeviceTreeBase.recursive_remove`
         * :meth:`~blivet.devicetree.DeviceTreeBase.resolve_device`

--- a/examples/factory.py
+++ b/examples/factory.py
@@ -9,9 +9,9 @@ b = blivet.Blivet()   # create an instance of Blivet (don't add system devices)
 
 # create two disk image files on which to create new devices
 disk1_file = create_sparse_tempfile("disk1", Size("100GiB"))
-b.config.disk_images["disk1"] = disk1_file
+b.disk_images["disk1"] = disk1_file
 disk2_file = create_sparse_tempfile("disk2", Size("100GiB"))
-b.config.disk_images["disk2"] = disk2_file
+b.disk_images["disk2"] = disk2_file
 
 b.reset()
 

--- a/examples/lvm.py
+++ b/examples/lvm.py
@@ -9,7 +9,7 @@ b = blivet.Blivet()   # create an instance of Blivet (don't add system devices)
 
 # create a disk image file on which to create new devices
 disk1_file = create_sparse_tempfile("disk1", Size("100GiB"))
-b.config.disk_images["disk1"] = disk1_file
+b.disk_images["disk1"] = disk1_file
 
 b.reset()
 

--- a/examples/lvm_cache.py
+++ b/examples/lvm_cache.py
@@ -10,9 +10,9 @@ b = blivet.Blivet()   # create an instance of Blivet (don't add system devices)
 
 # create a disk image file on which to create new devices
 disk1_file = create_sparse_tempfile("disk1", Size("100GiB"))
-b.config.disk_images["disk1"] = disk1_file
+b.disk_images["disk1"] = disk1_file
 disk2_file = create_sparse_tempfile("disk2", Size("100GiB"))
-b.config.disk_images["disk2"] = disk2_file
+b.disk_images["disk2"] = disk2_file
 
 b.reset()
 

--- a/examples/lvm_non_linear.py
+++ b/examples/lvm_non_linear.py
@@ -9,9 +9,9 @@ b = blivet.Blivet()   # create an instance of Blivet (don't add system devices)
 
 # create a disk image file on which to create new devices
 disk1_file = create_sparse_tempfile("disk1", Size("100GiB"))
-b.config.disk_images["disk1"] = disk1_file
+b.disk_images["disk1"] = disk1_file
 disk2_file = create_sparse_tempfile("disk2", Size("100GiB"))
-b.config.disk_images["disk2"] = disk2_file
+b.disk_images["disk2"] = disk2_file
 
 b.reset()
 

--- a/examples/partitioning.py
+++ b/examples/partitioning.py
@@ -9,9 +9,9 @@ b = blivet.Blivet()   # create an instance of Blivet (don't add system devices)
 
 # create two disk image files on which to create new devices
 disk1_file = create_sparse_tempfile("disk1", Size("100GiB"))
-b.config.disk_images["disk1"] = disk1_file
+b.disk_images["disk1"] = disk1_file
 disk2_file = create_sparse_tempfile("disk2", Size("100GiB"))
-b.config.disk_images["disk2"] = disk2_file
+b.disk_images["disk2"] = disk2_file
 
 b.reset()
 

--- a/tests/clearpart_test.py
+++ b/tests/clearpart_test.py
@@ -20,7 +20,7 @@ class ClearPartTestCase(unittest.TestCase):
 
     def test_should_clear(self):
         """ Test the Blivet.should_clear method. """
-        b = blivet.Blivet()
+        b = blivet.osinstall.InstallerStorageConfig()
 
         DiskDevice = blivet.devices.DiskDevice
         PartitionDevice = blivet.devices.PartitionDevice

--- a/tests/imagebackedtestcase.py
+++ b/tests/imagebackedtestcase.py
@@ -2,7 +2,7 @@
 import os
 import unittest
 
-from blivet import Blivet
+from blivet.osinstall import InstallerStorageConfig
 from blivet import util
 from blivet.size import Size
 from blivet.flags import flags
@@ -44,7 +44,7 @@ class ImageBackedTestCase(unittest.TestCase):
         """
         for (name, size) in iter(self.disks.items()):
             path = util.create_sparse_tempfile(name, size)
-            self.blivet.config.disk_images[name] = path
+            self.blivet.disk_images[name] = path
 
         #
         # set up the disk images with a disklabel
@@ -95,7 +95,7 @@ class ImageBackedTestCase(unittest.TestCase):
     def setUp(self):
         """ Do any setup required prior to running a test. """
         flags.image_install = True
-        self.blivet = Blivet()
+        self.blivet = InstallerStorageConfig()
 
         self.addCleanup(self._clean_up)
         self.set_up_storage()
@@ -104,7 +104,7 @@ class ImageBackedTestCase(unittest.TestCase):
         """ Clean up any resources that may have been set up for a test. """
         self.blivet.reset()
         self.blivet.devicetree.teardown_disk_images()
-        for fn in self.blivet.config.disk_images.values():
+        for fn in self.blivet.disk_images.values():
             if os.path.exists(fn):
                 os.unlink(fn)
 

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -48,7 +48,7 @@ class setupDiskImagesNonZeroSizeTestCase(unittest.TestCase):
         # anaconda first configures disk images
         for (name, size) in iter(self.disks.items()):
             path = util.create_sparse_tempfile(name, size)
-            self.blivet.config.disk_images[name] = path
+            self.blivet.disk_images[name] = path
 
         # at this point the DMLinearDevice has correct size
         self.blivet.setup_disk_images()
@@ -67,7 +67,7 @@ class setupDiskImagesNonZeroSizeTestCase(unittest.TestCase):
     def tearDown(self):
         self.blivet.reset()
         self.blivet.devicetree.teardown_disk_images()
-        for fn in self.blivet.config.disk_images.values():
+        for fn in self.blivet.disk_images.values():
             if os.path.exists(fn):
                 os.unlink(fn)
 


### PR DESCRIPTION
I don't know what to call this thing, but I'm doing the GitHub thing now.

This is just the beginning pieces of isolating installer-specific code that lives in blivet. This time around, the storage config is moved to blivet.osinstall out of blivet.blivet, and blivet.blivet.Blivet is significantly cleaned up as well. Everything's going to blivet.osinstall for the interim; eventually it's all going to be moved to anaconda when the timing is right, etc.

The commits tell a more robust story.