### PR TITLE
Improved handling of corrupt or otherwise unsupported disklabels

### DIFF
--- a/blivet/actionlist.py
+++ b/blivet/actionlist.py
@@ -215,7 +215,7 @@ class ActionList(object, metaclass=SynchronizedMeta):
 
         log.info("resetting parted disks...")
         for device in devices:
-            if device.partitioned:
+            if device.partitioned and device.format.supported:
                 device.format.reset_parted_disk()
 
             if device.original_format.type == "disklabel" and \
@@ -263,7 +263,7 @@ class ActionList(object, metaclass=SynchronizedMeta):
         devices = devices or []
         # removal of partitions makes use of original_format, so it has to stay
         # up to date in case of multiple passes through this method
-        for disk in (d for d in devices if d.partitioned):
+        for disk in (d for d in devices if d.partitioned and d.format.supported):
             disk.format.update_orig_parted_disk()
             disk.original_format = copy.deepcopy(disk.format)
 
@@ -334,6 +334,12 @@ class ActionList(object, metaclass=SynchronizedMeta):
                 for device in devices:
                     # make sure we catch any renumbering parted does
                     if device.exists and isinstance(device, PartitionDevice):
+                        # also update existence for partitions on unsupported disklabels
+                        if not device.disklabel_supported and \
+                           action.is_destroy and action.is_format and action.device == device.disk:
+                            device.exists = False
+                            continue
+
                         device.update_name()
                         device.format.device = device.path
 

--- a/blivet/autopart.py
+++ b/blivet/autopart.py
@@ -118,6 +118,9 @@ def _get_candidate_disks(storage):
     """
     disks = []
     for disk in storage.partitioned:
+        if not disk.format.supported:
+            continue
+
         if storage.config.clear_part_disks and \
            (disk.name not in storage.config.clear_part_disks):
             continue
@@ -433,7 +436,7 @@ def do_reqpart(storage, requests):
                         or `~.storage.autopart_requests` by default
        :type requests: list of :class:`~.partspec.PartSpec` instances
     """
-    if not storage.partitioned:
+    if not any(d.format.supported for d in storage.partitioned):
         raise NoDisksError(_("No usable disks selected"))
 
     disks = _get_candidate_disks(storage)
@@ -475,7 +478,7 @@ def do_autopart(storage, data, min_luks_entropy=None):
     log.debug("clear_part_disks: %s", storage.config.clear_part_disks)
     log.debug("autopart_requests:\n%s", "".join([str(p) for p in storage.autopart_requests]))
     log.debug("storage.disks: %s", [d.name for d in storage.disks])
-    log.debug("storage.partitioned: %s", [d.name for d in storage.partitioned])
+    log.debug("storage.partitioned: %s", [d.name for d in storage.partitioned if d.format.supported])
     log.debug("all names: %s", [d.name for d in storage.devices])
     log.debug("boot disk: %s", getattr(storage.boot_disk, "name", None))
 
@@ -485,7 +488,7 @@ def do_autopart(storage, data, min_luks_entropy=None):
     if not storage.do_autopart:
         return
 
-    if not storage.partitioned:
+    if not any(d.format.supported for d in storage.partitioned):
         raise NoDisksError(_("No usable disks selected"))
 
     if min_luks_entropy is not None:

--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -620,7 +620,7 @@ class Blivet(object, metaclass=SynchronizedMeta):
         # partitions. This can still happen through the UI but it makes sense to
         # avoid it where possible.
         partitions = sorted(self.partitions,
-                            key=lambda p: p.parted_partition.number,
+                            key=lambda p: getattr(p.parted_partition, "number", 1),
                             reverse=True)
         for part in partitions:
             log.debug("clearpart: looking at %s", part.name)
@@ -628,7 +628,7 @@ class Blivet(object, metaclass=SynchronizedMeta):
                 continue
 
             self.recursive_remove(part)
