### PR TITLE
Do not use deprecated pyudev methods

### DIFF
--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -279,8 +279,8 @@ class StorageDevice(Device):
             raise errors.DeviceError("device has not been created", self.name)
 
         try:
-            udev_device = pyudev.Device.from_device_file(udev.global_udev,
-                                                         self.path)
+            udev_device = pyudev.Devices.from_device_file(udev.global_udev,
+                                                          self.path)
 
         # from_device_file() does not process exceptions but just propagates
         # any errors that are raised.

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -41,7 +41,7 @@ INSTALLER_BLACKLIST = (r'^mtd', r'^mmcblk.+boot', r'^mmcblk.+rpmb', r'^zram')
 
 def get_device(sysfs_path):
     try:
-        dev = pyudev.Device.from_sys_path(global_udev, sysfs_path)
+        dev = pyudev.Devices.from_sys_path(global_udev, sysfs_path)
     except pyudev.DeviceNotFoundError as e:
         log.error(e)
         dev = None

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -23,6 +23,7 @@ Source0: http://github.com/rhinstaller/blivet/archive/%{realname}-%{realversion}
 %define utillinuxver 2.15.1
 %define libblockdevver 1.4
 %define libbytesizever 0.3
+%define pyudevver 0.18
 
 BuildArch: noarch
 BuildRequires: gettext
@@ -38,7 +39,7 @@ Summary: A python3 package for examining and modifying storage configuration.
 Requires: python3
 Requires: python3-six
 Requires: python3-kickstart
-Requires: python3-pyudev
+Requires: python3-pyudev >= %{pyudevver}
 Requires: parted >= %{partedver}
 Requires: python3-pyparted >= %{pypartedver}
 Requires: libselinux-python3


### PR DESCRIPTION
'pyudev.Device.from_sys_path' and 'pyudev.Device.from_device_file'
are deprecated since pyudev 0.18.