### PR TITLE
Default to LVM in the device factory.

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -1702,7 +1702,7 @@ class Blivet(object, metaclass=SynchronizedMeta):
 
         return fstype
 
-    def factory_device(self, device_type, size, **kwargs):
+    def factory_device(self, device_type=devicefactory.DEVICE_TYPE_LVM, size=None, **kwargs):
         """ Schedule creation of a device based on a top-down specification.
 
             :param device_type: device type constant

--- a/blivet/dbus/blivet.py
+++ b/blivet/dbus/blivet.py
@@ -225,8 +225,8 @@ class DBusBlivet(DBusObject):
                                                 "An error occured while committing the "
                                                 "changes to disk: %s" % str(e))
 
-    @dbus.service.method(dbus_interface=BLIVET_INTERFACE, in_signature='ita{sv}', out_signature='o')
-    def Factory(self, device_type, size, kwargs):
+    @dbus.service.method(dbus_interface=BLIVET_INTERFACE, in_signature='a{sv}', out_signature='o')
+    def Factory(self, kwargs):
         disks = [self._get_device_by_object_path(p) for p in kwargs.pop("disks", [])]
         kwargs["disks"] = disks
 
@@ -235,8 +235,12 @@ class DBusBlivet(DBusObject):
             device = self._get_device_by_object_path(dbus_device)
             kwargs["device"] = device
 
+        size = kwargs.pop("size", None)
+        if size is not None:
+            kwargs["size"] = Size(size)
+
         try:
-            device = self._blivet.factory_device(device_type, Size(size), **kwargs)
+            device = self._blivet.factory_device(**kwargs)
         except StorageError as e:
             raise dbus.exceptions.DBusException('%s.%s' % (BUS_NAME, e.__class__.__name__),
                                                 "An error occured while configuring the "

--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -125,7 +125,7 @@ def get_device_type(device):
     return device_type
 
 
-def get_device_factory(blivet, device_type, size, **kwargs):
+def get_device_factory(blivet, device_type=DEVICE_TYPE_LVM, size=None, **kwargs):
     """ Return a suitable DeviceFactory instance for device_type. """
     disks = kwargs.pop("disks", [])
 

--- a/tests/dbus_test.py
+++ b/tests/dbus_test.py
@@ -89,13 +89,15 @@ class DBusBlivetTestCase(TestCase):
         device_type = 1
         disks = ["/com/redhat/Blivet1/Devices/1", "/com/redhat/Blivet1/Devices/22"]
         size = 10 * 1024**3
-        kwargs = {"disks": disks,
+        kwargs = {"device_type": device_type,
+                  "size": size,
+                  "disks": disks,
                   "fstype": "xfs",
                   "name": "testdevice",
                   "raid_level": "raid0"}
         with patch("blivet.dbus.blivet.isinstance", return_value=True):
-            self.dbus_object.Factory(device_type, size, kwargs)
-        self.dbus_object._blivet.factory_device.assert_called_once_with(device_type, size, **kwargs)
+            self.dbus_object.Factory(kwargs)
+        self.dbus_object._blivet.factory_device.assert_called_once_with(**kwargs)
         self.dbus_object._blivet.reset_mock()
 
 

--- a/tests/devicefactory_test.py
+++ b/tests/devicefactory_test.py
@@ -243,6 +243,10 @@ class DeviceFactoryTestCase(unittest.TestCase):
                                sum(d.size for d in self.b.disks),
                                delta=self._get_size_delta(devices=[device]))
 
+    def test_default_factory_type(self):
+        factory = devicefactory.get_device_factory(self.b)
+        self.assertIsInstance(factory, devicefactory.LVMFactory)
+
 
 class PartitionFactoryTestCase(DeviceFactoryTestCase):
     device_class = PartitionDevice


### PR DESCRIPTION
My intention was to do this in a way that does not break existing callers who are passing type and size as positional args. I expect to follow this up on `3.0-devel` with another pull request to remove that compatibility.