-            log.debug("partitions: %s", [p.getDeviceNodeName() for p in part.parted_partition.disk.partitions])
+            log.debug("partitions: %s", [p.name for p in part.disk.children])
 
         # now remove any empty extended partitions
         self.remove_empty_extended_partitions()

--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -388,8 +388,8 @@ class ActionDestroyDevice(DeviceAction):
         if action.device.depends_on(self.device) and action.is_destroy:
             rc = True
         elif (action.is_destroy and action.is_device and
-              isinstance(self.device, PartitionDevice) and
-              isinstance(action.device, PartitionDevice) and
+              isinstance(self.device, PartitionDevice) and self.device.disklabel_supported and
+              isinstance(action.device, PartitionDevice) and action.device.disklabel_supported and
               self.device.disk == action.device.disk):
             # remove partitions in descending numerical order
             self_num = self.device.parted_partition.number
@@ -564,7 +564,7 @@ class ActionCreateFormat(DeviceAction):
             msg = _("Creating %(type)s on %(device)s") % {"type": self.device.format.type, "device": self.device.path}
             callbacks.create_format_pre(CreateFormatPreData(msg))
 
-        if isinstance(self.device, PartitionDevice):
+        if isinstance(self.device, PartitionDevice) and self.device.disklabel_supported:
             for flag in partitionFlag.keys():
                 # Keep the LBA flag on pre-existing partitions
                 if flag in [PARTITION_LBA, self.format.parted_flag]:

--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -1054,7 +1054,7 @@ class PartitionSetFactory(PartitionFactory):
         # drop any new disks that don't have free space
         min_free = min(Size("500MiB"), self.parent_factory.size)
         add_disks = [d for d in add_disks if d.partitioned and
-                     d.format.free >= min_free]
+                     d.format.supported and d.format.free >= min_free]
 
         log.debug("add_disks: %s", [d.name for d in add_disks])
         log.debug("remove_disks: %s", [d.name for d in remove_disks])

--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -156,7 +156,17 @@ class PartitionDevice(StorageDevice):
         #        For existing partitions we will get the size from
         #        parted.
 
-        if self.exists and not flags.testing:
+        # We can't rely on self.disk.format.supported because self.disk may get reformatted
+        # in the course of things.
+        self.disklabel_supported = True
+        if self.exists and self.disk.partitioned and not self.disk.format.supported:
+            log.info("partition %s disklabel is unsupported", self.name)
+            self.disklabel_supported = False
+        elif self.exists and not flags.testing:
+            if not self.disk.partitioned:
+                self.disklabel_supported = False
+                raise errors.DeviceError("disk has wrong format '%s'" % self.disk.format.type)
+
             log.debug("looking up parted Partition: %s", self.path)
             self._parted_partition = self.disk.format.parted_disk.getPartitionByPath(self.path)
             if not self._parted_partition:
@@ -351,7 +361,7 @@ class PartitionDevice(StorageDevice):
     def pre_commit_fixup(self):
         """ Re-get self.parted_partition from the original disklabel. """
         log_method_call(self, self.name)
-        if not self.exists:
+        if not self.exists or not self.disklabel_supported:
             return
 
         # find the correct partition on the original parted.Disk since the
@@ -386,7 +396,9 @@ class PartitionDevice(StorageDevice):
         self._name = value  # actual name setting is done by parted
 
     def update_name(self):
-        if self.parted_partition is None:
+        if self.disk and not self.disklabel_supported:
+            pass
+        elif self.parted_partition is None:
             self.name = self.req_name
         else:
             self.name = device_path_to_name(self.parted_partition.path)
@@ -473,7 +485,7 @@ class PartitionDevice(StorageDevice):
 
     @property
     def is_magic(self):
-        if not self.disk:
+        if not self.disk or not self.disklabel_supported:
             return False
 
         number = getattr(self.parted_partition, "number", -1)
@@ -481,7 +493,7 @@ class PartitionDevice(StorageDevice):
         return (number == magic)
 
     def remove_hook(self, modparent=True):
