### PR TITLE
Port LVM on RAID space calculations fixes (#1284660)

### DIFF
--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -1219,11 +1219,6 @@ class LVMFactory(DeviceFactory):
                    len(self.container.parents))
                 log.debug("size cut to %s to omit old device space", size)
 
-        if self.container_raid_level:
-            # add five extents per disk to account for md metadata
-            # (it was originally one per disk but that wasn't enough for raid5)
-            size += lvm.LVM_PE_SIZE * len(self.disks) * 5
-
         if self.container_encrypted:
             # Add space for LUKS metadata, each parent will be encrypted
             size += lvm.LVM_PE_SIZE * len(self.disks)

--- a/blivet/devicelibs/raid.py
+++ b/blivet/devicelibs/raid.py
@@ -268,8 +268,7 @@ class RAIDn(RAIDLevel):
             raise RaidError("superblock_size_func value of None is not acceptable")
 
         min_size = min(member_sizes)
-        total_space = self.get_net_array_size(num_members, min_size)
-        superblock_size = superblock_size_func(total_space)
+        superblock_size = superblock_size_func(min_size)
         min_data_size = self._trim(min_size - superblock_size, chunk_size)
         return self.get_net_array_size(num_members, min_data_size)
 

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -366,11 +366,6 @@ class LVMVolumeGroupDevice(ContainerDevice):
         # total the sizes of any LVs
         log.debug("%s size is %s", self.name, self.size)
         used = sum(lv.vgSpaceUsed for lv in self.lvs)
-        if not self.exists and raid_disks:
-            # (only) we allocate (5 * num_disks) extra extents for LV metadata
-            # on RAID (see the devicefactory.LVMFactory._get_total_space method)
-            new_lvs = [lv for lv in self.lvs if not lv.exists]
-            used += len(new_lvs) * 5 * raid_disks * self.peSize
         used += self.reservedSpace
         used += self.poolMetaData
         free = self.size - used

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -338,12 +338,25 @@ class LVMVolumeGroupDevice(ContainerDevice):
         """ The size of this VG """
         # TODO: just ask lvm if isModified returns False
 
-        # sum up the sizes of the PVs and align to pesize
-        size = 0
+        # sum up the sizes of the PVs, subtract the unusable (meta data) space
+        # and align to pesize
+        # NOTE: we either specify data alignment in a PV or the default is used
+        #       which is both handled by pv.format.peStart, but LVM takes into
+        #       account also the underlying block device which means that e.g.
+        #       for an MD RAID device, it tries to align everything also to chunk
+        #       size and alignment offset of such device which may result in up
+        #       to a twice as big non-data area
+        # TODO: move this to either LVMPhysicalVolume's peStart property once
+        #       formats know about their devices or to a new LVMPhysicalVolumeDevice
+        #       class once it exists
+        avail = Size(0)
         for pv in self.pvs:
-            size += max(0, self.align(pv.size - pv.format.peStart))
+            if isinstance(pv, MDRaidArrayDevice):
+                avail += self.align(pv.size - 2 * pv.format.peStart)
+            else:
+                avail += self.align(pv.size - pv.format.peStart)
 
-        return size
+        return avail
 
     @property
     def extents(self):

--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -1778,17 +1778,6 @@ class VGChunk(Chunk):
             raise ValueError(_("VGChunk requests must be of type "
                              "LVRequest"))
 
-        # (only) we allocate (5 * num_disks) extra extents for LV metadata
-        # on RAID (see the devicefactory.LVMFactory._get_total_space method)
-        if not req.device.exists and req.device.vg.pvs:
-            max_raid_disks = max(len(pv.disks) for pv in req.device.vg.pvs)
-            if max_raid_disks:
-                self.pool -= 5 * max_raid_disks
-
-        if req.device.cached:
-            # cached LV -> reserve space for the cache
-            self.pool -= int(self.vg.align(req.device.cache.size, roundup=True) / self.vg.peSize)
-
         super(VGChunk, self).addRequest(req)
 
     def lengthToSize(self, length):


### PR DESCRIPTION
These are all ported patches from the master branch fixing the bug rhbz#1284660 where our magical calculations of space in case of LVM on RAID lead to a failure of installation with a valid storage configuration in kickstart.