### PR TITLE
Fix removing PVs after removing VG (#1358067)

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -1106,7 +1106,7 @@ class LVMInternalLogicalVolumeDevice(LVMLogicalVolumeDevice):
             raise ValueError("new size must of type Size")
 
         if not self.takes_extra_space:
-            if size <= self.parent_lv.size:
+            if size <= self.parent_lv.size:  # pylint: disable=no-member
                 self._size = size
             else:
                 raise ValueError("Internal LV cannot be bigger than its parent LV")
@@ -1120,7 +1120,7 @@ class LVMInternalLogicalVolumeDevice(LVMLogicalVolumeDevice):
         if not self.takes_extra_space:
             return self._parent_lv.maxSize()
         else:
-            return self.size + self.vg.freeSpace
+            return self.size + self.vg.freeSpace  # pylint: disable=no-member
 
     def __repr__(self):
         s = "%s:\n" % self.__class__.__name__

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -467,6 +467,23 @@ class LVMVolumeGroupDevice(ContainerDevice):
         """ Is this device directly accessible? """
         return False
 
+    def removeHook(self, modparent=True):
+        if modparent:
+            for pv in self.pvs:
+                pv.format.vgName = None
+
+        # pylint: disable=bad-super-call
+        super(LVMVolumeGroupDevice, self).removeHook(modparent=modparent)
+
+    def addHook(self, new=True):
+        # pylint: disable=bad-super-call
+        super(LVMVolumeGroupDevice, self).addHook(new=new)
+        if new:
+            return
+
+        for pv in self.pvs:
+            pv.format.vgName = self.name
+
     def populateKSData(self, data):
         super(LVMVolumeGroupDevice, self).populateKSData(data)
         data.vgname = self.name

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -493,7 +493,7 @@ class DeviceTree(object):
         lvm.lvm_cc_addFilterRejectRegexp(device.name)
 
         if isinstance(device, DASDDevice):
-            self.dasd.remove(device)
+            self.dasd.remove(device)  # pylint: disable=no-member
 
         if device.name not in self.names:
             self.names.append(device.name)
@@ -524,7 +524,7 @@ class DeviceTree(object):
                 hidden.addHook(new=False)
                 lvm.lvm_cc_removeFilterRejectRegexp(hidden.name)
                 if isinstance(device, DASDDevice):
-                    self.dasd.append(device)
+                    self.dasd.append(device)  # pylint: disable=no-member
 
     def setupDiskImages(self):
         """ Set up devices to represent the disk image files. """


### PR DESCRIPTION
Set `vgName` in lvmpv format to `None` when removing the vg, so we can remove the pv too.