-        if modparent:
+        if modparent and self.disklabel_supported:
             # if this partition hasn't been allocated it could not have
             # a disk attribute
             if not self.disk:
@@ -525,7 +537,7 @@ class PartitionDevice(StorageDevice):
             size, partition type, flags
         """
         log_method_call(self, self.name, exists=self.exists)
-        if not self.exists:
+        if not self.exists or not self.disklabel_supported:
             return
 
         self._size = Size(self.parted_partition.getLength(unit="B"))
@@ -699,6 +711,9 @@ class PartitionDevice(StorageDevice):
     def _destroy(self):
         """ Destroy the device. """
         log_method_call(self, self.name, status=self.status)
+        if not self.disklabel_supported:
+            return
+
         # we should have already set self.parted_partition to point to the
         # partition on the original disklabel
         self.disk.original_format.remove_partition(self.parted_partition)
@@ -722,6 +737,9 @@ class PartitionDevice(StorageDevice):
             self.disk.format.commit()
 
     def _post_destroy(self):
+        if not self.disklabel_supported:
+            return
+
         super(PartitionDevice, self)._post_destroy()
         if isinstance(self.disk, DMDevice):
             udev.settle()
@@ -867,7 +885,7 @@ class PartitionDevice(StorageDevice):
     @property
     def resizable(self):
         return super(PartitionDevice, self).resizable and \
-            self.disk.type != 'dasd'
+            self.disk.type != 'dasd' and self.disklabel_supported
 
     def check_size(self):
         """ Check to make sure the size of the device is allowed by the

