### PR TITLE
Creation of LVs from non-existing LVs

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -986,14 +986,11 @@ class Blivet(object, metaclass=SynchronizedMeta):
 
         """
         # we need to remove the LVs from the devicetree because they are now
-        # internal LVs of the new LV which on the other hand needs to be added
+        # internal LVs of the new LV
         for lv in from_lvs:
             self.devicetree._remove_device(lv)
 
-        new_lv = LVMLogicalVolumeDevice(name, parents=vg, seg_type=seg_type, from_lvs=from_lvs, **kwargs)
-        self.devicetree._add_device(new_lv)
-
-        return new_lv
+        return LVMLogicalVolumeDevice(name, parents=vg, seg_type=seg_type, from_lvs=from_lvs, **kwargs)
 
     def new_btrfs(self, *args, **kwargs):
         """ Return a new BTRFSVolumeDevice or BRFSSubVolumeDevice.

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -614,8 +614,6 @@ class LVMLogicalVolumeBase(DMDevice, RaidDevice):
 
         self._from_lvs = from_lvs
         if self._from_lvs:
-            if any(not lv.exists for lv in self._from_lvs):
-                raise ValueError("Conversion of LVs only supported for existing LVs")
             if exists:
                 raise ValueError("Only new LVs can be created from other LVs")
             if size or maxsize or percent:
@@ -1144,13 +1142,19 @@ class LVMInternalLogicalVolumeMixin(object):
     # generally changes should be done on the parent LV (exceptions should
     # override these)
     def setup(self, orig=False):  # pylint: disable=unused-argument
-        raise errors.DeviceError("An internal LV cannot be set up separately")
+        if self._parent_lv.exists:
+            # unless this LV is yet to be used by the parent LV...
+            raise errors.DeviceError("An internal LV cannot be set up separately")
 
     def teardown(self, recursive=None):  # pylint: disable=unused-argument
-        raise errors.DeviceError("An internal LV cannot be torn down separately")
+        if self._parent_lv.exists:
+            # unless this LV is yet to be used by the parent LV...
+            raise errors.DeviceError("An internal LV cannot be torn down separately")
 
     def destroy(self):
-        raise errors.DeviceError("An internal LV cannot be destroyed separately")
+        if self._parent_lv.exists:
+            # unless this LV is yet to be used by the parent LV...
+            raise errors.DeviceError("An internal LV cannot be destroyed separately")
 
     @property
     def growable(self):
@@ -1470,6 +1474,13 @@ class LVMThinPoolMixin(object):
         if not self.exists:
             space += Size(blockdev.lvm.get_thpool_padding(space, self.vg.pe_size))
         return space
+
+    def _pre_create(self):
+        if self._from_lvs:
+            # make sure all the LVs this LV should be created from exist
+            for lv in self._from_lvs:
+                if not lv.exists:
+                    lv.create()
 
     def _create(self):
         """ Create the device. """

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -21,7 +21,7 @@ Source0: http://github.com/rhinstaller/blivet/archive/%{realname}-%{realversion}
 %define pypartedver 3.10.4
 %define e2fsver 1.41.0
 %define utillinuxver 2.15.1
-%define libblockdevver 1.7
+%define libblockdevver 1.9
 %define libbytesizever 0.3
 %define pyudevver 0.18
 

--- a/tests/devices_test/lvm_test.py
+++ b/tests/devices_test/lvm_test.py
@@ -505,6 +505,9 @@ class BlivetNewLVMDeviceTest(unittest.TestCase):
         # combine the two LVs into a thin pool (the LVs should become its internal LVs)
         pool = b.new_lv_from_lvs(vg, name="pool", seg_type="thin-pool", from_lvs=(lv1, lv2))
 
+        # add the pool LV into the devicetree
+        b.devicetree._add_device(pool)
+
         self.assertEqual(set(b.devices), {pv, vg, pool})
         self.assertEqual(set(b.vgs), {vg})
         self.assertEqual(set(b.lvs), {pool})


### PR DESCRIPTION
The first patch enables and implements creation of new LVs from non-existing LVs - IOW, makes sure the internal LVs are created first. The other two patches just fix minor issues, I've spotted while working on the feature.