### PR TITLE
Do not put LVM stuff into syslog

### DIFF
--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -94,7 +94,7 @@ def _set_global_config():
     if not flags.lvm_metadata_backup:
         config_string += "backup {backup=0 archive=0} "
     if flags.debug:
-        config_string += "log {level=7 file=/tmp/lvm.log}"
+        config_string += "log {level=7 file=/tmp/lvm.log syslog=0}"
 
     blockdev.lvm.set_global_config(config_string)
 


### PR DESCRIPTION
We already have this in a separate lvm.log file. There's no need for the
duplicity and since the LVM log can be really huge [1], it can save a lot of
space.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1327091