### PR TITLE
Device tags

### DIFF
--- a/blivet/devices/device.py
+++ b/blivet/devices/device.py
@@ -88,6 +88,7 @@ class Device(util.ObjectID, metaclass=SynchronizedMeta):
         if parents is not None and not isinstance(parents, list):
             raise ValueError("parents must be a list of Device instances")
 
+        self._tags = set()
         self.parents = parents or []
         self._children = []
 
@@ -300,6 +301,15 @@ class Device(util.ObjectID, metaclass=SynchronizedMeta):
             packages.extend(p for p in parent.packages if p not in packages)
 
         return packages
+
+    @property
+    def tags(self):
+        """ set of (str) tags describing this device. """
+        return self._tags
+
+    @tags.setter
+    def tags(self, newtags):
+        self._tags = set(newtags)
 
     def is_name_valid(self, name):  # pylint: disable=unused-argument
         """Is the device name valid for the device type?"""

--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -40,6 +40,7 @@ from ..fcoe import fcoe
 import logging
 log = logging.getLogger("blivet")
 
+from .lib import Tags
 from .storage import StorageDevice
 from .container import ContainerDevice
 from .network import NetworkStorageDevice
@@ -94,6 +95,23 @@ class DiskDevice(StorageDevice):
                                sysfs_path=sysfs_path, parents=parents,
                                serial=serial, model=model,
                                vendor=vendor, bus=bus)
+
+        try:
+            ssd = int(util.get_sysfs_attr(self.sysfs_path, "queue/rotational")) == 0
+        except TypeError:  # get_sysfs_attr returns None from all error paths
+            ssd = False
+
+        self.tags.add(Tags.local)
+        if ssd:
+            self.tags.add(Tags.ssd)
+        if bus == "usb":
+            self.tags.add(Tags.usb)
+        if self.removable:
+            self.tags.add(Tags.removable)
+
+    def _clear_local_tags(self):
+        local_tags = set([Tags.local, Tags.ssd, Tags.usb, Tags.removable])
+        self.tags = self.tags.difference(local_tags)
 
     def __repr__(self):
         s = StorageDevice.__repr__(self)
@@ -204,6 +222,7 @@ class DMRaidArrayDevice(DMDevice, ContainerDevice):
         super(DMRaidArrayDevice, self).__init__(name, fmt=fmt, size=size,
                                                 parents=parents, exists=True,
                                                 sysfs_path=sysfs_path)
+        self.tags.add(Tags.local)
 
     @property
     def devices(self):
@@ -332,6 +351,17 @@ class MultipathDevice(DMDevice):
         else:
             self.parents.append(parent)
 
+    def _add_parent(self, parent):
+        super()._add_parent(parent)
+        if Tags.remote not in self.tags and Tags.remote in parent.tags:
+            self.tags.add(Tags.remote)
+
+    def _remove_parent(self, parent):
+        super()._remove_parent(parent)
+        if Tags.remote in self.tags and Tags.remote in parent.tags and \
+           not any(p for p in self.parents if Tags.remote in p.tags and p != parent):
+            self.tags.remove(Tags.remote)
+
     def _setup(self, orig=False):
         """ Open, or set up, a device. """
         log_method_call(self, self.name, orig=orig, status=self.status,
@@ -406,6 +436,8 @@ class iScsiDiskDevice(DiskDevice, NetworkStorageDevice):
                       self.node.iface,
                       self.nic)
 
+        self._clear_local_tags()
+
     def dracut_setup_args(self):
         if self.ibft:
             return set(["iscsi_firmware"])
@@ -468,6 +500,8 @@ class FcoeDiskDevice(DiskDevice, NetworkStorageDevice):
         log.debug("created new fcoe disk %s (%s) @ %s",
                   device, self.identifier, self.nic)
 
+        self._clear_local_tags()
+
     def dracut_setup_args(self):
         dcb = True
 
@@ -513,6 +547,8 @@ class ZFCPDiskDevice(DiskDevice):
         self.wwpn = kwargs.pop("wwpn")
         self.fcp_lun = kwargs.pop("fcp_lun")
         DiskDevice.__init__(self, device, **kwargs)
+        self._clear_local_tags()
+        self.tags.add(Tags.remote)
 
     def __repr__(self):
         s = DiskDevice.__repr__(self)

--- a/blivet/devices/lib.py
+++ b/blivet/devices/lib.py
@@ -18,6 +18,7 @@
 #
 # Red Hat Author(s): David Lehman <dlehman@redhat.com>
 #
+from enum import Enum
 import os
 
 from .. import errors
@@ -25,6 +26,15 @@ from .. import udev
 from ..size import Size
 
 LINUX_SECTOR_SIZE = Size(512)
+
+
+class Tags(str, Enum):
+    """Tags that describe various classes of disk."""
+    local = 'local'
+    remote = 'remote'
+    removable = 'removable'
+    ssd = 'ssd'
+    usb = 'usb'
 
 
 def _collect_device_major_data():

--- a/blivet/devices/network.py
+++ b/blivet/devices/network.py
@@ -19,6 +19,8 @@
 # Red Hat Author(s): David Lehman <dlehman@redhat.com>
 #
 
+from .lib import Tags
+
 
 class NetworkStorageDevice(object):
 
