### PR TITLE
ARM platforms: support both msdos and gpt partitions

### DIFF
--- a/blivet/platform.py
+++ b/blivet/platform.py
@@ -268,6 +268,7 @@ class MacEFI(EFI):
 
 class Aarch64EFI(EFI):
     _non_linux_format_types = ["vfat", "ntfs"]
+    _disklabel_types = ["msdos", "gpt"]
 
 class PPC(Platform):
     _ppcMachine = arch.getPPCMachine()
@@ -366,7 +367,7 @@ class ARM(Platform):
     _boot_descriptions = {"disk": _boot_mbr_description,
                           "partition": Platform._boot_partition_description}
 
-    _disklabel_types = ["msdos"]
+    _disklabel_types = ["msdos", "gpt"]
     _boot_stage1_missing_error = N_("You must include at least one MBR-formatted "
                                     "disk as an install target.")
 


### PR DESCRIPTION
We need to be able to support both msdos and GPT partitions due to various low end Single Board Computers such as the Pine64. It would be really good to have this in Fedora 24 too, I think I have got the spots needed to support msdos and GPT on both ARMv7 and aarch64, I couldn't see any spots in anaconda itself.

A lot of new aarch64 single board computer devices need old style
msdos partition types due to restrictions in booting where the SoC
boots off a u-boot, that supports uEFI booting, written to the area
that is occupied by a GPT partition table.

Similarly a number of ARMv7 devices support booting from GPT
partitions where the u-boot binary is available in a EEPROM or nand.

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>