### PR TITLE
Check a device is a DASD before doing DASD-specific things. (#1353667)

### DIFF
--- a/blivet/devicelibs/dasd.py
+++ b/blivet/devicelibs/dasd.py
@@ -114,6 +114,10 @@ DASD_FORMAT_CDL = 2
 
 def is_ldl_dasd(device):
     """Determine whether or not a DASD is LDL formatted."""
+    if not device.startswith("dasd"):
+        # not a dasd; bail
+        return False
+
     device = "/dev/%s" % (device,)
 
     f = open(device, "r")


### PR DESCRIPTION
This will weed out non-DASD devices and prevent tb's occurring when we
try to check for DASD-specific attrs.

Resolves: rhbz#1353667