### PR TITLE
Wait for LV path to appear during auto-activate (#1325707)

### DIFF
--- a/blivet/devices/dm.py
+++ b/blivet/devices/dm.py
@@ -100,7 +100,8 @@ class DMDevice(StorageDevice):
     def status(self):
         match = next((m for m in block.dm.maps() if m.name == self.mapName),
            None)
-        return (match.live_table and not match.suspended) if match else False
+        return super(DMDevice, self).status and \
+               (match.live_table and not match.suspended) if match else False
 
     #def getTargetType(self):
     #    return dm.getDmTarget(name=self.name)


### PR DESCRIPTION
When a LV is on top of a RAID, and the RAID is not fully synced, it
appears that it can take a significant (1s or more) for the LV's path to
appear under /dev/mapper, causing problems when trying to immediately
wipe the filesystem from the LV before tearing down the LV, VG, PV and
RAID.

So, this adds a check to make sure the LV's path exists before declaring
that it has been auto-activated.

Resolves: rhbz#1325707