### PR TITLE
Improved handling of corrupt or otherwise unsupported disklabels (rhel7)

### DIFF
--- a/blivet/__init__.py
+++ b/blivet/__init__.py
@@ -847,7 +847,7 @@ class Blivet(object):
         # partitions. This can still happen through the UI but it makes sense to
         # avoid it where possible.
         partitions = sorted(self.partitions,
-                            key=lambda p: p.partedPartition.number,
+                            key=lambda p: getattr(p.partedPartition, "number", 1),
                             reverse=True)
         for part in partitions:
             log.debug("clearpart: looking at %s", part.name)
@@ -855,7 +855,7 @@ class Blivet(object):
                 continue
 
             self.recursiveRemove(part)
-            log.debug("partitions: %s", [p.getDeviceNodeName() for p in part.partedPartition.disk.partitions])
+            log.debug("partitions: %s", [p.name for p in self.devicetree.getChildren(part.disk)])
 
         # now remove any empty extended partitions
         self.removeEmptyExtendedPartitions()

--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -358,8 +358,8 @@ class ActionDestroyDevice(DeviceAction):
         if action.device.dependsOn(self.device) and action.isDestroy:
             rc = True
         elif (action.isDestroy and action.isDevice and
-              isinstance(self.device, PartitionDevice) and
-              isinstance(action.device, PartitionDevice) and
+              (isinstance(self.device, PartitionDevice) and self.device.disklabelSupported) and
+              (isinstance(action.device, PartitionDevice) and action.device.disklabelSupported) and
               self.device.disk == action.device.disk):
             # remove partitions in descending numerical order
             selfNum = self.device.partedPartition.number
@@ -530,7 +530,7 @@ class ActionCreateFormat(DeviceAction):
             callbacks.create_format_pre(CreateFormatPreData(msg))
             self.device.setup()
 
-        if isinstance(self.device, PartitionDevice):
+        if isinstance(self.device, PartitionDevice) and self.device.disklabelSupported:
             for flag in partitionFlag.keys():
                 # Keep the LBA flag on pre-existing partitions
                 if flag in [ PARTITION_LBA, self.format.partedFlag ]:

--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -1004,7 +1004,7 @@ class PartitionSetFactory(PartitionFactory):
         # drop any new disks that don't have free space
         min_free = min(Size("500MiB"), self.parent_factory.size)
         add_disks = [d for d in add_disks if d.partitioned and
-                                             d.format.free >= min_free]
+                     d.format.supported and d.format.free >= min_free]
 
         log.debug("add_disks: %s", [d.name for d in add_disks])
         log.debug("remove_disks: %s", [d.name for d in remove_disks])

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -781,7 +781,7 @@ class DeviceTree(object):
             device = self.getDeviceByName(name)
 
             if device is None and udev.device_is_dm_partition(info):
-                diskname = udev.device_get_dm_partition_disk(info)
+                diskname = udev.device_get_partition_disk(info)
                 disk = self.getDeviceByName(diskname)
                 return self.addUdevPartitionDevice(info, disk=disk)
 

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -537,8 +537,8 @@ def device_is_biosraid_member(info):
 
     return False
 
-def device_get_dm_partition_disk(info):
-    if not device_is_dm_partition(info):
+def device_get_partition_disk(info):
+    if not (device_is_partition(info) or device_is_dm_partition(info)):
         return None
 
     disk = None

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -76,12 +76,14 @@ def trigger(subsystem=None, action="add", name=None):
     util.run_program(["udevadm"] + argv)
     settle()
 
-def resolve_devspec(devspec):
+def resolve_devspec(devspec, sysname=False):
     if not devspec:
         return None
 
     # import devices locally to avoid cyclic import (devices <-> udev)
     from . import devices
+
+    devname = devices.devicePathToName(devspec)
 
     ret = None
     for dev in get_devices():
@@ -93,7 +95,7 @@ def resolve_devspec(devspec):
             if device_get_uuid(dev) == devspec[5:]:
                 ret = dev
                 break
-        elif device_get_name(dev) == devices.devicePathToName(devspec):
+        elif device_get_name(dev) == devname or dev.sys_name == devname:
             ret = dev
             break
         else:
@@ -107,7 +109,7 @@ def resolve_devspec(devspec):
                     break
 
     if ret:
-        return device_get_name(ret)
+        return ret.sys_name if sysname else device_get_name(ret)
 
 def resolve_glob(glob):
     import fnmatch

--- a/tests/storagetestcase.py
+++ b/tests/storagetestcase.py
@@ -26,6 +26,12 @@ class StorageTestCase(unittest.TestCase):
         self.storage = blivet.Blivet()
 
         # device status
+        self.storage_status = blivet.devices.StorageDevice.status
+        self.dm_status = blivet.devices.DMDevice.status
+        self.luks_status = blivet.devices.LUKSDevice.status
+        self.vg_status = blivet.devices.LVMVolumeGroupDevice.status
+        self.md_status = blivet.devices.MDRaidArrayDevice.status
+        self.file_status = blivet.devices.FileDevice.status
         blivet.devices.StorageDevice.status = False
         blivet.devices.DMDevice.status = False
         blivet.devices.LUKSDevice.status = False
