### PR TITLE
Some low-hanging fruit to speed reset() up

### DIFF
--- a/blivet/formats/__init__.py
+++ b/blivet/formats/__init__.py
@@ -50,7 +50,6 @@ from ..tasks import fsminsize
 import logging
 log = logging.getLogger("blivet")
 
-
 device_formats = {}
 
 
@@ -110,28 +109,6 @@ def get_format(fmt_type, *args, **kwargs):
     return fmt
 
 
-def collect_device_format_classes():
-    """ Pick up all device format classes from this directory.
-
-        .. note::
-
-            Modules must call :func:`register_device_format` to make format
-            classes available to :func:`getFormat`.
-    """
-    mydir = os.path.dirname(__file__)
-    myfile = os.path.basename(__file__)
-    (myfile_name, _ext) = os.path.splitext(myfile)
-    for module_file in os.listdir(mydir):
-        (mod_name, ext) = os.path.splitext(module_file)
-        if ext == ".py" and mod_name != myfile_name and not mod_name.startswith("."):
-            try:
-                globals()[mod_name] = importlib.import_module("." + mod_name, package=__package__)
-            except ImportError:
-                log.error("import of device format module '%s' failed", mod_name)
-                from traceback import format_exc
-                log.debug("%s", format_exc())
-
-
 def get_device_format_class(fmt_type):
     """ Return an appropriate format class.
 
@@ -142,9 +119,6 @@ def get_device_format_class(fmt_type):
 
         Returns None if no class is found for fmt_type.
     """
-    if not device_formats:
-        collect_device_format_classes()
-
     fmt = device_formats.get(fmt_type)
     if not fmt:
         for fmt_class in device_formats.values():
@@ -758,4 +732,5 @@ class DeviceFormat(ObjectID, metaclass=SynchronizedMeta):
 
 register_device_format(DeviceFormat)
 
-collect_device_format_classes()
+# import the format modules (which register their device formats)
+from . import biosboot, disklabel, dmraid, fslib, fs, luks, lvmpv, mdraid, multipath, prepboot, swap

--- a/blivet/mounts.py
+++ b/blivet/mounts.py
@@ -151,7 +151,8 @@ class MountsCache(object):
                     continue
 
                 # use the canonical device path (if available)
-                devspec = resolve_devspec(devspec, sysname=True) or devspec
+                if devspec.startswith("/dev"):
+                    devspec = resolve_devspec(devspec, sysname=True) or devspec
 
                 if fstype == "btrfs":
                     root = mountinfo.get_root(devspec, mountpoint)

--- a/blivet/populator/helpers/disklabel.py
+++ b/blivet/populator/helpers/disklabel.py
@@ -43,14 +43,11 @@ class DiskLabelFormatPopulator(FormatPopulator):
 
     @classmethod
     def match(cls, data, device):
-        is_multipath_member = (device.is_disk and
-                               blockdev.mpath_is_mpath_member(device.path))
-
         # XXX ignore disklabels on multipath or biosraid member disks
         return (bool(udev.device_get_disklabel_type(data)) and
                 not udev.device_is_biosraid_member(data) and
-                not is_multipath_member and
-                udev.device_get_format(data) != "iso9660")
+                udev.device_get_format(data) != "iso9660" and
+                not (device.is_disk and blockdev.mpath_is_mpath_member(device.path)))
 
     def _get_kwargs(self):
         kwargs = super()._get_kwargs()


### PR DESCRIPTION
Three small and simple changes that make ``reset()`` quite a bit faster (~3s on my testing VM). A lot more can/needs to be done in the future, but the rest is quite complicated.

Just a note for the second patch:
``resolve_devspec()`` is not needed there. Something like ``resolve_dev_symlink()`` would be sufficient and much more efficient, but since it is a common operation, I'd like to add such function to *libblockdev* and then do the change in *Blivet* to start using it.