### PR TITLE
Revert unsupported clearing of parted partition 'system'.

### DIFF
--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -693,8 +693,6 @@ class ActionDestroyFormat(DeviceAction):
         if isinstance(self.device, PartitionDevice) and self.device.disklabel_supported:
             if self.format.parted_flag:
                 self.device.unset_flag(self.format.parted_flag)
-            if self.format.parted_system is not None:
-                self.device.parted_partition.system = None
             self.device.disk.format.commit_to_disk()
         super(ActionDestroyFormat, self).execute(callbacks=callbacks)
         status = self.device.status


### PR DESCRIPTION
It appears that libparted does not provide any way to clear the `system` attribute of a partition, so don't try to.