### PR TITLE
Eliminate mountpoint symlinks when looking for mounted device

### DIFF
--- a/blivet/util.py
+++ b/blivet/util.py
@@ -113,6 +113,7 @@ def get_mount_paths(dev):
 
 def get_mount_device(mountpoint):
     """ Given a mountpoint, return the device node path mounted there. """
+    mountpoint = os.path.realpath(mountpoint)  # eliminate symlinks
     mounts = open("/proc/mounts").readlines()
     mount_device = None
     for mnt in mounts:


### PR DESCRIPTION
Resolves: rhbz#1322439
## 

Mountpoints in `/proc/mounts` are listed with resolved/eliminated symlinks.
