### PR TITLE
Retry umount and log output of lsof if it fails

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -693,8 +693,6 @@ class FS(DeviceFormat):
         mountpoint = kwargs.get("mountpoint") or self.systemMountpoint
         rc = util.umount(mountpoint)
         if rc:
-            # try and catch whatever is causing the umount problem
-            util.run_program(["lsof", mountpoint])
             raise FSError("umount of %s failed (%d)" % (mountpoint, rc))
 
         if mountpoint == self._chrootedMountpoint:


### PR DESCRIPTION
This is a copy of how lorax handles umount. Try 3 times, sleep 1s
between retries and log the output of lsof if the logging level is debug
or higher.

_This is related to rhbz#1315541 trying to see if retrying the umount helps_