### PR TITLE
Use the new way extra information is provided for LVs

### DIFF
--- a/blivet/populator/helpers/lvm.py
+++ b/blivet/populator/helpers/lvm.py
@@ -339,7 +339,7 @@ class LVMFormatPopulator(FormatPopulator):
 
         # assign parents to internal LVs (and vice versa)
         for lv in orphan_lvs.values():
-            parent_lv = lvm.determine_parent_lv(vg_name, lv, all_lvs)
+            parent_lv = lvm.determine_parent_lv(lv, all_lvs, lv_info)
             if parent_lv:
                 lv.parent_lv = parent_lv
             else:

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -21,7 +21,7 @@ Source0: http://github.com/rhinstaller/blivet/archive/%{realname}-%{realversion}
 %define pypartedver 3.10.4
 %define e2fsver 1.41.0
 %define utillinuxver 2.15.1
-%define libblockdevver 1.4
+%define libblockdevver 1.7
 %define libbytesizever 0.3
 %define pyudevver 0.18
 


### PR DESCRIPTION
Instead of doing multiple calls to libblockdev for every LV to find out what its
potential pool, data and metadata LVs are, we can use the information from the
overall information about LVs libblockdev now provides.