### PR TITLE
Fix root detection on btrfs in rescue mode

### DIFF
--- a/blivet/__init__.py
+++ b/blivet/__init__.py
@@ -3025,7 +3025,10 @@ def _findExistingInstallations(devicetree):
         util.makedirs(getTargetPhysicalRoot())
 
     roots = []
-    for device in devicetree.leaves:
+
+    direct_devices = (dev for dev in devicetree.devices if dev.direct)
+
+    for device in direct_devices:
         if not device.format.linuxNative or not device.format.mountable or \
            not device.controllable:
             continue

--- a/blivet/__init__.py
+++ b/blivet/__init__.py
@@ -2106,7 +2106,7 @@ def mountExistingSystem(fsset, rootDevice,
         rootDevice.setup()
         rootDevice.format.mount(chroot=rootPath,
                                 mountpoint="/",
-                                options=readOnly)
+                                options="%s,%s" % (rootDevice.format.options, readOnly))
 
     fsset.parseFSTab()
 

--- a/blivet/devices/btrfs.py
+++ b/blivet/devices/btrfs.py
@@ -325,7 +325,7 @@ class BTRFSVolumeDevice(BTRFSDevice, ContainerDevice):
 
     def listSubVolumes(self, snapshotsOnly=False):
         subvols = []
-        if flags.installer_mode:
+        if flags.installer_mode or flags.rescue_mode:
             self.setup(orig=True)
 
             try:
@@ -346,7 +346,7 @@ class BTRFSVolumeDevice(BTRFSDevice, ContainerDevice):
         else:
             self._getDefaultSubVolumeID(mountpoint)
         finally:
-            if flags.installer_mode:
+            if flags.installer_mode or flags.rescue_mode:
                 self._undo_temp_mount()
 
         return subvols

--- a/blivet/flags.py
+++ b/blivet/flags.py
@@ -29,6 +29,7 @@ class Flags(object):
         #
         self.testing = False
         self.installer_mode = False
+        self.rescue_mode = False
 
         #
         # minor modes (installer-specific)
@@ -90,6 +91,7 @@ class Flags(object):
 
     def update_from_anaconda_flags(self, anaconda_flags):
         self.installer_mode = True
+        self.rescue_mode = anaconda_flags.rescue_mode
         self.testing = anaconda_flags.testing
         self.automated_install = anaconda_flags.automatedInstall
         self.live_install = anaconda_flags.livecdInstall


### PR DESCRIPTION
Mount btrfs volumes during rescue mode (to get list of its
subvolumes) and include non-leaf btrfs subvolumes when looking for
root devices and make sure it's mounted with subvol mount option.

Resolves: rhbz#1250011