### PR TITLE
Disk tags as disk spec for new partitions

### DIFF
--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -70,7 +70,7 @@ class PartitionDevice(StorageDevice):
                  size=None, grow=False, maxsize=None, start=None, end=None,
                  major=None, minor=None, bootable=None,
                  sysfs_path='', parents=None, exists=False,
-                 part_type=None, primary=False, weight=0):
+                 part_type=None, primary=False, weight=0, disk_tags=None):
         """
             :param name: the device name (generally a device node's basename)
             :type name: str
@@ -110,13 +110,27 @@ class PartitionDevice(StorageDevice):
             :type bootable: bool
             :keyword weight: an initial sorting weight to assign
             :type weight: int
+            :keyword disk_tags: (str) tags defining candidate disk set
+            :type disk_tags: iterable
 
             .. note::
 
                 If a start sector is specified the partition will not be
                 adjusted for optimal alignment. That is up to the caller.
+
+            .. note::
+
+                You can only pass one of parents or disk_tags when instantiating
+                a non-existent partition. If both disk set and disk tags are
+                specified, the explicit disk set will be used.
+
+            .. note::
+
+                Multiple disk tags will be combined using the logical "or" operation.
+
         """
         self.req_disks = []
+        self.req_disk_tags = []
         self.req_part_type = None
         self.req_primary = None
         self.req_grow = None
@@ -187,6 +201,7 @@ class PartitionDevice(StorageDevice):
             # XXX It might be worthwhile to create a shit-simple
             #     PartitionRequest class and pass one to this constructor
             #     for new partitions.
+            self.req_disk_tags = list(disk_tags) if disk_tags is not None else list()
             self.req_name = name
             self.req_part_type = part_type
             self.req_primary = primary

--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -626,6 +626,20 @@ def align_size_for_disklabel(size, disklabel):
     return (grains * grain_size) + (grain_size if rem else Size(0))
 
 
+def resolve_disk_tags(disks, tags):
+    """Resolve disk tags to a disk list.
+
+        :param disks: available disks
+        :type disks: list of :class:`~.devices.StorageDevice`
+        :param tags: tags to select disks based on
+        :type tags: list of str
+
+        If tags contains multiple values it is interpeted as
+        "include disks containing *any* of these tags".
+    """
+    return [disk for disk in disks if any(tag in disk.tags for tag in tags)]
+
+
 def allocate_partitions(storage, disks, partitions, freespace):
     """ Allocate partitions based on requested features.
 
@@ -677,6 +691,8 @@ def allocate_partitions(storage, disks, partitions, freespace):
         if _part.req_disks:
             # use the requested disk set
             req_disks = _part.req_disks
+        elif _part.req_disk_tags:
+            req_disks = resolve_disk_tags(disks, _part.req_disk_tags)
         else:
             # no disks specified means any disk will do
             req_disks = disks

--- a/tests/partitioning_test.py
+++ b/tests/partitioning_test.py
@@ -9,6 +9,7 @@ from blivet.partitioning import get_next_partition_type
 from blivet.partitioning import do_partitioning
 from blivet.partitioning import allocate_partitions
 from blivet.partitioning import get_free_regions
+from blivet.partitioning import resolve_disk_tags
 from blivet.partitioning import Request
 from blivet.partitioning import Chunk
 from blivet.partitioning import LVRequest
@@ -19,6 +20,7 @@ from blivet.partitioning import PartitionRequest
 from blivet.devices import StorageDevice
 from blivet.devices import LVMVolumeGroupDevice
 from blivet.devices import LVMLogicalVolumeDevice
+from blivet.devices import DiskDevice
 from blivet.devices import DiskFile
 from blivet.devices import PartitionDevice
 from blivet.devices.lvm import LVMCacheRequest
@@ -722,3 +724,17 @@ class ExtendedPartitionTestCase(ImageBackedTestCase):
                          "user-specified extended partition was removed")
 
         self.blivet.do_it()
+
+
+class DiskTagsTestCase(unittest.TestCase):
+    def test_disk_tags(self):
+        disks = []
+        for i in range(3):
+            disk = DiskDevice("disk%d" % i)
+            disk.tags.add(str(i))
+            disks.append(disk)
+
+        self.assertEqual(resolve_disk_tags(disks, ["1"]), [disks[1]])
+        self.assertEqual(resolve_disk_tags(disks, ["0", "2"]), [disks[0], disks[2]])
+        self.assertEqual(resolve_disk_tags(disks, ["local"]), disks)
+        self.assertEqual(resolve_disk_tags(disks, ["canteloupe"]), [])


### PR DESCRIPTION
This builds on #485 by doing two things:

1. add a constructor argument to `PartitionDevice` to allow passing tags as disk set specification
2. add handling in `partitioning.allocate_partitions` to resolve the tags to a disk set at partition allocation time