### PR TITLE
Correctly recognize internal RAID LVs

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -958,6 +958,18 @@ class LVMInternalLVtype(Enum):
             else:
                 return cls.data
 
+        if lv_attr[0] == "r":
+            # internal LV which is at the same time a RAID LV
+            if lv_attr[6] == "C":
+                # part of the cache -> cache origin
+                # (cache pool cannot be a RAID LV, cache pool's data LV would
+                # have lv_attr[0] == "C", metadata LV would have
+                # lv_attr[0] == "e" even if they were RAID LVs)
+                return cls.origin
+            elif lv_attr[6] == "r":
+                # a data LV (metadata LV would have lv_attr[0] == "e")
+                return cls.data
+
         for lv_type, letters in attr_letters.items():
             if lv_attr[0] in letters:
                 return lv_type

--- a/blivet/populator/helpers/lvm.py
+++ b/blivet/populator/helpers/lvm.py
@@ -218,7 +218,7 @@ class LVMFormatPopulator(FormatPopulator):
             elif lv_attr[0] == 'v':
                 # skip vorigins
                 return
-            elif lv_attr[0] in 'IielTCo' and lv_name.endswith(']'):
+            elif lv_attr[0] in 'IrielTCo' and lv_name.endswith(']'):
                 # an internal LV, add the an instance of the appropriate class
                 # to internal_lvs for later processing when non-internal LVs are
                 # processed


### PR DESCRIPTION
If an internal LV is a RAID LV, it's lv_attr is really interesting. Usually
(bug in LVM?) it has 'r' as the first letter so we need to allow that and then
do some magic to correctly determine the role of the LV.

Using 'lvs -o+lv_role' would be much better for this, but I only learnt about it
today and using it would require more changes (incl. some in libblockdev).