--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -545,7 +545,7 @@ def do_partitioning(storage):
         :raises: :class:`~.errors.PartitioningError`
         :returns: :const:`None`
     """
-    disks = [d for d in storage.partitioned if not d.protected]
+    disks = [d for d in storage.partitioned if d.format.supported and not d.protected]
     for disk in disks:
         try:
             disk.setup()

--- a/blivet/populator/helpers/disklabel.py
+++ b/blivet/populator/helpers/disklabel.py
@@ -29,7 +29,6 @@ from gi.repository import BlockDev as blockdev
 from ... import formats
 from ... import udev
 from ...errors import InvalidDiskLabelError
-from ...i18n import _
 from ...storage_log import log_exception_info, log_method_call
 from .formatpopulator import FormatPopulator
 
@@ -94,9 +93,7 @@ class DiskLabelFormatPopulator(FormatPopulator):
             fmt = formats.get_format("disklabel", **kwargs)
         except InvalidDiskLabelError as e:
             log.info("no usable disklabel on %s", self.device.name)
-            if disklabel_type == "gpt":
-                log.debug(e)
-                self.device.format = formats.get_format(_("Invalid Disk Label"))
+            log.debug(e)
         else:
             self.device.format = fmt
 

--- a/tests/unsupported_disklabel_test.py
+++ b/tests/unsupported_disklabel_test.py
@@ -1,0 +1,157 @@
+# vim:set fileencoding=utf-8
+
+import unittest
+from unittest.mock import patch, sentinel, DEFAULT
+
+from blivet.actionlist import ActionList
+from blivet.deviceaction import ActionDestroyFormat
+from blivet.devices import DiskDevice
+from blivet.devices import DiskFile
+from blivet.devices import LVMLogicalVolumeDevice
+from blivet.devices import LVMVolumeGroupDevice
+from blivet.devices import PartitionDevice
+from blivet.devicetree import DeviceTree
+from blivet.formats import get_format
+from blivet.size import Size
+from blivet.util import sparsetmpfile
+
+
+class UnsupportedDiskLabelTestCase(unittest.TestCase):
+    def setUp(self):
+        disk1 = DiskDevice("testdisk", size=Size("300 GiB"), exists=True,
+                           fmt=get_format("disklabel", exists=True))
+        disk1.format._supported = False
+
+        with self.assertLogs("blivet", level="INFO") as cm:
+            partition1 = PartitionDevice("testpart1", size=Size("150 GiB"), exists=True,
+                                         parents=[disk1], fmt=get_format("ext4", exists=True))
+        self.assertTrue("disklabel is unsupported" in "\n".join(cm.output))
+
+        with self.assertLogs("blivet", level="INFO") as cm:
+            partition2 = PartitionDevice("testpart2", size=Size("100 GiB"), exists=True,
+                                         parents=[disk1], fmt=get_format("lvmpv", exists=True))
+        self.assertTrue("disklabel is unsupported" in "\n".join(cm.output))
+
+        # To be supported, all of a devices ancestors must be supported.
+        disk2 = DiskDevice("testdisk2", size=Size("300 GiB"), exists=True,
+                           fmt=get_format("lvmpv", exists=True))
+
+        vg = LVMVolumeGroupDevice("testvg", exists=True, parents=[partition2, disk2])
+
+        lv = LVMLogicalVolumeDevice("testlv", exists=True, size=Size("64 GiB"),
+                                    parents=[vg], fmt=get_format("ext4", exists=True))
+
+        with sparsetmpfile("addparttest", Size("50 MiB")) as disk_file:
+            disk3 = DiskFile(disk_file)
+            disk3.format = get_format("disklabel", device=disk3.path, exists=False)
+
+        self.disk1 = disk1
+        self.disk2 = disk2
+        self.disk3 = disk3
+        self.partition1 = partition1
+        self.partition2 = partition2
+        self.vg = vg
+        self.lv = lv
+
+    def test_unsupported_disklabel(self):
+        """ Test behavior of partitions on unsupported disklabels. """
+        # Verify basic properties of the disk and disklabel.
+        self.assertTrue(self.disk1.partitioned)
+        self.assertFalse(self.disk1.format.supported)
+        self.assertTrue(self.disk3.partitioned)
+        self.assertTrue(self.disk3.format.supported)  # normal disklabel is supported
+
+        # Verify some basic properties of the partitions.
+        self.assertFalse(self.partition1.disk.format.supported)
+        self.assertFalse(self.partition2.disk.format.supported)
+        self.assertEqual(self.partition1.disk, self.disk1)
+        self.assertEqual(self.partition2.disk, self.disk1)
+        self.assertIsNone(self.partition1.parted_partition)
+        self.assertIsNone(self.partition2.parted_partition)
+        self.assertFalse(self.partition1.is_magic)
+        self.assertFalse(self.partition2.is_magic)
+
+        # Verify that probe returns without changing anything.
+        partition1_type = sentinel.partition1_type
+        self.partition1._part_type = partition1_type
+        self.partition1.probe()
+        self.assertEqual(self.partition1.part_type, partition1_type)
+        self.partition1._part_type = None
+
+        # partition1 is not resizable even though it contains a resizable filesystem
+        self.assertEqual(self.partition1.resizable, False)
+
+        # lv is resizable as usual
+        with patch.object(self.lv.format, "_resizable", new=True):
+            self.assertEqual(self.lv.resizable, True)
+
+        # the lv's destroy method should call blockdev.lvm.lvremove as usual
+        with patch.object(self.lv, "_pre_destroy"):
+            with patch("blivet.devices.lvm.blockdev.lvm.lvremove") as lvremove:
+                self.lv.destroy()
+                self.assertTrue(lvremove.called)
+
+        # the vg's destroy method should call blockdev.lvm.vgremove as usual
+        with patch.object(self.vg, "_pre_destroy"):
+            with patch.multiple("blivet.devices.lvm.blockdev.lvm",
+                                vgreduce=DEFAULT,
+                                vgdeactivate=DEFAULT,
+                                vgremove=DEFAULT) as mocks:
+                self.vg.destroy()
+        self.assertTrue(mocks["vgreduce"].called)
+        self.assertTrue(mocks["vgdeactivate"].called)
+        self.assertTrue(mocks["vgremove"].called)
+
+        # the partition's destroy method shouldn't try to call any disklabel methods
+        with patch.object(self.partition2, "_pre_destroy"):
+            with patch.object(self.partition2.disk, "original_format") as disklabel:
+                self.partition2.destroy()
+        self.assertEqual(len(disklabel.mock_calls), 0)
+        self.assertTrue(self.partition2.exists)
+
+        # Destroying the disklabel should set all partitions to non-existing.
+        # XXX This part is handled by ActionList.
+        actions = ActionList()
+        unsupported_disklabel = self.disk1.format
+        actions.add(ActionDestroyFormat(self.disk1))
+        self.assertTrue(self.disk1.format.exists)
+        self.assertTrue(self.partition1.exists)
+        self.assertTrue(self.partition2.exists)
+        with patch.object(unsupported_disklabel, "_pre_destroy"):
+            with patch.object(unsupported_disklabel, "_destroy") as destroy:
+                with patch.object(actions, "_pre_process"):
+                    with patch.object(actions, "_post_process"):
+                        actions.process(devices=[self.partition1, self.partition2, self.disk1])
+
+        self.assertTrue(destroy.called)
+        self.assertFalse(unsupported_disklabel.exists)
+        self.assertFalse(self.partition1.exists)
+        self.assertFalse(self.partition2.exists)
+
+    def test_recursive_remove(self):
+        devicetree = DeviceTree()
+        devicetree._add_device(self.disk1)
+        devicetree._add_device(self.partition1)
+        devicetree._add_device(self.partition2)
+        devicetree._add_device(self.disk2)
+        devicetree._add_device(self.vg)
+        devicetree._add_device(self.lv)
+
+        self.assertIn(self.disk1, devicetree.devices)
+        self.assertIn(self.partition1, devicetree.devices)
+        self.assertIn(self.lv, devicetree.devices)
+        self.assertEqual(devicetree.get_device_by_name(self.disk1.name), self.disk1)
+        self.assertIsNotNone(devicetree.get_device_by_name(self.partition1.name))
+        self.assertIsNotNone(devicetree.get_device_by_name(self.partition1.name, hidden=True))
+        self.assertIsNotNone(devicetree.get_device_by_name(self.lv.name, hidden=True))
+        self.assertIsNotNone(devicetree.get_device_by_path(self.lv.path, hidden=True))
+        self.assertIsNotNone(devicetree.get_device_by_id(self.partition2.id, hidden=True,
+                                                         incomplete=True))
+        self.assertEqual(len(devicetree.get_dependent_devices(self.disk1)), 4)
+        with patch('blivet.devicetree.ActionDestroyFormat.apply'):
+            devicetree.recursive_remove(self.disk1)
+            self.assertTrue(self.disk1 in devicetree.devices)
+            self.assertFalse(self.partition1 in devicetree.devices)
+            self.assertFalse(self.partition2 in devicetree.devices)
+            self.assertFalse(self.vg in devicetree.devices)
+            self.assertFalse(self.lv in devicetree.devices)


### PR DESCRIPTION
This is a total reversal from the "unusable storage" dialog I added last year. The idea here is that blivet should not be constrained by what disklabels parted supports. If there are partitions in the system for it, we should be able to identify them and whatever it built on them. We should also be able to completely clear them so that users can get to a known-good state. Here are the main points of what this patch set does:

- include partitions and their descendants even if parted doesn't support the disklabel
  - we cannot support modifying the partition table in this case
  - we can, however, use the devices as-is or completely wipe the disk to start over
- make a better effort to find the disk a partition belongs on, regardless of whether `udev`/`blkid` provide expected data

The corresponding anaconda piece will hide all devices built on an unsupported disklabel from the user while allowing them to clear the disk or just ignore it. Kickstart's `clearpart` should also work as expected now with unsupported disklabels.
