### PR TITLE
Cache and reuse data about multipath members

### DIFF
--- a/blivet/events/handler.py
+++ b/blivet/events/handler.py
@@ -24,6 +24,7 @@ from ..errors import DeviceError, EventHandlingError
 from ..devices import DM_MAJORS, MD_MAJORS
 from .. import udev
 from ..threads import SynchronizedMeta
+from ..static_data import mpath_members
 
 from .changes import data as event_data
 from .changes import record_change
@@ -129,6 +130,7 @@ class EventHandlerMixin(metaclass=SynchronizedMeta):
         # XXX Don't change anything (except simple attributes?) if actions are being executed.
         if device is None and self._event_device_is_physical_disk(event):
             log.info("disk %s was added", udev.device_get_name(event.info))
+            mpath_members.update_cache(udev.device_get_devname(event.info))
             self.handle_device(event.info)
         elif device is not None and device.exists:
             log.info("device %s was activated", device.name)

--- a/blivet/populator/helpers/disklabel.py
+++ b/blivet/populator/helpers/disklabel.py
@@ -21,16 +21,13 @@
 #
 
 import os
-import gi
-gi.require_version("BlockDev", "1.0")
-
-from gi.repository import BlockDev as blockdev
 
 from ... import formats
 from ... import udev
 from ...errors import InvalidDiskLabelError
 from ...storage_log import log_exception_info, log_method_call
 from .formatpopulator import FormatPopulator
+from ...static_data import mpath_members
 
 import logging
 log = logging.getLogger("blivet")
@@ -46,7 +43,7 @@ class DiskLabelFormatPopulator(FormatPopulator):
         return (bool(udev.device_get_disklabel_type(data)) and
                 not udev.device_is_biosraid_member(data) and
                 udev.device_get_format(data) != "iso9660" and
-                not (device.is_disk and blockdev.mpath_is_mpath_member(device.path)))
+                not (device.is_disk and mpath_members.is_mpath_member(device.path)))
 
     def _get_kwargs(self):
         kwargs = super()._get_kwargs()

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -44,7 +44,7 @@ from ..flags import flags
 from ..storage_log import log_method_call
 from ..threads import SynchronizedMeta
 from .helpers import get_device_helper, get_format_helper
-from ..static_data import lvs_info, pvs_info, luks_data
+from ..static_data import lvs_info, pvs_info, luks_data, mpath_members
 
 import logging
 log = logging.getLogger("blivet")
@@ -225,7 +225,7 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
         return device
 
     def _clear_new_multipath_member(self, device):
-        if device is None or not device.is_disk or not blockdev.mpath.is_mpath_member(device.path):
+        if device is None or not device.is_disk or not mpath_members.is_mpath_member(device.path):
             return
 
         # newly added device (eg iSCSI) could make this one a multipath member
@@ -486,6 +486,7 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
                  self.ignored_disks, self.exclusive_disks)
 
         self.drop_lvm_cache()
+        mpath_members.drop_cache()
 
         if flags.installer_mode and not flags.image_install:
             blockdev.mpath.set_friendly_names(flags.multipath_friendly_names)

--- a/blivet/static_data/__init__.py
+++ b/blivet/static_data/__init__.py
@@ -1,2 +1,3 @@
 from .lvm_info import lvs_info, pvs_info
 from .luks_data import luks_data
+from .mpath_info import mpath_members

--- a/blivet/static_data/mpath_info.py
+++ b/blivet/static_data/mpath_info.py
@@ -1,0 +1,65 @@
+#
+# Copyright (C) 2016  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU Lesser General Public License v.2, or (at your option) any later
+# version. This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY expressed or implied, including the implied
+# warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+# the GNU Lesser General Public License for more details.  You should have
+# received a copy of the GNU Lesser General Public License along with this
+# program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+# Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat trademarks
+# that are incorporated in the source code or documentation are not subject
+# to the GNU Lesser General Public License and may only be used or
+# replicated with the express permission of Red Hat, Inc.
+#
+# Red Hat Author(s): Vratislav Podzimek <vpodzime@redhat.com>
+#
+
+import os
+import gi
+gi.require_version("BlockDev", "1.0")
+
+from gi.repository import BlockDev as blockdev
+
+import logging
+log = logging.getLogger("blivet")
+
+
+class MpathMembers(object):
+    """A cache for querying multipath member devices"""
+
+    def __init__(self):
+        self._members = None
+
+    def is_mpath_member(self, device):
+        """Checks if the given device is a member of some multipath mapping or not.
+
+        :param str device: path of the device to query
+
+        """
+        if self._members is None:
+            self._members = set(blockdev.mpath.get_mpath_members())
+
+        device = os.path.realpath(device)
+        device = device[len("/dev/"):]
+
+        return device in self._members
+
+    def update_cache(self, device):
+        """Update the cache with the given device (checks and adds it is an mpath member)
+
+        :param str device: path of the device to check and add
+
+        """
+        device = os.path.realpath(device)
+        device = device[len("/dev/"):]
+        if blockdev.mpath.is_mpath_member(device):
+            self._members.add(device)
+
+    def drop_cache(self):
+        self._members = None
+
+mpath_members = MpathMembers()

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -734,7 +734,7 @@ class FormatPopulatorTestCase(PopulatorHelperTestCase):
             self.assertTrue(self.helper_class.match(data, device),
                             msg="Failed to match %s against %s" % (self.udev_type, self.helper_name))
 
-    @patch("blivet.populator.helpers.disklabel.blockdev.mpath_is_mpath_member", return_value=False)
+    @patch("blivet.static_data.mpath_members.is_mpath_member", return_value=False)
     @patch("blivet.udev.device_is_partition", return_value=False)
     @patch("blivet.udev.device_is_dm_partition", return_value=False)
     # pylint: disable=unused-argument
@@ -790,7 +790,7 @@ class HFSPopulatorTestCase(FormatPopulatorTestCase):
 class DiskLabelPopulatorTestCase(PopulatorHelperTestCase):
     helper_class = DiskLabelFormatPopulator
 
-    @patch("blivet.populator.helpers.disklabel.blockdev.mpath_is_mpath_member", return_value=False)
+    @patch("blivet.static_data.mpath_members.is_mpath_member", return_value=False)
     @patch("blivet.udev.device_is_biosraid_member", return_value=False)
     @patch("blivet.udev.device_get_format", return_value=None)
     @patch("blivet.udev.device_get_disklabel_type", return_value="dos")
@@ -828,7 +828,7 @@ class DiskLabelPopulatorTestCase(PopulatorHelperTestCase):
         self.assertFalse(self.helper_class.match(data, device))
         is_mpath_member.return_value = False
 
-    @patch("blivet.populator.helpers.disklabel.blockdev.mpath_is_mpath_member", return_value=False)
+    @patch("blivet.static_data.mpath_members.is_mpath_member", return_value=False)
     @patch("blivet.udev.device_is_biosraid_member", return_value=False)
     @patch("blivet.udev.device_get_format", return_value=None)
     @patch("blivet.udev.device_get_disklabel_type", return_value="dos")


### PR DESCRIPTION
With the new function provided by libblockdev we can easily get the list of
multipath member devices once and then query it instead of querying every device
whether it is an mpath member or not.

Note: This is an enhancement so it's targeting the _2.1-devel_ branch.
