### PR TITLE
Compare sizes instead of numbers of sectors

### DIFF
--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -1016,9 +1016,10 @@ class PartitionRequest(Request):
         sector_size = Size(partition.parted_partition.disk.device.sectorSize)
 
         if partition.req_grow:
-            limits = [l for l in [size_to_sectors(partition.req_max_size, sector_size),
-                                  size_to_sectors(partition.format.max_size, sector_size),
-                                  partition.parted_partition.disk.maxPartitionLength] if l > 0]
+            req_format_max_size = min((size for size in (partition.req_max_size, partition.format.max_size)
+                                       if size > 0), default=Size(0))
+            limits = [l for l in (size_to_sectors(req_format_max_size, sector_size),
+                                  partition.parted_partition.disk.maxPartitionLength) if l > 0]
 
             if limits:
                 max_sectors = min(limits)


### PR DESCRIPTION
Instead of dividing two potentially big sizes by sector size and then comparing
the numbers of sectors we can compare the sizes and divide just the smaller
(more limitting) one. This is a minor optimization, but more importantly a nice
way to prevent issues with really big numbers that may not fit into 64bits (Size
divided by Size is a number).

Related: rhbz#1326897