### PR TITLE
fcoe: don't use dcb for autoconnecting of bnx2x and bnx2fc (#1261703)

### DIFF
--- a/blivet/fcoe.py
+++ b/blivet/fcoe.py
@@ -88,8 +88,10 @@ class fcoe(object):
             log.info("No FCoE EDD info found: %s", buf.rstrip())
             return
 
-        log.info("FCoE NIC found in EDD: %s", val)
-        self.addSan(val, dcb=True, auto_vlan=True)
+        dcb = self._iface_driver(val) not in ("bnx2x", "bnx2fc")
+
+        log.info("FCoE NIC found in EDD: %s, using dcb: %s", val, dcb)
+        self.addSan(val, dcb=dcb, auto_vlan=True)
 
     def startup(self):
         if self.started:
@@ -165,28 +167,12 @@ class fcoe(object):
 
             time.sleep(1)
 
-            if rc == 0:
-                self.write_nic_fcoe_cfg(nic, dcb=dcb, auto_vlan=auto_vlan)
-                rc, out = util.run_program_and_capture_output(
-                    ["systemctl", "restart", "fcoe.service"])
-            else:
-                log.info("Timed out when %s", timeout_msg)
-
+        if rc == 0:
+            self.write_nic_fcoe_cfg(nic, dcb=dcb, auto_vlan=auto_vlan)
+            rc, out = util.run_program_and_capture_output(
+                ["systemctl", "restart", "fcoe.service"])
         else:
-            dpath = os.readlink("/sys/class/net/%s/device/driver" % nic)
-            driver = os.path.basename(dpath)
-            if driver == "bnx2x":
-                util.run_program(["ip", "link", "set", nic, "up"])
-                util.run_program(["modprobe", "8021q"])
-                udev.settle()
-                # Sleep for 3 s to allow dcb negotiation (#813057)
-                time.sleep(3)
-                rc, out = util.run_program_and_capture_output(
-                    ["fipvlan", '-c', '-s', '-f', '-fcoe', nic])
-            else:
-                self.write_nic_fcoe_cfg(nic, dcb=dcb, auto_vlan=auto_vlan)
-                rc, out = util.run_program_and_capture_output(
-                    ["systemctl", "restart", "fcoe.service"])
+            log.info("Timed out when %s", timeout_msg)
 
         if rc == 0:
             self._stabilize()
@@ -196,6 +182,16 @@ class fcoe(object):
             error_msg = out
 
         return error_msg
+
+    def _iface_driver(self, nic):
+        try:
+            dpath = os.readlink("/sys/class/net/%s/device/driver" % nic)
+        except OSError as e:
+            log.debug("Can't find driver of device %s, %s", nic, e)
+            driver = ""
+        else:
+            driver = os.path.basename(dpath)
+        return driver
 
     def write(self, root):
         if not self.nics:


### PR DESCRIPTION
Also use fcoemon instead of fipvlan for bnx2fc.

Resolves: rhbz#1261703