### PR TITLE
UUID now set correctly when reformatting partition

### DIFF
--- a/blivet/actionlist.py
+++ b/blivet/actionlist.py
@@ -227,7 +227,10 @@ class ActionList(object, metaclass=SynchronizedMeta):
         fixup_devices = devices + [a.device for a in self._actions
                                    if a.is_destroy and a.is_device]
         for device in fixup_devices:
-            device.pre_commit_fixup()
+            if isinstance(device, PartitionDevice) and not self.find(device=device, object_type="device"):
+                device.pre_commit_fixup(current_fmt=True)
+            else:
+                device.pre_commit_fixup()
 
         # setup actions to create any extended partitions we added
         #

--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -689,6 +689,9 @@ class ActionDestroyFormat(DeviceAction):
 
     def execute(self, callbacks=None):
         """ wipe the filesystem signature from the device """
+        # remove any flag if set
+        if self.format.parted_flag:
+            self.device.unset_flag(self.format.parted_flag)
         super(ActionDestroyFormat, self).execute(callbacks=callbacks)
         status = self.device.status
         self.device.setup(orig=True)

--- a/blivet/devices/md.py
+++ b/blivet/devices/md.py
@@ -481,7 +481,7 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
 
         self._post_teardown(recursive=recursive)
 
-    def pre_commit_fixup(self):
+    def pre_commit_fixup(self, current_fmt=False):
         """ Determine create parameters for this set """
         log_method_call(self, self.name)
         # UEFI firmware/bootloader cannot read 1.1 or 1.2 metadata arrays

--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -358,7 +358,7 @@ class PartitionDevice(StorageDevice):
     parted_partition = property(lambda d: d._get_parted_partition(),
                                 lambda d, p: d._set_parted_partition(p))
 
-    def pre_commit_fixup(self):
+    def pre_commit_fixup(self, current_fmt=False):
         """ Re-get self.parted_partition from the original disklabel. """
         log_method_call(self, self.name)
         if not self.exists or not self.disklabel_supported:
@@ -366,7 +366,10 @@ class PartitionDevice(StorageDevice):
 
         # find the correct partition on the original parted.Disk since the
         # name/number we're now using may no longer match
-        _disklabel = self.disk.original_format
+        if not current_fmt:
+            _disklabel = self.disk.original_format
+        else:
+            _disklabel = self.disk.format
 
         if self.is_extended:
             # getPartitionBySector doesn't work on extended partitions

--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -751,7 +751,7 @@ class StorageDevice(Device):
                       lambda d, f: d._set_format(f),
                       doc="The device's formatting.")
 
-    def pre_commit_fixup(self):
+    def pre_commit_fixup(self, current_fmt=False):
         """ Do any necessary pre-commit fixups."""
         pass
 


### PR DESCRIPTION
When repurposing a partition, partition type UUID is now set correctly (#1258167)