### PR TITLE
Remove several redundant recursive teardown calls.

### DIFF
--- a/blivet/osinstall.py
+++ b/blivet/osinstall.py
@@ -250,7 +250,7 @@ def _find_existing_installations(devicetree):
 
         if not os.access(get_sysroot() + "/etc/fstab", os.R_OK):
             util.umount(mountpoint=get_sysroot())
-            device.teardown(recursive=True)
+            device.teardown()
             continue
 
         try:

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -418,6 +418,9 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
 
     def teardown_disk_images(self):
         """ Tear down any disk image stacks. """
+        if not self.disk_images:
+            return
+
         self.teardown_all()
         for (name, _path) in self.disk_images.items():
             dm_device = self.get_device_by_name(name)
@@ -454,9 +457,6 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
         finally:
             parted.clear_exn_handler()
             self._hide_ignored_disks()
-
-        if flags.installer_mode:
-            self.teardown_all()
 
     def _resolve_protected_device_specs(self):
         # resolve the protected device specs to device names


### PR DESCRIPTION
The most important one is definitely the one in `_find_existing_installations`, since it can trigger full setup and recursive teardown for each lv in vgs with an md pv.

The only one of these that I think may not be completely redundant is the one at the end of `PopulatorMixin.populate`, since anaconda runs that method directly (as opposed to using `Blivet.reset`) after adding network storage through the GUI. For that one, we could either leave it as-is or we could add an explicit `teardown_all` in anaconda after the `populate` call.
