### PR TITLE
Actions for creating LVs from other LVs

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -986,14 +986,11 @@ class Blivet(object, metaclass=SynchronizedMeta):
 
         """
         # we need to remove the LVs from the devicetree because they are now
-        # internal LVs of the new LV which on the other hand needs to be added
+        # internal LVs of the new LV
         for lv in from_lvs:
             self.devicetree._remove_device(lv)
 
-        new_lv = LVMLogicalVolumeDevice(name, parents=vg, seg_type=seg_type, from_lvs=from_lvs, **kwargs)
-        self.devicetree._add_device(new_lv)
-
-        return new_lv
+        return LVMLogicalVolumeDevice(name, parents=vg, seg_type=seg_type, from_lvs=from_lvs, **kwargs)
 
     def new_btrfs(self, *args, **kwargs):
         """ Return a new BTRFSVolumeDevice or BRFSSubVolumeDevice.

--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -988,7 +988,10 @@ class Blivet(object, metaclass=SynchronizedMeta):
         # we need to remove the LVs from the devicetree because they are now
         # internal LVs of the new LV
         for lv in from_lvs:
-            self.devicetree._remove_device(lv)
+            if lv in self.devicetree.devices:
+                self.devicetree._remove_device(lv)
+            else:
+                raise ValueError("All LVs to construct a new one from have to be in the devicetree")
 
         return LVMLogicalVolumeDevice(name, parents=vg, seg_type=seg_type, from_lvs=from_lvs, **kwargs)
 

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -673,6 +673,11 @@ class LVMLogicalVolumeBase(DMDevice, RaidDevice):
         return self.vg.pvs
 
     @property
+    def from_lvs(self):
+        # this needs to be read-only
+        return self._from_lvs
+
+    @property
     def is_raid_lv(self):
         seg_type = self.seg_type
         if self.seg_type == "cache":

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -629,8 +629,6 @@ class LVMLogicalVolumeBase(DMDevice, RaidDevice):
 
         self._from_lvs = from_lvs
         if self._from_lvs:
-            if any(not lv.exists for lv in self._from_lvs):
-                raise ValueError("Conversion of LVs only supported for existing LVs")
             if exists:
                 raise ValueError("Only new LVs can be created from other LVs")
             if size or maxsize or percent:
@@ -1159,13 +1157,19 @@ class LVMInternalLogicalVolumeMixin(object):
     # generally changes should be done on the parent LV (exceptions should
     # override these)
     def setup(self, orig=False):  # pylint: disable=unused-argument
-        raise errors.DeviceError("An internal LV cannot be set up separately")
+        if self._parent_lv.exists:
+            # unless this LV is yet to be used by the parent LV...
+            raise errors.DeviceError("An internal LV cannot be set up separately")
 
     def teardown(self, recursive=None):  # pylint: disable=unused-argument
-        raise errors.DeviceError("An internal LV cannot be torn down separately")
+        if self._parent_lv.exists:
+            # unless this LV is yet to be used by the parent LV...
+            raise errors.DeviceError("An internal LV cannot be torn down separately")
 
     def destroy(self):
-        raise errors.DeviceError("An internal LV cannot be destroyed separately")
+        if self._parent_lv.exists:
+            # unless this LV is yet to be used by the parent LV...
+            raise errors.DeviceError("An internal LV cannot be destroyed separately")
 
     @property
     def growable(self):
@@ -1485,6 +1489,11 @@ class LVMThinPoolMixin(object):
         if not self.exists:
             space += Size(blockdev.lvm.get_thpool_padding(space, self.vg.pe_size))
         return space
+
+    def _pre_create(self):
+        # make sure all the LVs this LV should be created from exist (if any)
+        if self._from_lvs and any(not lv.exists for lv in self._from_lvs):
+            raise errors.DeviceError("Component LVs need to be created first")
 
     def _create(self):
         """ Create the device. """

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -2037,7 +2037,9 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
 
     @type_specific
     def depends_on(self, dep):
-        return DMDevice.depends_on(self, dep)
+        # internal LVs are not in the device tree and thus not parents nor
+        # children
+        return DMDevice.depends_on(self, dep) or (dep in self._internal_lvs)
 
     @type_specific
     def read_current_size(self):

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -2061,6 +2061,12 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
         if modparent:
             self.vg._remove_log_vol(self)
 
+        if self._from_lvs:
+            for lv in self._from_lvs:
+                # changes the LV into a non-internal one
+                lv.parent_lv = None
+                lv.int_lv_type = None
+
         LVMLogicalVolumeBase.remove_hook(self, modparent=modparent)
 
     @type_specific
@@ -2071,6 +2077,9 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
 
         if self not in self.vg.lvs:
             self.vg._add_log_vol(self)
+        if self._from_lvs:
+            self._check_from_lvs()
+            self._convert_from_lvs()
 
     @type_specific
     def populate_ksdata(self, data):

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -21,7 +21,7 @@ Source0: http://github.com/rhinstaller/blivet/archive/%{realname}-%{realversion}
 %define pypartedver 3.10.4
 %define e2fsver 1.41.0
 %define utillinuxver 2.15.1
-%define libblockdevver 1.7
+%define libblockdevver 1.9
 %define libbytesizever 0.3
 %define pyudevver 0.18
 

--- a/tests/devices_test/lvm_test.py
+++ b/tests/devices_test/lvm_test.py
@@ -572,6 +572,8 @@ class BlivetNewLVMDeviceTest(unittest.TestCase):
         self.assertTrue(lv2.is_internal_lv)
         self.assertEqual(lv2.int_lv_type, LVMInternalLVtype.meta)
         self.assertEqual(lv2.size, Size("50 MiB"))
