### PR TITLE
Remove installer mode

### DIFF
--- a/blivet/__init__.py
+++ b/blivet/__init__.py
@@ -22,41 +22,11 @@
 
 __version__ = '2.0.2'
 
-##
-# Default stub values for installer-specific stuff that gets set up in
-# enable_installer_mode.  These constants are only for use inside this file.
-# For use in other blivet files, they must either be passed to the function
-# in question or care must be taken so they are imported only after
-# enable_installer_mode is called.
-##
-iutil = None
-ROOT_PATH = '/'
-_storage_root = ROOT_PATH
-_sysroot = ROOT_PATH
-short_product_name = 'blivet'
-ERROR_RAISE = 0
-
-
-class ErrorHandler(object):
-
-    def cb(self, exn):
-        # pylint: disable=unused-argument
-        return ERROR_RAISE
-
-error_handler = ErrorHandler()
-
-get_bootloader = lambda: None
-
-##
-# end installer stubs
-##
-
 import sys
 import importlib
 import warnings
 
-from . import util, arch, udev
-from .flags import flags
+from . import util, arch
 
 import logging
 log = logging.getLogger("blivet")
@@ -96,69 +66,6 @@ else:
 missing_plugs = _REQUESTED_PLUGIN_NAMES - avail_plugs
 for p in missing_plugs:
     log.info("Failed to load plugin %s", p)
-
-
-def enable_installer_mode():
-    """ Configure the module for use by anaconda (OS installer). """
-    global iutil
-    global ROOT_PATH
-    global _storage_root
-    global _sysroot
-    global short_product_name
-    global get_bootloader
-    global error_handler
-    global ERROR_RAISE
-
-    from pyanaconda import iutil  # pylint: disable=redefined-outer-name
-    from pyanaconda.constants import shortProductName as short_product_name  # pylint: disable=redefined-outer-name
-    from pyanaconda.bootloader import get_bootloader  # pylint: disable=redefined-outer-name
-    from pyanaconda.errors import errorHandler as error_handler  # pylint: disable=redefined-outer-name
-    from pyanaconda.errors import ERROR_RAISE  # pylint: disable=redefined-outer-name
-
-    if hasattr(iutil, 'getTargetPhysicalRoot'):
-        # For anaconda versions > 21.43
-        _storage_root = iutil.getTargetPhysicalRoot()  # pylint: disable=no-name-in-module
-        _sysroot = iutil.getSysroot()
-    else:
-        # For prior anaconda versions
-        from pyanaconda.constants import ROOT_PATH  # pylint: disable=redefined-outer-name,no-name-in-module
-        _storage_root = _sysroot = ROOT_PATH
-
-    from pyanaconda.anaconda_log import program_log_lock
-    util.program_log_lock = program_log_lock
-
-    udev.device_name_blacklist = [r'^mtd', r'^mmcblk.+boot', r'^mmcblk.+rpmb', r'^zram']
-
-
-def get_sysroot():
-    """Returns the path to the target OS installation.
-
-    For traditional installations, this is the same as the physical
-    storage root.
-    """
-    return _sysroot
-
-
-def get_target_physical_root():
-    """Returns the path to the "physical" storage root.
-
-    This may be distinct from the sysroot, which could be a
-    chroot-type subdirectory of the physical root.  This is used for
-    example by all OSTree-based installations.
-    """
-    return _storage_root
-
-
-def set_sysroot(storage_root, sysroot=None):
-    """Change the OS root path.
-       :param storage_root: The root of physical storage
-       :param sysroot: An optional chroot subdirectory of storage_root
-    """
-    global _storage_root
-    global _sysroot
-    _storage_root = _sysroot = storage_root
-    if sysroot is not None:
-        _sysroot = sysroot
 
 
 class _LazyImportObject(object):

--- a/blivet/__init__.py
+++ b/blivet/__init__.py
@@ -55,7 +55,7 @@ import sys
 import importlib
 import warnings
 
-from . import util, arch
+from . import util, arch, udev
 from .flags import flags
 
 import logging
@@ -127,7 +127,7 @@ def enable_installer_mode():
     from pyanaconda.anaconda_log import program_log_lock
     util.program_log_lock = program_log_lock
 
