### PR TITLE
Ensure biosboot shows up in kickstart (#1242666)

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -1849,6 +1849,11 @@ class Blivet(object, metaclass=SynchronizedMeta):
         if self.bootloader_device is not None:
             bootloader_devices.append(self.bootloader_device)
 
+        # biosboot is a special case
+        for device in self.devices:
+            if device.format.type == 'biosboot':
+                bootloader_devices.append(device)
+
         # make a list of ancestors of all used devices
         devices = list(set(a for d in list(self.mountpoints.values()) + self.swaps + bootloader_devices
                            for a in d.ancestors))

--- a/tests/blivet_test.py
+++ b/tests/blivet_test.py
@@ -18,6 +18,7 @@ class BlivetTestCase(unittest.TestCase):
         in the kickstart data
         '''
 
+        # prepboot test case
         with patch('blivet.blivet.Blivet.bootloader_device', new_callable=PropertyMock) as mock_bootloader_device:
             with patch('blivet.blivet.Blivet.mountpoints', new_callable=PropertyMock) as mock_mountpoints:
                 # set up prepboot partition
@@ -25,15 +26,36 @@ class BlivetTestCase(unittest.TestCase):
                 bootloader_device_obj.size = Size('5 MiB')
                 bootloader_device_obj.format = formats.get_format("prepboot")
 
-                blivet_obj = Blivet()
+                prepboot_blivet_obj = Blivet()
 
                 # mountpoints must exist for update_ksdata to run
                 mock_bootloader_device.return_value = bootloader_device_obj
                 mock_mountpoints.values.return_value = []
 
                 # initialize ksdata
-                test_ksdata = returnClassForVersion()()
-                blivet_obj.ksdata = test_ksdata
-                blivet_obj.update_ksdata()
+                prepboot_ksdata = returnClassForVersion()()
+                prepboot_blivet_obj.ksdata = prepboot_ksdata
+                prepboot_blivet_obj.update_ksdata()
 
-        self.assertTrue("part prepboot" in str(blivet_obj.ksdata))
+        self.assertIn("part prepboot", str(prepboot_blivet_obj.ksdata))
+
+        # biosboot test case
+        with patch('blivet.blivet.Blivet.devices', new_callable=PropertyMock) as mock_devices:
+            with patch('blivet.blivet.Blivet.mountpoints', new_callable=PropertyMock) as mock_mountpoints:
+                # set up biosboot partition
+                biosboot_device_obj = PartitionDevice("biosboot_partition_device")
+                biosboot_device_obj.size = Size('1MiB')
+                biosboot_device_obj.format = formats.get_format("biosboot")
+
+                biosboot_blivet_obj = Blivet()
+
+                # mountpoints must exist for updateKSData to run
+                mock_devices.return_value = [biosboot_device_obj]
+                mock_mountpoints.values.return_value = []
+
+                # initialize ksdata
+                biosboot_ksdata = returnClassForVersion()()
+                biosboot_blivet_obj.ksdata = biosboot_ksdata
+                biosboot_blivet_obj.update_ksdata()
+
+        self.assertIn("part biosboot", str(biosboot_blivet_obj.ksdata))


### PR DESCRIPTION
Added support to detect the biosboot partition.

The biosboot partition, unlike other bootloaders, is not considered a stage1
device and is not mountable therefore it never actually showed up. Detection
of the biosboot partition required a special case that does not impact the
internal bootloader device properties which would have wreaked havoc
elsewhere in the codebase.

Resolves: rhbz#1242666