### PR TITLE
Kickstart missing bootloader partitions (#1242666)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ TEST_DEPENDENCIES += python-coverage python3-coverage
 TEST_DEPENDENCIES += xfsprogs hfsplus-tools
 TEST_DEPENDENCIES += python3-pocketlint python3-bugzilla
 TEST_DEPENDENCIES += python3-pep8
+TEST_DEPENDENCIES += python3-kickstart
 TEST_DEPENDENCIES := $(shell echo $(sort $(TEST_DEPENDENCIES)) | uniq)
 
 all:

--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -1840,8 +1840,14 @@ class Blivet(object, metaclass=SynchronizedMeta):
                   MDRaidArrayDevice: ("RaidData", "raid"),
                   BTRFSDevice: ("BTRFSData", "btrfs")}
 
+        # list comprehension that builds device ancestors should not get None as a member
+        # when searching for bootloader devices
+        bootloader_devices = []
+        if self.bootloader_device is not None:
+            bootloader_devices.append(self.bootloader_device)
+
         # make a list of ancestors of all used devices
-        devices = list(set(a for d in list(self.mountpoints.values()) + self.swaps
+        devices = list(set(a for d in list(self.mountpoints.values()) + self.swaps + bootloader_devices
                            for a in d.ancestors))
 
         # devices which share information with their distinct raw device

--- a/tests/blivet_test.py
+++ b/tests/blivet_test.py
@@ -1,0 +1,39 @@
+import unittest
+from unittest.mock import PropertyMock
+from unittest.mock import patch
+from pykickstart.version import returnClassForVersion
+from blivet import Blivet
+from blivet.devices import PartitionDevice
+from blivet import formats
+from blivet.size import Size
+
+
+class BlivetTestCase(unittest.TestCase):
+    '''
+    Define tests for the Blivet class
+    '''
+    def test_bootloader_in_kickstart(self):
+        '''
+        test that a bootloader such as prepboot/biosboot shows up
+        in the kickstart data
+        '''
+
+        with patch('blivet.blivet.Blivet.bootloader_device', new_callable=PropertyMock) as mock_bootloader_device:
+            with patch('blivet.blivet.Blivet.mountpoints', new_callable=PropertyMock) as mock_mountpoints:
+                # set up prepboot partition
+                bootloader_device_obj = PartitionDevice("test_partition_device")
+                bootloader_device_obj.size = Size('5 MiB')
+                bootloader_device_obj.format = formats.get_format("prepboot")
+
+                blivet_obj = Blivet()
+
+                # mountpoints must exist for update_ksdata to run
+                mock_bootloader_device.return_value = bootloader_device_obj
+                mock_mountpoints.values.return_value = []
+
+                # initialize ksdata
+                test_ksdata = returnClassForVersion()()
+                blivet_obj.ksdata = test_ksdata
+                blivet_obj.update_ksdata()
+
+        self.assertTrue("part prepboot" in str(blivet_obj.ksdata))


### PR DESCRIPTION
Blivet generates the information about user defined custom partitioning
that is used in the kickstart file. The output was missing the biosboot
and prepboot data rendering the kickstart unusable for automated
installation using the generated file.

Added code and unit tests to add and verify the presence of the
bootloader device in the generated kickstart data.

Resolves: rhbz#1242666