### PR TITLE
Add callbacks for populate

### DIFF
--- a/blivet/callbacks.py
+++ b/blivet/callbacks.py
@@ -109,6 +109,12 @@ class Callbacks:
        instance of :class:`~.callbacks.CallbackList`.
     """
     def __init__(self):
+        self.populate_started = CallbackList()
+        """callback list for when devicetree population is started"""
+
+        self.device_scanned = CallbackList()
+        """callback list for when a device scan is completed"""
+
         self.device_added = CallbackList()
         """callback list for when a device is added to the devicetree"""
 
@@ -145,6 +151,21 @@ class Callbacks:
         .. note::
            The arguments for these callbacks are provided by name, so any callbacks
            you provide should be able to handle that.
+
+        .. function:: populate_started_cb(n_devices)
+
+           Devicetree population was started.
+
+           :param int n_devices: (expected) total number of devices to scan
+
+
+        .. function:: device_scanned_cb(device_name)
+
+           A device scan was finished (note that some devices may be scanned
+           multiple times).
+
+           :param str device_name: name of the device that was scanned
+
 
         .. function:: device_added_cb(device)
 

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -45,6 +45,7 @@ from ..storage_log import log_method_call
 from ..threads import SynchronizedMeta
 from .helpers import get_device_helper, get_format_helper
 from ..static_data import lvs_info, pvs_info, luks_data
+from ..callbacks import callbacks
 
 import logging
 log = logging.getLogger("blivet")
@@ -285,6 +286,7 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
         reason = self._reason_to_skip_device(info)
         if reason:
             log.debug("skipping %s device %s", reason, name)
+            callbacks.device_scanned(device_name=name)
             return
 
         log.info("scanning %s (%s)...", name, sysfs_path)
@@ -307,6 +309,7 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
 
         if not device:
             log.debug("no device obtained for %s", name)
+            callbacks.device_scanned(device_name=name)
             return
 
         log.info("got device: %r", device)
@@ -319,6 +322,7 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
         if device_added or update_orig_fmt:
             device.original_format = copy.deepcopy(device.format)
         device.device_links = udev.device_get_symlinks(info)
+        callbacks.device_scanned(device_name=name)
 
     def handle_format(self, info, device):
         log_method_call(self, name=getattr(device, "name", None))
@@ -496,6 +500,8 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
         self._find_live_backing_device()
 
         old_devices = {}
+        n_devices = 0
+        report = True
 
         # Now, loop and scan for devices that have appeared since the two above
         # blocks or since previous iterations.
@@ -507,11 +513,16 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
                 new_name = udev.device_get_name(new_device)
                 if new_name not in old_devices:
                     old_devices[new_name] = new_device
+                    n_devices += 1
                     devices.append(new_device)
 
             if len(devices) == 0:
                 # nothing is changing -- we are finished building devices
                 break
+
+            if report:
+                callbacks.populate_started(n_devices=n_devices)
+                report = False
 
             log.info("devices to scan: %s", [udev.device_get_name(d) for d in devices])
             for dev in devices:


### PR DESCRIPTION
It's easy for us to advertise how many devices we expect to scan and then report
each device scan completion. The user code can then show scanning progress to
users.