### PR TITLE
Restore the correct default partition table type for AArch64 EFI.

### DIFF
--- a/blivet/platform.py
+++ b/blivet/platform.py
@@ -268,7 +268,7 @@ class MacEFI(EFI):
 
 class Aarch64EFI(EFI):
     _non_linux_format_types = ["vfat", "ntfs"]
-    _disklabel_types = ["msdos", "gpt"]
+    _disklabel_types = ["gpt", "msdos"]
 
 class PPC(Platform):
     _ppcMachine = arch.getPPCMachine()


### PR DESCRIPTION
Signed-off-by: David A. Marlin <dmarlin@redhat.com>
Resolves: rhbz#1349130