-    flags.installer_mode = True
+    udev.device_name_blacklist = [r'^mtd', r'^mmcblk.+boot', r'^mmcblk.+rpmb', r'^zram']
 
 
 def get_sysroot():

--- a/blivet/actionlist.py
+++ b/blivet/actionlist.py
@@ -199,7 +199,7 @@ class ActionList(object, metaclass=SynchronizedMeta):
 
         problematic = self._find_active_devices_on_action_disks(devices=devices)
         if problematic:
-            if flags.installer_mode:
+            if flags.auto_dev_updates:
                 for device in devices:
                     if device.protected:
                         continue

--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -114,16 +114,6 @@ class Blivet(object, metaclass=SynchronizedMeta):
         self._next_id += 1
         return newid
 
-    def shutdown(self):
-        """ Deactivate all devices (installer_mode only). """
-        if not flags.installer_mode:
-            return
-
-        try:
-            self.devicetree.teardown_all()
-        except Exception:  # pylint: disable=broad-except
-            log_exception_info(log.error, "failure tearing down device tree")
-
     def reset(self, cleanup_only=False):
         """ Reset storage configuration to reflect actual system state.
 
@@ -147,7 +137,7 @@ class Blivet(object, metaclass=SynchronizedMeta):
         self.edd_dict = get_edd_dict(self.partitioned)
         self.devicetree.edd_dict = self.edd_dict
 
-        if not flags.installer_mode:
+        if flags.include_nodev:
             self.devicetree.handle_nodev_filesystems()
 
     @property

--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -45,7 +45,7 @@ from .platform import platform as _platform
 from .formats import get_format
 from . import arch
 from . import devicefactory
-from . import get_sysroot, short_product_name, __version__
+from . import __version__
 from .threads import SynchronizedMeta
 
 import logging
@@ -84,6 +84,10 @@ class Blivet(object, metaclass=SynchronizedMeta):
         self.set_default_fstype(get_default_filesystem_type())
         self._default_boot_fstype = None
 
+        self._short_product_name = 'blivet'
+        self._sysroot = '/'
+        self._storage_root = '/'
+
         self._next_id = 0
         self._dump_file = "%s/storage.state" % tempfile.gettempdir()
 
@@ -95,6 +99,36 @@ class Blivet(object, metaclass=SynchronizedMeta):
                                      disk_images=self.disk_images)
         self.roots = []
         self.services = set()
+
+    @property
+    def short_product_name(self):
+        return self._short_product_name
+
+    @short_product_name.setter
+    def short_product_name(self, name):
+        """ Change the (short) product name.
+        :param name: The product name.
+        :type name: string
+        """
+        log.debug("new short product name: %s", name)
+        self._short_product_name = name
+
+    @property
+    def sysroot(self):
+        return self._sysroot
+
+    @sysroot.setter
+    def sysroot(self, storage_root, sysroot):
+        """ Change the OS root path.
+        :param storage_root: The root of physical storage
+        :type storage_root: string
+        :param sysroot: An optional chroot subdirectory of storage_root
+        :type sysroot: string
+        """
+        self._storage_root = self._sysroot = storage_root
+        if sysroot is not None:
+            log.debug("new sysroot: %s", sysroot)
+            self._sysroot = sysroot
 
     def do_it(self, callbacks=None):
         """
@@ -517,7 +551,7 @@ class Blivet(object, metaclass=SynchronizedMeta):
         else:
             swap = getattr(kwargs.get("fmt"), "type", None) == "swap"
             mountpoint = getattr(kwargs.get("fmt"), "mountpoint", None)
