### PR TITLE
Break the cycle in LVMPhysicalVolume.destroy (#1331630)

### DIFF
--- a/blivet/formats/lvmpv.py
+++ b/blivet/formats/lvmpv.py
@@ -128,7 +128,7 @@ class LVMPhysicalVolume(DeviceFormat):
         try:
             blockdev.lvm.pvremove(self.device)
         except blockdev.LVMError:
-            DeviceFormat.destroy(self, **kwargs)
+            DeviceFormat._destroy(self, **kwargs)
         finally:
             blockdev.lvm.pvscan(self.device)
 


### PR DESCRIPTION
If pvremove() fails, we need to jump to DeviceFormat._destroy() not destroy()
because destroy calls self._destroy() which jumps to LVMPhysicalVolume.destroy()
again because 'self' is a LVMPhysicalVolume instance.