### PR TITLE
Ignore pylint being confused with our mixins' properties

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -1092,7 +1092,7 @@ class LVMInternalLogicalVolumeMixin(object):
             raise ValueError("new size must of type Size")
 
         if not self.takes_extra_space:
-            if size <= self.parent_lv.size:
+            if size <= self.parent_lv.size:  # pylint: disable=no-member
                 self._size = size  # pylint: disable=attribute-defined-outside-init
             else:
                 raise ValueError("Internal LV cannot be bigger than its parent LV")


### PR DESCRIPTION
Pylint somehow fails to figure out that 'parent_lv' is a property of the mixin
class and reports it to be a method which doesn't have any 'size' member.