### PR TITLE
Configuration actions

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -77,6 +77,8 @@ class FS(DeviceFormat):
     # value is already unpredictable and can change in the future...
     _metadata_size_factor = 1.0
 
+    config_actions_map = {"label": "write_label"}
+
     def __init__(self, **kwargs):
         """
             :keyword device: path to the block device node (required for
@@ -580,7 +582,7 @@ class FS(DeviceFormat):
             raise FSReadLabelError("can not read label for filesystem %s" % self.type)
         return self._readlabel.do_task()
 
-    def write_label(self):
+    def write_label(self, dry_run=False):
         """ Create a label for this filesystem.
 
             :raises: FSError
@@ -605,7 +607,8 @@ class FS(DeviceFormat):
         if not os.path.exists(self.device):
             raise FSError("device does not exist")
 
-        self._writelabel.do_task()
+        if not dry_run:
+            self._writelabel.do_task()
 
     @property
     def utils_available(self):


### PR DESCRIPTION
This is not a final version, just a "request for comments".

I've decided to use the "single class" approach with a dict of supported ("configurable") attributes and functions used to set the attribute. I didn't have to create a special function for label configuration -- we already have the `write_label` functions so I've just changed it to take the `dry_run` option for the input validation.

Pros:
- It's easy to tell if format supports configuration of an attribute using actions.
- Having only one class makes the API simpler for the users.
- It's possible to use existing validation functions/tasks.

Cons:
- Every attribute needs a special function that looks like a setter but it actually isn't (because of the `dry_run` option).

