### PR TITLE
Fix mpath edge case in disk filtering

### DIFF
--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -876,6 +876,10 @@ class DeviceTreeBase(object, metaclass=SynchronizedMeta):
                 # past, so I guess we will support it forever.
                 if disk.parents and all(p.format.hidden for p in disk.parents):
                     ignored = any(self._is_ignored_disk(d) for d in disk.parents)
+                elif disk.format.hidden and len(disk.children) == 1:
+                    # Similarly, if the filter allows an mpath or fwraid, we cannot
+                    # ignore the member devices.
+                    ignored = self._is_ignored_disk(disk.children[0])
 
                 if ignored:
                     self.hide(disk)


### PR DESCRIPTION
People should be able to set `exclusive_disks = ["mpatha"]` (via `ignoredisk --onlyuse=mpatha` in kickstart) without having to list the member disks.