### PR TITLE
Protect the live device's parent (#1172342)

### DIFF
--- a/blivet/populator.py
+++ b/blivet/populator.py
@@ -429,6 +429,13 @@ class Populator(object):
                 lvm.lvm_cc_addFilterRejectRegexp(name)
                 return
 
+        # If this is the live device protect the whole disk
+        if self.liveBackingDevice == name and not disk.protected \
+           and disk.name not in self.protectedDevNames:
+            log.info("Protecting %s, parent of live device %s", disk.name, name)
+            disk.protected = True
+            self.protectedDevNames.append(disk.name)
+
         if not disk.partitioned:
             # Ignore partitions on:
             #  - devices we do not support partitioning of, like logical volumes


### PR DESCRIPTION
When an iso9660 is written to a USB the child partitions are excluded
from the devicetree by addUdevPartitionDevice. This means it never gets
to the point where it can protect the parent devices.

This adds a second check to see if the liveBackingDevice name starts
with any of the other device names. If so then the device is set as
protected and added to the protectedDevNames list.