@@ -42,3 +44,5 @@ class NetworkStorageDevice(object):
         """
         self.host_address = host_address
         self.nic = nic
+
+        self.tags.add(Tags.remote)  # pylint: disable=no-member

--- a/doc/api/devices.rst
+++ b/doc/api/devices.rst
@@ -130,6 +130,7 @@ devices
         * :attr:`~blivet.devices.storage.StorageDevice.size`
         * :attr:`~blivet.devices.storage.StorageDevice.status`
         * :attr:`~blivet.devices.storage.StorageDevice.sysfs_path`
+        * :attr:`~blivet.devices.device.Device.tags`
         * :attr:`~blivet.devices.storage.StorageDevice.target_size`
         * :meth:`~blivet.devices.storage.StorageDevice.teardown`
         * :attr:`~blivet.devices.storage.StorageDevice.uuid`

--- a/tests/devices_test/tags_test.py
+++ b/tests/devices_test/tags_test.py
@@ -1,0 +1,82 @@
+
+import unittest
+from unittest.mock import patch
+
+from blivet.devices import DiskDevice, FcoeDiskDevice, iScsiDiskDevice, MultipathDevice, StorageDevice, ZFCPDiskDevice
+from blivet.devices.lib import Tags
+from blivet.devices.device import Device
+
+
+class DeviceTagsTest(unittest.TestCase):
+    def _get_device(self, *args, **kwargs):
+        return StorageDevice(*args, **kwargs)
+
+    def test_tags(self):
+        #
+        # basic function on the tags property
+        #
+        d = Device('testdev')
+        self.assertTrue(hasattr(d, 'tags'))
+        self.assertIsInstance(d.tags, set)
+        self.assertEqual(d.tags, set())
+
+        d.tags.add('testlabel1')  # pylint: disable=no-member
+        self.assertIn('testlabel1', d.tags)
+
+        d.tags.add('testlabel2')  # pylint: disable=no-member
+        self.assertIn('testlabel2', d.tags)
+
+        d.tags.remove('testlabel1')
+        self.assertNotIn('testlabel1', d.tags)
+        self.assertIn('testlabel2', d.tags)
+
+        new_tags = ["one", "two"]
+        d.tags = new_tags
+        self.assertEqual(d.tags, set(new_tags))
+
+    def test_auto_tags(self):
+        #
+        # automatically-set tags for DiskDevice
+        #
+        with patch('blivet.devices.disk.util') as patched_util:
+            patched_util.get_sysfs_attr.return_value = None
+            d = DiskDevice('test1')
+            self.assertIn(Tags.local, d.tags)
+            self.assertNotIn(Tags.ssd, d.tags)
+            self.assertNotIn(Tags.usb, d.tags)
+
+            patched_util.get_sysfs_attr.return_value = '1'
+            d = DiskDevice('test2')
+            self.assertIn(Tags.local, d.tags)
+            self.assertNotIn(Tags.ssd, d.tags)
+
+            patched_util.get_sysfs_attr.return_value = '0'
+            d = DiskDevice('test2')
+            self.assertIn(Tags.local, d.tags)
+            self.assertIn(Tags.ssd, d.tags)
+
+        self.assertNotIn(Tags.usb, DiskDevice('test3').tags)
+        self.assertIn(Tags.usb, DiskDevice('test4', bus='usb').tags)
+
+        #
+        # automatically-set tags for networked storage devices
+        #
+        iscsi_kwarg_names = ["initiator", "nic", "node", "ibft", "fw_name", "fw_address", "fw_port"]
+        iscsi_device = iScsiDiskDevice('test5', **dict((k, None) for k in iscsi_kwarg_names))
+        self.assertIn(Tags.remote, iscsi_device.tags)
+        self.assertNotIn(Tags.local, iscsi_device.tags)
+        fcoe_device = FcoeDiskDevice('test6', nic=None, identifier=None)
+        self.assertIn(Tags.remote, fcoe_device.tags)
+        self.assertNotIn(Tags.local, fcoe_device.tags)
+        zfcp_device = ZFCPDiskDevice('test7', hba_id=None, wwpn=None, fcp_lun=None)
+        self.assertIn(Tags.remote, zfcp_device.tags)
+        self.assertNotIn(Tags.local, zfcp_device.tags)
+
+        multipath_device = MultipathDevice('test8', parents=[iscsi_device])
+        self.assertIn(Tags.remote, multipath_device.tags)
+        self.assertNotIn(Tags.local, multipath_device.tags)
+
+        #
+        # built-in tags should also be accessible as str
+        #
+        self.assertIn("remote", multipath_device.tags)

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -696,9 +696,9 @@ class MultipathDevicePopulatorTestCase(PopulatorHelperTestCase):
 
         device_name = "mpathtest"
         device_get_name.return_value = device_name
-        slave_1 = Mock()
+        slave_1 = Mock(tags=set())
         slave_1.parents = []
-        slave_2 = Mock()
+        slave_2 = Mock(tags=set())
         slave_2.parents = []
         devicetree._add_device(slave_1)
         devicetree._add_device(slave_2)


### PR DESCRIPTION
_I'm trying to sort out what the set of tags should be, so:
1. the set of tags is still in flux
2. the code doesn't currently match what I've written below_


Add a read/write property to `Device` containing a `set` of string tags. The primary use-case is disk selection, where users want to control which disks are used for various purposes. Ultimately, this could be exposed through `pykickstart` to add more powerful disk selection. The initial set of tags, which will be set automatically in the `Device` classes, is:

- local
    - rotational
    - removable
- remote
    - multipath

I had initially included basic device type tags, eg: `lvm`, `iscsi`, but I don't really see a use-case for them. Does anyone have use-cases in mind?

I am undecided on several questions:
1. should every tag have an inverse? (eg: local/remote, ssd/rotational)
2. what about `raid`? (I don't know if we can even reliably determine this aside from easy cases like dmraid)