### PR TITLE
Add the P_ keyword to xgettext.

### DIFF
--- a/po/Makefile
+++ b/po/Makefile
@@ -30,7 +30,7 @@ SRCFILES 	= $(PYSRC)
 all::  update-po $(MOFILES)
 
 $(POTFILE): $(SRCFILES)
-	$(XGETTEXT) -L Python --keyword=_ --keyword=N_ $(SRCFILES)
+	$(XGETTEXT) -L Python --keyword=_ --keyword=N_ --keyword=P_:1,2 $(SRCFILES)
 	@if cmp -s $(NLSPACKAGE).po $(POTFILE); then \
 	    rm -f $(NLSPACKAGE).po; \
 	else \


### PR DESCRIPTION
The plural string, "RAID level %(raidLevel)s requires that device have
at least %(minMembers)d member(s)." was not being included for
translation.

This also affects 1.20-devel but I don't know how much you want to care about Fedora string freezes.