### PR TITLE
Add xfs to default filesystem types

### DIFF
--- a/blivet/formats/__init__.py
+++ b/blivet/formats/__init__.py
@@ -46,7 +46,7 @@ def register_device_format(fmt_class):
     log.debug("registered device format class %s as %s", fmt_class.__name__,
                                                          fmt_class._type)
 
-default_fstypes = ("ext4", "ext3", "ext2")
+default_fstypes = ("ext4", "xfs", "ext3", "ext2")
 def get_default_filesystem_type():
     for fstype in default_fstypes:
         try:


### PR DESCRIPTION
XFS is the default filesystem type for several of the current linux
distributions. It should be included as a potential default filesystem
type in the constructor list.

Related: rhbz#1242666