### PR TITLE
Add an InitializeDisk method to DBusBlivet

### DIFF
--- a/blivet/dbus/blivet.py
+++ b/blivet/dbus/blivet.py
@@ -109,3 +109,10 @@ class DBusBlivet(DBusObject):
         """ Remove a device and all devices built on it. """
         device = self._dbus_devices[object_path]
         self._blivet.devicetree.recursive_remove(device)
+
+    @dbus.service.method(dbus_interface=BLIVET_INTERFACE, in_signature='o')
+    def InitializeDisk(self, object_path):
+        """ Clear a disk and create a disklabel on it. """
+        self.RemoveDevice(object_path)
+        device = self._dbus_devices[object_path]
+        self._blivet.initialize_disk(device)

--- a/tests/dbus_test.py
+++ b/tests/dbus_test.py
@@ -54,6 +54,18 @@ class UDevBlivetTestCase(TestCase):
         self.dbus_object._blivet.devicetree.recursive_remove.assert_called_once_with(device_mock)
         self.dbus_object._blivet.reset_mock()
 
+    def test_InitializeDisk(self):
+        self.dbus_object._blivet.reset_mock()
+        object_path = '/com/redhat/Blivet1/Devices/23'
+        device_mock = Mock("device 23")
+        with patch.object(self.dbus_object, '_dbus_devices', new=dict()):
+            self.dbus_object._dbus_devices[object_path] = device_mock
+            self.dbus_object.InitializeDisk(object_path)
+
+        self.dbus_object._blivet.devicetree.recursive_remove.assert_called_once_with(device_mock)
+        self.dbus_object._blivet.initialize_disk.assert_called_once_with(device_mock)
+        self.dbus_object._blivet.reset_mock()
+
 
 class DBusObjectTestCase(TestCase):
     @patch.object(DBusObject, '__init__', return_value=None)


### PR DESCRIPTION
This is just one commit on top of #392 and #394.

I closed #395 because I accidentally created it against `master` instead of `2.2-devel`.