### PR TITLE
Add name of problematic device to UnusableConfigurationError

### DIFF
--- a/blivet/errors.py
+++ b/blivet/errors.py
@@ -197,6 +197,10 @@ class UnusableConfigurationError(StorageError):
     """ User has an unusable initial storage configuration. """
     suggestion = ""
 
+    def __init__(self, message, dev_name=None):
+        super().__init__(message)
+        self.dev_name = dev_name
+
 
 class DiskLabelScanError(UnusableConfigurationError):
     suggestion = N_("For some reason we were unable to locate a disklabel on a "

--- a/blivet/populator/helpers/partition.py
+++ b/blivet/populator/helpers/partition.py
@@ -91,7 +91,7 @@ class PartitionDevicePopulator(DevicePopulator):
                     msg = "failed to scan disk %s" % disk.name
                     cls = DiskLabelScanError
 
-                raise cls(msg)
+                raise cls(msg, disk.name)
 
             # there's no need to filter partitions on members of multipaths or
             # fwraid members from lvm since multipath and dmraid are already


### PR DESCRIPTION
Having name of the problematic/unusable disk in this exception would help when trying to ignore the disk during (next) reset. 