### PR TITLE
Fix not enough free space after creating extended partition (#1252350)

### DIFF
--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -916,7 +916,13 @@ def allocate_partitions(storage, disks, partitions, freespace):
         if part_type == parted.PARTITION_EXTENDED and \
            part_type != _part.req_part_type:
             log.debug("creating extended partition")
-            add_partition(disklabel, free, part_type, None)
+            ext = add_partition(disklabel, free, part_type, None)
+
+            # extedned partition took all free space - make the size request smaller
+            if aligned_size > (ext.geometry.length - disklabel.alignment.grainSize) * disklabel.sector_size:
+                log.debug("not enough free space after creating extended "
+                          "partition - shrinking the logical partition")
+                aligned_size = aligned_size - (disklabel.alignment.grainSize * disklabel.sector_size)
 
             # now the extended partition exists, so set type to logical
             part_type = parted.PARTITION_LOGICAL


### PR DESCRIPTION
When adding fourth partition extended partition is automatically
created. Because the extended partition takes 1 MiB of the free space
we might not have enough free space for the logical partition.
This patch shrinks the logical partition if this problem occurs.