### PR TITLE
Fix checks when changing fslabel using actions

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -592,8 +592,6 @@ class FS(DeviceFormat):
 
             Raises a FSError if the label can not be set.
         """
-        if self.label is None:
-            raise FSError("makes no sense to write a label when accepting default label")
 
         if not self.exists:
             raise FSError("filesystem has not been created")
@@ -601,13 +599,16 @@ class FS(DeviceFormat):
         if not self._writelabel.available:
             raise FSError("no application to set label for filesystem %s" % self.type)
 
-        if not self.label_format_ok(self.label):
-            raise FSError("bad label format for labelling application %s" % self._writelabel)
-
         if not os.path.exists(self.device):
             raise FSError("device does not exist")
 
         if not dry_run:
+            if self.label is None:
+                raise FSError("makes no sense to write a label when accepting default label")
+
+            if not self.label_format_ok(self.label):
+                raise FSError("bad label format for labelling application %s" % self._writelabel)
+
             self._writelabel.do_task()
 
     @property


### PR DESCRIPTION
Found this when adding support for relabel using `ActionConfigureFormat` to blivet-gui. Checks (using `write_label` with `dry_run=True`) are done in constructor of the actions, but `self.label` is set in `apply`, so these two checks will always fail in dry run mode.