### PR TITLE
Do not try to create format for snapshots in create_device

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -812,7 +812,10 @@ class Blivet(object, metaclass=SynchronizedMeta):
             :rtype: None
         """
         self.devicetree.actions.add(ActionCreateDevice(device))
-        if device.format.type and not device.format_immutable:
+
+        is_snapshot = isinstance(device, LVMLogicalVolumeDevice) and device.is_snapshot_lv
+
+        if device.format.type and not device.format_immutable and not is_snapshot:
             self.devicetree.actions.add(ActionCreateFormat(device))
 
     def destroy_device(self, device):


### PR DESCRIPTION
For snapshots, format already exists after creating the snapshot.