@@ -35,6 +41,10 @@ class StorageTestCase(unittest.TestCase):
 
         # prevent PartitionDevice from trying to dig around in the partition's
         # geometry
+        self.partition_set_target = PartitionDevice._setTargetSize
+        self.partition_align_target = PartitionDevice.alignTargetSize
+        self.partition_max = PartitionDevice.maxSize
+        self.partition_min = PartitionDevice.minSize
         blivet.devices.PartitionDevice._setTargetSize = StorageDevice._setTargetSize
         blivet.devices.PartitionDevice.alignTargetSize = StorageDevice.alignTargetSize
         blivet.devices.PartitionDevice.maxSize = StorageDevice.maxSize
@@ -56,7 +66,23 @@ class StorageTestCase(unittest.TestCase):
             device._partType = parted.PARTITION_NORMAL
             device._bootable = False
 
+        self.partition_probe = PartitionDevice.probe
         PartitionDevice.probe = partition_probe
+
+    def tearDown(self):
+        blivet.devices.StorageDevice.status = self.storage_status
+        blivet.devices.DMDevice.status = self.dm_status
+        blivet.devices.LUKSDevice.status = self.luks_status
+        blivet.devices.LVMVolumeGroupDevice.status = self.vg_status
+        blivet.devices.MDRaidArrayDevice.status = self.md_status
+        blivet.devices.FileDevice.status = self.file_status
+
+        blivet.devices.PartitionDevice._setTargetSize = self.partition_set_target
+        blivet.devices.PartitionDevice.alignTargetSize = self.partition_align_target
+        blivet.devices.PartitionDevice.maxSize = self.partition_max
+        blivet.devices.PartitionDevice.minSize = self.partition_min
+
+        blivet.devices.PartitionDevice.probe = self.partition_probe
 
     def newDevice(self, *args, **kwargs):
         """ Return a new Device instance suitable for testing. """

