### PR TITLE
Use None as mountpoint for new snapshots

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -1307,7 +1307,7 @@ class LVMSnapshotMixin(object):
         fmt = copy.deepcopy(self.origin.format)
         fmt.exists = False
         if hasattr(fmt, "mountpoint"):
-            fmt.mountpoint = ""
+            fmt.mountpoint = None
             fmt._chrooted_mountpoint = None
             fmt.device = self.path
 


### PR DESCRIPTION
Default value for mountpoint is always None not an empty string.