### PR TITLE
Make sure a logical volume is active before formatting it

### DIFF
--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -573,6 +573,7 @@ class ActionCreateFormat(DeviceAction):
                                 get_current_entropy(), min_required_entropy)
                     self.device.format.min_luks_entropy = 0
 
+        self.device.setup()
         self.device.format.create(device=self.device.path,
                                   options=self.device.formatArgs)
 


### PR DESCRIPTION
This is fixed in 1.x+ but 0.x still fails while formatting a deactivated logical volume.