--- a/tests/unsupported_disklabel_test.py
+++ b/tests/unsupported_disklabel_test.py
@@ -1,0 +1,159 @@
+# vim:set fileencoding=utf-8
+
+import unittest
+from mock import patch, sentinel, DEFAULT
+
+from blivet import Blivet
+from blivet.deviceaction import ActionDestroyFormat
+from blivet.devices import DiskDevice
+from blivet.devices import DiskFile
+from blivet.devices import LVMLogicalVolumeDevice
+from blivet.devices import LVMVolumeGroupDevice
+from blivet.devices import PartitionDevice
+from blivet.devicetree import DeviceTree
+from blivet.formats import getFormat
+from blivet.size import Size
+from blivet.util import sparsetmpfile
+
+
+class UnsupportedDiskLabelTestCase(unittest.TestCase):
+    def setUp(self):
+        disk1 = DiskDevice("testdisk", size=Size("300 GiB"), exists=True,
+                           fmt=getFormat("disklabel", exists=True))
+        disk1.format._supported = False
+        partition1 = PartitionDevice("testpart1", size=Size("150 GiB"), exists=True,
+                                     parents=[disk1], fmt=getFormat("ext4", exists=True))
+        partition2 = PartitionDevice("testpart2", size=Size("100 GiB"), exists=True,
+                                     parents=[disk1], fmt=getFormat("lvmpv", exists=True))
+
+        # To be supported, all of a devices ancestors must be supported.
+        disk2 = DiskDevice("testdisk2", size=Size("300 GiB"), exists=True,
+                           fmt=getFormat("lvmpv", exists=True))
+
+        vg = LVMVolumeGroupDevice("testvg", exists=True, parents=[partition2, disk2])
+
+        lv = LVMLogicalVolumeDevice("testlv", exists=True, size=Size("64 GiB"),
+                                    parents=[vg], fmt=getFormat("ext4", exists=True))
+
+        with sparsetmpfile("addparttest", Size("50 MiB")) as disk_file:
+            disk3 = DiskFile(disk_file)
+            disk3.format = getFormat("disklabel", device=disk3.path, exists=False)
+
+        self.disk1 = disk1
+        self.disk2 = disk2
+        self.disk3 = disk3
+        self.partition1 = partition1
+        self.partition2 = partition2
+        self.vg = vg
+        self.lv = lv
+
+    def test_unsupported_disklabel(self):
+        """ Test behavior of partitions on unsupported disklabels. """
+        # Verify basic properties of the disk and disklabel.
+        self.assertTrue(self.disk1.partitioned)
+        self.assertFalse(self.disk1.format.supported)
+        self.assertTrue(self.disk3.partitioned)
+        self.assertTrue(self.disk3.format.supported)  # normal disklabel is supported
+
+        # Verify some basic properties of the partitions.
+        self.assertFalse(self.partition1.disklabelSupported)
+        self.assertFalse(self.partition2.disklabelSupported)
+        self.assertEqual(self.partition1.disk, self.disk1)
+        self.assertEqual(self.partition2.disk, self.disk1)
+        self.assertIsNone(self.partition1.partedPartition)
+        self.assertIsNone(self.partition2.partedPartition)
+        self.assertFalse(self.partition1.isMagic)
+        self.assertFalse(self.partition2.isMagic)
+
+        # Verify that probe returns without changing anything.
+        partition1_type = sentinel.partition1_type
+        self.partition1._partType = partition1_type
+        self.partition1.probe()
+        self.assertEqual(self.partition1.partType, partition1_type)
+        self.partition1._partType = None
+
+        # partition1 is not resizable even though it contains a resizable filesystem
+        self.assertEqual(self.partition1.resizable, False)
+
+        # lv is resizable as usual
+        with patch.object(self.lv.format, "_resizable", new=True):
+            self.assertEqual(self.lv.resizable, True)
+
+        # the lv's destroy method should call devicelibs.lvm.lvremove as usual
+        with patch.object(self.lv, "_preDestroy"):
+            with patch("blivet.devicelibs.lvm.lvremove") as lvremove:
+                self.lv.destroy()
+                self.assertTrue(lvremove.called)
+
+        # the vg's destroy method should call devicelibs.lvm.vgremove as usual
+        with patch.object(self.vg, "_preDestroy"):
+            with patch.multiple("blivet.devicelibs.lvm",
+                                vgreduce=DEFAULT,
+                                vgdeactivate=DEFAULT,
+                                vgremove=DEFAULT) as mocks:
+                self.vg.destroy()
+        self.assertTrue(mocks["vgreduce"].called)
+        self.assertTrue(mocks["vgdeactivate"].called)
+        self.assertTrue(mocks["vgremove"].called)
+
+        # the partition's destroy method shouldn't try to call any disklabel methods
+        with patch.object(self.partition2, "_preDestroy"):
+            with patch.object(self.partition2.disk, "originalFormat") as disklabel:
+                self.partition2.destroy()
+        self.assertEqual(len(disklabel.mock_calls), 0)
+        self.assertTrue(self.partition2.exists)
+
+        # Destroying the disklabel should set all partitions to non-existing.
+        # XXX This part is handled by ActionList.
+        devicetree = DeviceTree()
+        devicetree._addDevice(self.disk1)
+        devicetree._addDevice(self.partition1)
+        devicetree._addDevice(self.partition2)
+        devicetree._addDevice(self.disk2)
+        devicetree._addDevice(self.vg)
+        devicetree._addDevice(self.lv)
+
+        unsupported_disklabel = self.disk1.format
+        action = ActionDestroyFormat(self.disk1)
+        devicetree._actions.append(action)
+        action._applied = True
+        self.assertTrue(self.disk1.format.exists)
+        self.assertTrue(self.partition1.exists)
+        self.assertTrue(self.partition2.exists)
+        with patch.object(unsupported_disklabel, "destroy") as destroy:
+            with patch.object(devicetree, "_preProcessActions"):
+                with patch.object(devicetree, "_postProcessActions"):
+                    devicetree.processActions()
+
+        self.assertTrue(destroy.called)
+        self.assertFalse(self.partition1.exists)
+        self.assertFalse(self.partition2.exists)
+
+    def test_recursiveRemove(self):
+        b = Blivet()
+        devicetree = b.devicetree
+        devicetree._addDevice(self.disk1)
+        devicetree._addDevice(self.partition1)
+        devicetree._addDevice(self.partition2)
+        devicetree._addDevice(self.disk2)
+        devicetree._addDevice(self.vg)
+        devicetree._addDevice(self.lv)
+
+        self.assertIn(self.disk1, devicetree.devices)
+        self.assertIn(self.partition1, devicetree.devices)
+        self.assertIn(self.lv, devicetree.devices)
+        self.assertEqual(b.devicetree.getDeviceByName(self.disk1.name), self.disk1)
+        self.assertIsNotNone(devicetree.getDeviceByName(self.partition1.name))
+        self.assertIsNotNone(devicetree.getDeviceByName(self.partition1.name, hidden=True))
+        self.assertIsNotNone(devicetree.getDeviceByName(self.lv.name, hidden=True))
+        self.assertIsNotNone(devicetree.getDeviceByPath(self.lv.path, hidden=True))
+        self.assertIsNotNone(devicetree.getDeviceByID(self.partition2.id, hidden=True,
+                                                      incomplete=True))
+        self.assertEqual(len(devicetree.getDependentDevices(self.disk1)), 4)
+        with patch('blivet.ActionDestroyFormat.apply'):
+            b.recursiveRemove(self.disk1)
+            self.assertTrue(self.disk1 in devicetree.devices)
+            self.assertFalse(self.partition1 in devicetree.devices)
+            self.assertFalse(self.partition2 in devicetree.devices)
+            self.assertFalse(self.vg in devicetree.devices)
+            self.assertFalse(self.lv in devicetree.devices)


### PR DESCRIPTION
Same as #427 except for `rhel7-branch`, which means I had to drag over a few minor things to make it all work the same.