+        self.assertTrue(pool.depends_on(lv1))
+        self.assertTrue(pool.depends_on(lv2))
 
         self.assertEqual(pool.name, "testvg-pool")
         self.assertEqual(pool.size, Size("500 MiB"))

--- a/tests/devices_test/lvm_test.py
+++ b/tests/devices_test/lvm_test.py
@@ -12,6 +12,7 @@ from blivet.devices.lvm import LVMCacheRequest
 from blivet.devices.lvm import LVPVSpec, LVMInternalLVtype
 from blivet.size import Size
 from blivet.devicelibs import raid
+from blivet import errors
 
 DEVICE_CLASSES = [
     LVMLogicalVolumeDevice,
@@ -523,6 +524,70 @@ class BlivetNewLVMDeviceTest(unittest.TestCase):
         self.assertEqual(pool.metadata_size, Size("50 MiB"))
         self.assertIs(pool.vg, vg)
 
+        with patch("blivet.devices.lvm.blockdev.lvm") as lvm:
+            with patch.object(pool, "_pre_create"):
+                pool.create()
+                self.assertTrue(lvm.thpool_convert.called)
+
+    def test_new_lv_from_non_existing_lvs(self):
+        # same test as above, just with non-existing LVs used to create the new one
+        b = blivet.Blivet()
+        pv = StorageDevice("pv1", fmt=blivet.formats.get_format("lvmpv"),
+                           size=Size("1 GiB"), exists=True)
+        vg = LVMVolumeGroupDevice("testvg", parents=[pv], exists=True)
+        lv1 = LVMLogicalVolumeDevice("data_lv", parents=[vg], size=Size("500 MiB"), exists=False)
+        lv2 = LVMLogicalVolumeDevice("metadata_lv", parents=[vg], size=Size("50 MiB"), exists=False)
+
+        for dev in (pv, vg, lv1, lv2):
+            b.devicetree._add_device(dev)
+
+        # check that all the above devices are in the expected places
+        self.assertEqual(set(b.devices), {pv, vg, lv1, lv2})
+        self.assertEqual(set(b.vgs), {vg})
+        self.assertEqual(set(b.lvs), {lv1, lv2})
+        self.assertEqual(set(b.vgs[0].lvs), {lv1, lv2})
+
+        self.assertEqual(vg.size, Size("1020 MiB"))
+        self.assertEqual(lv1.size, Size("500 MiB"))
+        self.assertEqual(lv2.size, Size("50 MiB"))
+
+        # combine the two LVs into a thin pool (the LVs should become its internal LVs)
+        pool = b.new_lv_from_lvs(vg, name="pool", seg_type="thin-pool", from_lvs=(lv1, lv2))
+
+        # add the pool LV into the devicetree
+        b.devicetree._add_device(pool)
+
+        self.assertEqual(set(b.devices), {pv, vg, pool})
+        self.assertEqual(set(b.vgs), {vg})
+        self.assertEqual(set(b.lvs), {pool})
+        self.assertEqual(set(b.vgs[0].lvs), {pool})
+        self.assertEqual(set(b.vgs[0].lvs[0]._internal_lvs), {lv1, lv2})
+
+        self.assertTrue(lv1.is_internal_lv)
+        self.assertEqual(lv1.int_lv_type, LVMInternalLVtype.data)
+        self.assertEqual(lv1.size, Size("500 MiB"))
+        self.assertTrue(lv2.is_internal_lv)
+        self.assertEqual(lv2.int_lv_type, LVMInternalLVtype.meta)
+        self.assertEqual(lv2.size, Size("50 MiB"))
+
+        self.assertEqual(pool.name, "testvg-pool")
+        self.assertEqual(pool.size, Size("500 MiB"))
+        self.assertEqual(pool.metadata_size, Size("50 MiB"))
+        self.assertIs(pool.vg, vg)
+
+        # both component LVs don't exist
+        with self.assertRaises(errors.DeviceError):
+            with patch("blivet.devices.lvm.blockdev.lvm") as lvm:
+                pool.create()
+
+        # lv2 will still not exist
+        lv1.exists = True
+        with self.assertRaises(errors.DeviceError):
+            with patch("blivet.devices.lvm.blockdev.lvm") as lvm:
+                pool.create()
+
+        # both component LVs exist, should just work
+        lv2.exists = True
         with patch("blivet.devices.lvm.blockdev.lvm") as lvm:
             with patch.object(pool, "_pre_create"):
                 pool.create()

--- a/tests/devices_test/lvm_test.py
+++ b/tests/devices_test/lvm_test.py
@@ -506,6 +506,9 @@ class BlivetNewLVMDeviceTest(unittest.TestCase):
         # combine the two LVs into a thin pool (the LVs should become its internal LVs)
         pool = b.new_lv_from_lvs(vg, name="pool", seg_type="thin-pool", from_lvs=(lv1, lv2))
 
+        # add the pool LV into the devicetree
+        b.devicetree._add_device(pool)
+
         self.assertEqual(set(b.devices), {pv, vg, pool})
         self.assertEqual(set(b.vgs), {vg})
         self.assertEqual(set(b.lvs), {pool})


### PR DESCRIPTION
The first three patches are the same as in the PR #465 and may be ignored here. The next 5 patches tweak the little details we need to make actions for creating LVs from other LVs work. The last patch adds tests for the newly-supported functionality.