### PR TITLE
Don't require existing origin when modeling snapshot

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -1168,8 +1168,6 @@ class LVMSnapshotMixin(object):
 
         if self.origin and not isinstance(self.origin, LVMLogicalVolumeDevice):
             raise ValueError("lvm snapshot origin must be a logical volume")
-        if self.origin and not self.origin.exists:
-            raise ValueError("lvm snapshot origin volume must already exist")
         if self.vorigin and not self.exists:
             raise ValueError("only existing vorigin snapshots are supported")
 

--- a/tests/devices_test/lvm_test.py
+++ b/tests/devices_test/lvm_test.py
@@ -29,9 +29,6 @@ class LVMDeviceTest(unittest.TestCase):
         lv = LVMLogicalVolumeDevice("testlv", parents=[vg],
                                     fmt=blivet.formats.get_format("xfs"))
 
-        with self.assertRaisesRegex(ValueError, "lvm snapshot origin volume must already exist"):
-            LVMLogicalVolumeDevice("snap1", parents=[vg], origin=lv)
-
         with self.assertRaisesRegex(ValueError, "lvm snapshot origin must be a logical volume"):
             LVMLogicalVolumeDevice("snap1", parents=[vg], origin=pv)
 
@@ -59,9 +56,6 @@ class LVMDeviceTest(unittest.TestCase):
         vg = LVMVolumeGroupDevice("testvg", parents=[pv])
         pool = LVMLogicalVolumeDevice("pool1", parents=[vg], size=Size("500 MiB"), seg_type="thin-pool")
         thinlv = LVMLogicalVolumeDevice("thinlv", parents=[pool], size=Size("200 MiB"), seg_type="thin")
-
-        with self.assertRaisesRegex(ValueError, "lvm snapshot origin volume must already exist"):
-            LVMLogicalVolumeDevice("snap1", parents=[pool], origin=thinlv, seg_type="thin")
 
         with self.assertRaisesRegex(ValueError, "lvm snapshot origin must be a logical volume"):
             LVMLogicalVolumeDevice("snap1", parents=[pool], origin=pv, seg_type="thin")


### PR DESCRIPTION
You can't add snapshot to a model when this check is enabled. I don't know why you want this but it looks as a huge drawback to me.