-            name = self.suggest_device_name(prefix=short_product_name,
+            name = self.suggest_device_name(prefix=self.short_product_name,
                                             swap=swap,
                                             mountpoint=mountpoint)
 
@@ -880,7 +914,7 @@ class Blivet(object, metaclass=SynchronizedMeta):
             :rtype: str
         """
         if not prefix:
-            prefix = short_product_name
+            prefix = self.short_product_name
 
         # try to create a device name incorporating the hostname
         if hostname not in (None, "", 'localhost', 'localhost.localdomain'):
@@ -1000,10 +1034,10 @@ class Blivet(object, metaclass=SynchronizedMeta):
 
     def write(self):
         """ Write out all storage-related configuration files. """
-        if not os.path.isdir("%s/etc" % get_sysroot()):
-            os.mkdir("%s/etc" % get_sysroot())
+        if not os.path.isdir("%s/etc" % self.sysroot):
+            os.mkdir("%s/etc" % self.sysroot)
 
-        self.write_dasd_conf(get_sysroot())
+        self.write_dasd_conf(self.sysroot)
 
     def write_dasd_conf(self, root):
         """ Write /etc/dasd.conf to target system for all DASD devices

--- a/blivet/devices/btrfs.py
+++ b/blivet/devices/btrfs.py
@@ -334,7 +334,7 @@ class BTRFSVolumeDevice(BTRFSDevice, ContainerDevice, RaidDevice):
 
     def list_subvolumes(self, snapshots_only=False):
         subvols = []
-        if flags.installer_mode:
+        if flags.auto_dev_updates:
             self.setup(orig=True)
         elif not self.original_format.status:
             return subvols

--- a/blivet/flags.py
+++ b/blivet/flags.py
@@ -30,7 +30,6 @@ class Flags(object):
         # mode of operation
         #
         self.testing = False
-        self.installer_mode = False
         self.debug = False
 
         #
@@ -111,7 +110,6 @@ class Flags(object):
             self.noiswmd = True
 
     def update_from_anaconda_flags(self, anaconda_flags):
-        self.installer_mode = True
         # always enable the debug mode when in the installer mode so that we
         # have more data in the logs for rare cases that are hard to reproduce
         self.debug = True

--- a/blivet/flags.py
+++ b/blivet/flags.py
@@ -62,14 +62,20 @@ class Flags(object):
 
         self.gpt = False
 
+        # for this flag to take effect,
+        # blockdev.mpath.set_friendly_names(flags.multipath_friendly_names) must
+        # be called prior to calling Blivet.reset() or DeviceTree.populate()
         self.multipath_friendly_names = True
+
+        # set to False since automatic updates of a device's information
+        # or state should not be necessary by default
+        self.auto_dev_updates = False
 
         # set to False to suppress the default LVM behavior of saving
         # backup metadata in /etc/lvm/{archive,backup}
         self.lvm_metadata_backup = True
 
-        # whether to include nodev filesystems in the devicetree (only
-        # meaningful when flags.installer_mode is False)
+        # whether to include nodev filesystems in the devicetree
         self.include_nodev = False
 
         self.boot_cmdline = {}
@@ -126,5 +132,7 @@ class Flags(object):
         # into the *host's* /etc/lvm. This can get real messy on build systems.
         if self.image_install:
             self.lvm_metadata_backup = False
+
+        self.auto_dev_updates = True
 
 flags = Flags()

--- a/blivet/flags.py
+++ b/blivet/flags.py
@@ -75,6 +75,9 @@ class Flags(object):
         # is ordinary not necessary
         self.selinux_reset_fcon = False
 
+        # set to True since we want to keep these around by default
+        self.keep_empty_ext_partitions = True
+
         # set to False to suppress the default LVM behavior of saving
         # backup metadata in /etc/lvm/{archive,backup}
         self.lvm_metadata_backup = True
@@ -139,5 +142,6 @@ class Flags(object):
 
         self.auto_dev_updates = True
         self.selinux_reset_fcon = True
+        self.keep_empty_ext_partitions = False
 
 flags = Flags()

--- a/blivet/flags.py
+++ b/blivet/flags.py
@@ -109,37 +109,4 @@ class Flags(object):
         if "noiswmd" in self.boot_cmdline:
             self.noiswmd = True
 
-    def update_from_anaconda_flags(self, anaconda_flags):
-        # always enable the debug mode when in the installer mode so that we
-        # have more data in the logs for rare cases that are hard to reproduce
-        self.debug = True
-        self.testing = anaconda_flags.testing
-        self.automated_install = anaconda_flags.automatedInstall
-        self.live_install = anaconda_flags.livecdInstall
-        self.image_install = anaconda_flags.imageInstall
-
-        self.selinux = anaconda_flags.selinux
-
-        self.gfs2 = "gfs2" in self.boot_cmdline
-        self.jfs = "jfs" in self.boot_cmdline
-        self.reiserfs = "reiserfs" in self.boot_cmdline
-
-        self.arm_platform = anaconda_flags.armPlatform
-        self.gpt = anaconda_flags.gpt
-
-        self.multipath_friendly_names = anaconda_flags.mpathFriendlyNames
-        self.allow_imperfect_devices = anaconda_flags.rescue_mode
-
-        self.ibft = anaconda_flags.ibft
-        self.dmraid = anaconda_flags.dmraid
-
-        # We don't want image installs writing backups of the *image* metadata
-        # into the *host's* /etc/lvm. This can get real messy on build systems.
-        if self.image_install:
-            self.lvm_metadata_backup = False
-
-        self.auto_dev_updates = True
-        self.selinux_reset_fcon = True
-        self.keep_empty_ext_partitions = False
-
 flags = Flags()

--- a/blivet/flags.py
+++ b/blivet/flags.py
@@ -71,6 +71,10 @@ class Flags(object):
         # or state should not be necessary by default
         self.auto_dev_updates = False
 
+        # set to False by default since a forced reset for file contexts
+        # is ordinary not necessary
+        self.selinux_reset_fcon = False
+
         # set to False to suppress the default LVM behavior of saving
         # backup metadata in /etc/lvm/{archive,backup}
         self.lvm_metadata_backup = True
@@ -134,5 +138,6 @@ class Flags(object):
             self.lvm_metadata_backup = False
 
         self.auto_dev_updates = True
+        self.selinux_reset_fcon = True
 
 flags = Flags()

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -119,7 +119,7 @@ class FS(DeviceFormat):
         self.label = kwargs.get("label")
         self.fsprofile = kwargs.get("fsprofile")
 
-        if flags.installer_mode and self._resize.available:
+        if flags.auto_dev_updates and self._resize.available:
             # if you want current/min size you have to call update_size_info
             try:
                 self.update_size_info()

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -514,7 +514,7 @@ class FS(DeviceFormat):
         chroot = kwargs.get("chroot", "/")
         mountpoint = kwargs.get("mountpoint") or self.mountpoint
 
-        if flags.selinux and "ro" not in self._mount.mount_options(options).split(",") and flags.installer_mode:
+        if flags.selinux and "ro" not in self._mount.mount_options(options).split(",") and flags.selinux_reset_fcon:
             ret = util.reset_file_context(mountpoint, chroot)
             if not ret:
                 log.warning("Failed to reset SElinux context for newly mounted filesystem root directory to default.")

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -121,7 +121,7 @@ class LUKS(DeviceFormat):
         elif not self.map_name and self.device:
             self.map_name = "luks-%s" % os.path.basename(self.device)
 
-        if flags.installer_mode and self._resize.available:
+        if flags.auto_dev_updates and self._resize.available:
             # if you want current/min size you have to call update_size_info
             self.update_size_info()
 
@@ -233,6 +233,7 @@ class LUKS(DeviceFormat):
 
     def _pre_create(self, **kwargs):
         super(LUKS, self)._pre_create(**kwargs)
+        self.map_name = None
         if not self.has_key:
             raise LUKSError("luks device has no key/passphrase")
 
@@ -250,7 +251,7 @@ class LUKS(DeviceFormat):
     def _post_create(self, **kwargs):
         super(LUKS, self)._post_create(**kwargs)
         self.uuid = blockdev.crypto.luks_uuid(self.device)
-        if flags.installer_mode or not self.map_name:
+        if not self.map_name:
             self.map_name = "luks-%s" % self.uuid
 
     @property

--- a/blivet/osinstall.py
+++ b/blivet/osinstall.py
@@ -20,6 +20,25 @@
 
 """This module provides functions related to OS installation."""
 
+##
+# Default stub values for installer-specific stuff that gets set up in
+# enable_installer_mode.  These constants are only for use inside this file.
+# For use in other blivet files, they must either be passed to the function
+# in question or care must be taken so they are imported only after
+# enable_installer_mode is called.
+##
+iutil = None
+ERROR_RAISE = 0
+ROOT_PATH = "/"
+_storage_root = ROOT_PATH
+_sysroot = ROOT_PATH
+
+get_bootloader = lambda: None
+
+##
+# end installer stubs
+##
+
 import shlex
 import os
 import stat
@@ -33,9 +52,10 @@ gi.require_version("BlockDev", "1.0")
 from gi.repository import BlockDev as blockdev
 
 from pykickstart.constants import AUTOPART_TYPE_LVM, CLEARPART_TYPE_NONE, CLEARPART_TYPE_LINUX, CLEARPART_TYPE_ALL, CLEARPART_TYPE_LIST
+from pyanaconda.constants import shortProductName
+from pyanaconda.errors import errorHandler as error_handler
 
-from . import util
-from . import get_sysroot, get_target_physical_root, get_bootloader, error_handler, ERROR_RAISE
+from . import util, udev
 
 from .blivet import Blivet
 from .storage_log import log_exception_info
@@ -57,6 +77,82 @@ import logging
 log = logging.getLogger("blivet")
 
 
+def get_sysroot():
+    """Returns the path to the target OS installation.
+
+    For traditional installations, this is the same as the physical
+    storage root.
+    """
+    return _sysroot
+
+
+def set_sysroot(storage_root, sysroot=None):
+    """Change the OS root path.
+       :param storage_root: The root of physical storage
+       :param sysroot: An optional chroot subdirectory of storage_root
+    """
+    global _storage_root
+    global _sysroot
+    _storage_root = _sysroot = storage_root
+    if sysroot is not None:
+        _sysroot = sysroot
+
+
+def get_target_physical_root():
+    """Returns the path to the "physical" storage root.
+
+    This may be distinct from the sysroot, which could be a
+    chroot-type subdirectory of the physical root.  This is used for
+    example by all OSTree-based installations.
+    """
+    return _storage_root
+
+
+def enable_installer_mode():
+    """ Configure the module for use by anaconda (OS installer). """
+    global iutil
+    global ROOT_PATH
+    global _storage_root
+    global _sysroot
+    global get_bootloader
+    global ERROR_RAISE
+
+    from pyanaconda import iutil  # pylint: disable=redefined-outer-name
+    from pyanaconda.errors import ERROR_RAISE  # pylint: disable=redefined-outer-name
+    from pyanaconda.bootloader import get_bootloader  # pylint: disable=redefined-outer-name
+
+    if hasattr(iutil, 'getTargetPhysicalRoot'):
+        # For anaconda versions > 21.43
+        _storage_root = iutil.getTargetPhysicalRoot()  # pylint: disable=no-name-in-module
+        _sysroot = iutil.getSysroot()
+    else:
+        # For prior anaconda versions
+        from pyanaconda.constants import ROOT_PATH  # pylint: disable=redefined-outer-name,no-name-in-module
+        _storage_root = _sysroot = ROOT_PATH
+
+    from pyanaconda.anaconda_log import program_log_lock
+    util.program_log_lock = program_log_lock
+
+    # always enable the debug mode when in the installer mode so that we
+    # have more data in the logs for rare cases that are hard to reproduce
+    flags.debug = True
+
+    flags.gfs2 = "gfs2" in flags.boot_cmdline
+    flags.jfs = "jfs" in flags.boot_cmdline
+    flags.reiserfs = "reiserfs" in flags.boot_cmdline
+
+    # We don't want image installs writing backups of the *image* metadata
+    # into the *host's* /etc/lvm. This can get real messy on build systems.
+    if flags.image_install:
+        flags.lvm_metadata_backup = False
+
+    flags.auto_dev_updates = True
+    flags.selinux_reset_fcon = True
+    flags.keep_empty_ext_partitions = False
+
+    udev.device_name_blacklist = [r'^mtd', r'^mmcblk.+boot', r'^mmcblk.+rpmb', r'^zram']
+
+
 def copy_to_system(source):
     if not os.access(source, os.R_OK):
         log.info("copy_to_system: source '%s' does not exist.", source)
@@ -69,6 +165,34 @@ def copy_to_system(source):
         os.makedirs(target_dir)
     shutil.copy(source, target)
     return True
+
+
+def update_from_anaconda_flags(blivet_flags, anaconda_flags):
+    """
+    Set installer-specific flags. This changes blivet default flags by
+    either flipping the original value, or it assigns the flag value
+    based on anaconda settings that are passed in.
+
+    :param blivet_flags: Blivet flags
+    :type flags: :class:`blivet.flags.Flags`
+    :param anaconda_flags: anaconda flags
+    :type anaconda_flags: :class:`pyanaconda.flags.Flags`
+    """
+    blivet_flags.testing = anaconda_flags.testing
+    blivet_flags.automated_install = anaconda_flags.automatedInstall
+    blivet_flags.live_install = anaconda_flags.livecdInstall
+    blivet_flags.image_install = anaconda_flags.imageInstall
+
+    blivet_flags.selinux = anaconda_flags.selinux
+
+    blivet_flags.arm_platform = anaconda_flags.armPlatform
+    blivet_flags.gpt = anaconda_flags.gpt
+
+    blivet_flags.multipath_friendly_names = anaconda_flags.mpathFriendlyNames
+    blivet_flags.allow_imperfect_devices = anaconda_flags.rescue_mode
+
+    blivet_flags.ibft = anaconda_flags.ibft
+    blivet_flags.dmraid = anaconda_flags.dmraid
 
 
 def release_from_redhat_release(fn):
@@ -1122,6 +1246,14 @@ class InstallerStorage(Blivet):
         self._free_space_snapshot = None
         self.live_backing_device = None
 
+        self._short_product_name = shortProductName
+        # if the following two values have been set (e.g. enable_installer_mode
+        # was called), override the default values here
+        if _sysroot:
+            self._sysroot = _sysroot
+        if _storage_root:
+            self._storag_root = _storage_root
+
     def do_it(self, callbacks=None):
         """
         Commit queued changes to disk.
@@ -1188,13 +1320,13 @@ class InstallerStorage(Blivet):
         self.dump_state("final")
 
     def write(self):
-        Blivet.write(self)
+        super().write()
 
         self.make_mtab()
         self.fsset.write()
-        iscsi.write(get_sysroot(), self)
-        fcoe.write(get_sysroot())
-        zfcp.write(get_sysroot())
+        iscsi.write(self.sysroot, self)
+        fcoe.write(self.sysroot)
+        zfcp.write(self.sysroot)
 
     @property
     def bootloader(self):
@@ -1823,10 +1955,10 @@ class InstallerStorage(Blivet):
         return None
 
     def turn_on_swap(self):
-        self.fsset.turn_on_swap(root_path=get_sysroot())
+        self.fsset.turn_on_swap(root_path=self.sysroot)
 
     def mount_filesystems(self, read_only=None, skip_root=False):
-        self.fsset.mount_filesystems(root_path=get_sysroot(),
+        self.fsset.mount_filesystems(root_path=self.sysroot,
                                      read_only=read_only, skip_root=skip_root)
 
     def umount_filesystems(self, swapoff=True):
@@ -1844,7 +1976,7 @@ class InstallerStorage(Blivet):
     def make_mtab(self):
         path = "/etc/mtab"
         target = "/proc/self/mounts"
-        path = os.path.normpath("%s/%s" % (get_sysroot(), path))
+        path = os.path.normpath("%s/%s" % (self.sysroot, path))
 
         if os.path.islink(path):
             # return early if the mtab symlink is already how we like it
@@ -1980,7 +2112,7 @@ def write_escrow_packets(storage):
 def storage_initialize(storage, ksdata, protected):
     """ Perform installer-specific storage initialization. """
     from pyanaconda.flags import flags as anaconda_flags
-    flags.update_from_anaconda_flags(anaconda_flags)
+    update_from_anaconda_flags(flags, anaconda_flags)
 
     # Platform class setup depends on flags, re-initialize it.
     _platform.update_from_flags()

--- a/blivet/osinstall.py
+++ b/blivet/osinstall.py
@@ -25,6 +25,7 @@ import os
 import stat
 import time
 import parted
+import shutil
 
 import gi
 gi.require_version("BlockDev", "1.0")
@@ -54,6 +55,20 @@ from .i18n import _
 
 import logging
 log = logging.getLogger("blivet")
+
+
+def copy_to_system(source):
+    if not os.access(source, os.R_OK):
+        log.info("copy_to_system: source '%s' does not exist.", source)
+        return False
+
+    target = get_sysroot() + source
+    target_dir = os.path.dirname(target)
+    log.debug("copy_to_system: '%s' -> '%s'.", source, target)
+    if not os.path.isdir(target_dir):
+        os.makedirs(target_dir)
+    shutil.copy(source, target)
+    return True
 
 
 def release_from_redhat_release(fn):
@@ -765,9 +780,9 @@ class FSSet(object):
 
         # /etc/multipath.conf
         if any(d for d in self.devices if d.type == "dm-multipath"):
-            util.copy_to_system("/etc/multipath.conf")
-            util.copy_to_system("/etc/multipath/wwids")
-            util.copy_to_system("/etc/multipath/bindings")
+            copy_to_system("/etc/multipath.conf")
+            copy_to_system("/etc/multipath/wwids")
+            copy_to_system("/etc/multipath/bindings")
         else:
             log.info("not writing out mpath configuration")
 

--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -350,7 +350,7 @@ def remove_new_partitions(disks, remove, all_partitions):
         # remove empty extended so it doesn't interfere
         extended = disk.format.extended_partition
         if extended and not disk.format.logical_partitions and \
-           (flags.installer_mode or
+           (not flags.keep_empty_ext_partitions or
                 extended not in (p.parted_partition for p in all_partitions)):
             log.debug("removing empty extended partition from %s", disk.name)
             disk.format.parted_disk.removePartition(extended)

--- a/blivet/populator/helpers/lvm.py
+++ b/blivet/populator/helpers/lvm.py
@@ -262,7 +262,7 @@ class LVMFormatPopulator(FormatPopulator):
                                                    uuid=lv_uuid, size=lv_size, seg_type=lv_type,
                                                    exists=True, **lv_kwargs)
                 self._devicetree._add_device(lv_device)
-                if flags.installer_mode:
+                if flags.auto_dev_updates:
                     lv_device.setup()
 
                 if lv_device.status:

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -444,7 +444,7 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
             parted.clear_exn_handler()
             self._hide_ignored_disks()
 
-        if flags.installer_mode:
+        if flags.auto_dev_updates:
             self.teardown_all()
 
     def _populate(self):
@@ -453,7 +453,7 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
 
         self.drop_lvm_cache()
 
-        if flags.installer_mode and not flags.image_install:
+        if flags.auto_dev_updates and not flags.image_install:
             blockdev.mpath.set_friendly_names(flags.multipath_friendly_names)
 
         self.setup_disk_images()

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -35,8 +35,8 @@ global_udev = pyudev.Context()
 import logging
 log = logging.getLogger("blivet")
 
-INSTALLER_BLACKLIST = (r'^mtd', r'^mmcblk.+boot', r'^mmcblk.+rpmb', r'^zram')
-""" device name regexes to ignore when flags.installer_mode is True """
+device_name_blacklist = []
+""" device name regexes to ignore; this should be empty by default """
 
 
 def get_device(sysfs_path):
@@ -143,8 +143,8 @@ def __is_blacklisted_blockdev(dev_name):
     if dev_name.startswith("ram") or dev_name.startswith("fd"):
         return True
 
-    if flags.installer_mode:
-        if any(re.search(expr, dev_name) for expr in INSTALLER_BLACKLIST):
+    if device_name_blacklist:
+        if any(re.search(expr, dev_name) for expr in device_name_blacklist):
             return True
 
     if os.path.exists("/sys/class/block/%s/device/model" % (dev_name,)):

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -3,7 +3,6 @@ import functools
 import glob
 import itertools
 import os
-import shutil
 import selinux
 import subprocess
 import re
@@ -508,23 +507,6 @@ def find_program_in_path(prog, raise_on_error=False):
 def makedirs(path):
     if not os.path.isdir(path):
         os.makedirs(path, 0o755)
-
-
-def copy_to_system(source):
-    # do the import now because enable_installer_mode() has finally been called.
-    from . import get_sysroot
-
-    if not os.access(source, os.R_OK):
-        log.info("copy_to_system: source '%s' does not exist.", source)
-        return False
-
-    target = get_sysroot() + source
-    target_dir = os.path.dirname(target)
-    log.debug("copy_to_system: '%s' -> '%s'.", source, target)
-    if not os.path.isdir(target_dir):
-        os.makedirs(target_dir)
-    shutil.copy(source, target)
-    return True
 
 
 def lsmod():

--- a/tests/formats_test/selinux_test.py
+++ b/tests/formats_test/selinux_test.py
@@ -19,13 +19,13 @@ class SELinuxContextTestCase(loopbackedtestcase.LoopBackedTestCase):
         super(SELinuxContextTestCase, self).__init__(methodName=methodName, device_spec=[Size("100 MiB")])
 
     def setUp(self):
-        self.installer_mode = blivet.flags.installer_mode
+        self.selinux_reset_fcon = blivet.flags.selinux_reset_fcon
         super(SELinuxContextTestCase, self).setUp()
 
     def test_mounting_ext2fs(self):
         """ Test that lost+found directory gets assigned correct SELinux
-            context if installer_mode is True, and retains some random old
-            context if installer_mode is False.
+            context if selinux_set_fcon is True, and retains some random old
+            context if selinux_set_fcon is False.
         """
         LOST_AND_FOUND_CONTEXT = 'system_u:object_r:lost_found_t:s0'
         an_fs = fs.Ext2FS(device=self.loop_devices[0], label="test")
@@ -35,7 +35,7 @@ class SELinuxContextTestCase(loopbackedtestcase.LoopBackedTestCase):
 
         self.assertIsNone(an_fs.create())
 
-        blivet.flags.installer_mode = False
+        blivet.flags.selinux_reset_fcon = False
         mountpoint = tempfile.mkdtemp("test.selinux")
         an_fs.mount(mountpoint=mountpoint)
 
@@ -49,7 +49,7 @@ class SELinuxContextTestCase(loopbackedtestcase.LoopBackedTestCase):
 
         self.assertNotEqual(lost_and_found_selinux_context[1], LOST_AND_FOUND_CONTEXT)
 
-        blivet.flags.installer_mode = True
+        blivet.flags.selinux_reset_fcon = True
         mountpoint = tempfile.mkdtemp("test.selinux")
         an_fs.mount(mountpoint=mountpoint)
 
@@ -72,7 +72,7 @@ class SELinuxContextTestCase(loopbackedtestcase.LoopBackedTestCase):
 
         self.assertIsNone(an_fs.create())
 
-        blivet.flags.installer_mode = False
+        blivet.flags.selinux_reset_fcon = False
         mountpoint = tempfile.mkdtemp("test.selinux")
         an_fs.mount(mountpoint=mountpoint)
 
@@ -82,7 +82,7 @@ class SELinuxContextTestCase(loopbackedtestcase.LoopBackedTestCase):
         an_fs.unmount()
         os.rmdir(mountpoint)
 
-        blivet.flags.installer_mode = True
+        blivet.flags.selinux_reset_fcon = True
         mountpoint = tempfile.mkdtemp("test.selinux")
         an_fs.mount(mountpoint=mountpoint)
 
@@ -94,4 +94,4 @@ class SELinuxContextTestCase(loopbackedtestcase.LoopBackedTestCase):
 
     def tearDown(self):
         super(SELinuxContextTestCase, self).tearDown()
-        blivet.flags.installer_mode = self.installer_mode
+        blivet.flags.selinux_reset_fcon = self.selinux_reset_fcon

--- a/tests/partitioning_test.py
+++ b/tests/partitioning_test.py
@@ -700,9 +700,9 @@ class ExtendedPartitionTestCase(ImageBackedTestCase):
         self.blivet.do_it()
 
     def test_implicit_extended_partitions_installer_mode(self):
-        flags.installer_mode = True
+        flags.keep_empty_ext_partitions = False
         self.test_implicit_extended_partitions()
-        flags.installer_mode = False
+        flags.keep_empty_ext_partitions = True
 
     def test_explicit_extended_partitions(self):
         """ Verify that explicitly requested extended partitions work. """


### PR DESCRIPTION
This gets rid of flags.installer_mode from blivet. A few flags are created in its stead which are hopefully more generic, although I'm really bad at thinking of names. In other places local/surrounding logic could be used instead of just checking for flags.installer_mode.