### PR TITLE
Fix blivet constructor fs support check

### DIFF
--- a/blivet/formats/__init__.py
+++ b/blivet/formats/__init__.py
@@ -50,9 +50,9 @@ default_fstypes = ("ext4", "ext3", "ext2")
 def get_default_filesystem_type():
     for fstype in default_fstypes:
         try:
-            supported = get_device_format_class(fstype).supported
+            supported = getFormat(fstype).supported
         except AttributeError:
-            supported = None
+            supported = False
 
         if supported:
             return fstype


### PR DESCRIPTION
Calls to get_default_filesystem_type check to see if the filesystem is
supported by the installed operating system. The boolean flag that
indicated support was actually returning an instance of the property
object which, when cast to a boolean type, is always True.

Converted to call the actual boolean property and made the error handler
return False instead of None for consistency with the property.

Related: rhbz#1242666