### PR TITLE
DeviceFactory constructor argument cleanup

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -1219,20 +1219,18 @@ class Blivet(object, metaclass=SynchronizedMeta):
 
         return fstype
 
-    def factory_device(self, device_type=devicefactory.DEVICE_TYPE_LVM, size=None, **kwargs):
+    def factory_device(self, device_type=devicefactory.DEVICE_TYPE_LVM, **kwargs):
         """ Schedule creation of a device based on a top-down specification.
 
             :param device_type: device type constant
             :type device_type: int (:const:`~.devicefactory.DEVICE_TYPE_*`)
-            :param size: requested size
-            :type size: :class:`~.size.Size`
             :returns: the newly configured device
             :rtype: :class:`~.devices.StorageDevice`
 
             See :class:`~.devicefactory.DeviceFactory` for possible kwargs.
 
         """
-        log_method_call(self, device_type, size, **kwargs)
+        log_method_call(self, device_type, **kwargs)
 
         # we can't do anything with existing devices
         # if device and device.exists:
@@ -1248,8 +1246,7 @@ class Blivet(object, metaclass=SynchronizedMeta):
            device_type == devicefactory.DEVICE_TYPE_BTRFS:
             device_type = devicefactory.DEVICE_TYPE_PARTITION
 
-        factory = devicefactory.get_device_factory(self, device_type, size,
-                                                   **kwargs)
+        factory = devicefactory.get_device_factory(self, device_type=device_type, **kwargs)
 
         if not factory.disks:
             raise StorageError("no disks specified for new device")

--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -125,10 +125,8 @@ def get_device_type(device):
     return device_type
 
 
-def get_device_factory(blivet, device_type=DEVICE_TYPE_LVM, size=None, **kwargs):
+def get_device_factory(blivet, device_type=DEVICE_TYPE_LVM, **kwargs):
     """ Return a suitable DeviceFactory instance for device_type. """
-    disks = kwargs.pop("disks", [])
-
     class_table = {DEVICE_TYPE_LVM: LVMFactory,
                    DEVICE_TYPE_BTRFS: BTRFSFactory,
                    DEVICE_TYPE_PARTITION: PartitionFactory,
@@ -137,9 +135,9 @@ def get_device_factory(blivet, device_type=DEVICE_TYPE_LVM, size=None, **kwargs)
                    DEVICE_TYPE_DISK: DeviceFactory}
 
     factory_class = class_table[device_type]
-    log.debug("instantiating %s: %s, %s, %s, %s", factory_class,
-              blivet, size, [d.name for d in disks], kwargs)
-    return factory_class(blivet, size, disks, **kwargs)
+    log.debug("instantiating %s: %s, %s, %s", factory_class,
+              blivet, [d.name for d in kwargs.get("disks", [])], kwargs)
+    return factory_class(blivet, **kwargs)
 
 
 class DeviceFactory(object):
@@ -250,18 +248,27 @@ class DeviceFactory(object):
     child_factory_class = None
     child_factory_fstype = None
     size_set_class = TotalSizeSet
+    _default_settings = {"size": None,  # the requested size for this device
+                         "disks": [],  # the set of disks to allocate from
+                         "mountpoint": None,
+                         "label": None,
+                         "device_name": None,
+                         "raid_level": None,
+                         "encrypted": None,
+                         "container": None,
+                         "device": None,
+                         "container_name": None,
+                         "container_size": SIZE_POLICY_AUTO,
+                         "container_raid_level": None,
+                         "container_encrypted": None}
 
-    def __init__(self, storage, size, disks, fstype=None, mountpoint=None,
-                 label=None, raid_level=None, encrypted=False,
-                 container_encrypted=False, container_name=None,
-                 container_raid_level=None, container_size=SIZE_POLICY_AUTO,
-                 name=None, device=None, min_luks_entropy=None):
+    def __init__(self, storage, **kwargs):
         """
             :param storage: a Blivet instance
             :type storage: :class:`~.Blivet`
-            :param size: the desired size for the device
+            :keyword size: the desired size for the device
             :type size: :class:`~.size.Size`
-            :param disks: the set of disks to use
+            :keyword disks: the set of disks to use
             :type disks: list of :class:`~.devices.StorageDevice`
 
             :keyword fstype: filesystem type
@@ -294,49 +301,46 @@ class DeviceFactory(object):
             :keyword container_encrypted: whether to encrypt the container
             :type container_encrypted: bool
             :keyword container_size: requested container size
-            :type container_size: :class:`~.size.Size`
+            :type container_size: :class:`~.size.Size`, :const:`SIZE_POLICY_AUTO` (the default),
+                                  or :const:`SIZE_POLICY_MAX`
             :keyword min_luks_entropy: minimum entropy in bits required for
                                        LUKS format creation
             :type min_luks_entropy: int
 
         """
-        self.storage = storage          # a Blivet instance
-        self.size = size                # the requested size for this device
-        self.disks = disks              # the set of disks to allocate from
+        self.storage = storage  # a Blivet instance
 
-        self.original_size = size
-        self.original_disks = disks[:]
+        self._encrypted = None
+        self._raid_level = None
+        self._container_raid_level = None
 
-        self.fstype = fstype
-        self.mountpoint = mountpoint
-        self.label = label
+        # Apply defaults.
+        for setting, value in self._default_settings.items():
+            setattr(self, setting, value)
 
-        self.raid_level = raid_level
-        self.container_raid_level = container_raid_level
+        self.fstype = None  # not included in default_settings b/c of special handling below
+        self.min_luks_entropy = luks_data.min_entropy
 
-        self.encrypted = encrypted
-        self.container_encrypted = container_encrypted
+        self.device = kwargs.get("device")
 
-        self.container_name = container_name
-        self.device_name = name
+        # Map kwarg 'name' to attribute 'device_name'.
+        if "name" in kwargs:
+            kwargs["device_name"] = kwargs.pop("name")
 
-        self.container_size = container_size
+        # Now override defaults with values passed via kwargs.
+        for setting, value in kwargs.items():
+            setattr(self, setting, value)
 
-        self.container = None
-        self.device = device
+        self.original_size = self.size
+        self.original_disks = self.disks[:]
 
         if not self.fstype:
             self.fstype = self.storage.get_fstype(mountpoint=self.mountpoint)
-            if fstype == "swap":
+            if self.fstype == "swap":
                 self.mountpoint = None
 
         self.child_factory = None
         self.parent_factory = None
-
-        if min_luks_entropy is None:
-            self.min_luks_entropy = luks_data.min_entropy
-        else:
-            self.min_luks_entropy = min_luks_entropy
 
         # used for error recovery
         self.__devices = []
@@ -415,20 +419,20 @@ class DeviceFactory(object):
         if self.size != size:
             log.debug("adjusted size from %s to %s to honor format limits",
                       self.size, size)
-            self.size = size
+            self.size = size  # pylint: disable=attribute-defined-outside-init
 
     def _handle_no_size(self):
         """ Set device size so that it grows to the largest size possible. """
         if self.size is not None:
             return
 
-        self.size = self._get_free_disk_space()
+        self.size = self._get_free_disk_space()  # pylint: disable=attribute-defined-outside-init
 
         if self.device:
             self.size += self.device.size
 
         if self.container_size > 0:
-            self.size = min(self.container_size, self.size)
+            self.size = min(self.container_size, self.size)  # pylint: disable=attribute-defined-outside-init
 
     def _get_total_space(self):
         """ Return the total space need for this factory's device/container.
@@ -545,12 +549,14 @@ class DeviceFactory(object):
 
     def _set_container(self):
         """ Set this factory's container device. """
+        # pylint: disable=attribute-defined-outside-init
         self.container = self.get_container(device=self.raw_device,
                                             name=self.container_name)
 
     def _create_container(self):
         """ Create the container device required by this factory device. """
         parents = self._get_parent_devices()
+        # pylint: disable=attribute-defined-outside-init
         self.container = self._get_new_container(name=self.container_name,
                                                  parents=parents)
         self.storage.create_device(self.container)
@@ -773,6 +779,7 @@ class DeviceFactory(object):
 
     def _set_name(self):
         if not self.device_name:
+            # pylint: disable=attribute-defined-outside-init
             self.device_name = self.storage.suggest_device_name(
                 parent=self.container,
                 swap=(self.fstype == "swap"),
@@ -794,10 +801,13 @@ class DeviceFactory(object):
         pass
 
     def _get_child_factory_args(self):
-        return [self.storage, self._get_total_space(), self.disks]
+        return []
 
     def _get_child_factory_kwargs(self):
-        return {"fstype": self.child_factory_fstype}
+        return {"storage": self.storage,
+                "size": self._get_total_space(),
+                "disks": self.disks,
+                "fstype": self.child_factory_fstype}
 
     def _set_up_child_factory(self):
         if self.child_factory or not self.child_factory_class or \
@@ -846,7 +856,7 @@ class DeviceFactory(object):
     def _configure(self):
         self._set_container()
         if self.container and self.container.exists:
-            self.disks = self.container.disks
+            self.disks = self.container.disks  # pylint: disable=attribute-defined-outside-init
 
         self._normalize_size()
         self._set_up_child_factory()
@@ -983,8 +993,7 @@ class PartitionSetFactory(PartitionFactory):
 
     """ Factory for creating a set of related partitions. """
 
-    def __init__(self, storage, size, disks, fstype=None, encrypted=False,
-                 devices=None):
+    def __init__(self, storage, **kwargs):
         """ Create a new DeviceFactory instance.
 
             Arguments:
@@ -1000,12 +1009,8 @@ class PartitionSetFactory(PartitionFactory):
 
                 devices             an initial set of devices
         """
-        super(PartitionSetFactory, self).__init__(storage, size, disks,
-                                                  fstype=fstype,
-                                                  encrypted=encrypted)
-        self._devices = []
-        if devices:
-            self._devices = devices
+        self._devices = kwargs.pop("devices", None) or []
+        super(PartitionSetFactory, self).__init__(storage, **kwargs)
 
     @property
     def devices(self):
@@ -1195,8 +1200,8 @@ class LVMFactory(DeviceFactory):
     child_factory_fstype = "lvmpv"
     size_set_class = TotalSizeSet
 
-    def __init__(self, *args, **kwargs):
-        super(LVMFactory, self).__init__(*args, **kwargs)
+    def __init__(self, storage, **kwargs):
+        super(LVMFactory, self).__init__(storage, **kwargs)
         if self.container_raid_level:
             self.child_factory_class = MDFactory
 
@@ -1210,7 +1215,7 @@ class LVMFactory(DeviceFactory):
 
         if self.container and (self.container.exists or
                                self.container_size != SIZE_POLICY_AUTO):
-            self.size = self.container.free_space
+            self.size = self.container.free_space  # pylint: disable=attribute-defined-outside-init
 
             if self.container_size == SIZE_POLICY_MAX:
                 self.size += self._get_free_disk_space()
@@ -1343,6 +1348,7 @@ class LVMFactory(DeviceFactory):
 
     def _set_name(self):
         if not self.device_name:
+            #  pylint: disable=attribute-defined-outside-init
             self.device_name = self.storage.suggest_device_name(
                 parent=self.container,
                 swap=(self.fstype == "swap"),
@@ -1435,10 +1441,10 @@ class LVMThinPFactory(LVMFactory):
               pool management must not be hidden in device management routines
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, storage, **kwargs):
         # pool name is for identification -- not renaming
         self.pool_name = kwargs.pop("pool_name", None)
-        super(LVMThinPFactory, self).__init__(*args, **kwargs)
+        super(LVMThinPFactory, self).__init__(storage, **kwargs)
 
         self.pool = None
 
@@ -1650,8 +1656,8 @@ class MDFactory(DeviceFactory):
     child_factory_fstype = "mdmember"
     size_set_class = SameSizeSet
 
-    def __init__(self, storage, size, disks, **kwargs):
-        super(MDFactory, self).__init__(storage, size, disks, **kwargs)
+    def __init__(self, storage, **kwargs):
+        super(MDFactory, self).__init__(storage, **kwargs)
         if not self.raid_level:
             raise DeviceFactoryError("MDFactory class must have some RAID level.")
 
@@ -1694,8 +1700,8 @@ class BTRFSFactory(DeviceFactory):
     child_factory_class = PartitionSetFactory
     child_factory_fstype = "btrfs"
 
-    def __init__(self, storage, size, disks, **kwargs):
-        super(BTRFSFactory, self).__init__(storage, size, disks, **kwargs)
+    def __init__(self, storage, **kwargs):
+        super(BTRFSFactory, self).__init__(storage, **kwargs)
 
         if self.encrypted:
             log.info("overriding encryption setting for btrfs factory")
@@ -1711,7 +1717,7 @@ class BTRFSFactory(DeviceFactory):
         """ Set device size so that it grows to the largest size possible. """
         super(BTRFSFactory, self)._handle_no_size()
         if self.container and self.container.exists:
-            self.size = self.container.size
+            self.size = self.container.size  # pylint: disable=attribute-defined-outside-init
 
     def _get_total_space(self):
         """ Return the total space needed for the specified container. """
@@ -1758,6 +1764,7 @@ class BTRFSFactory(DeviceFactory):
     def _create_container(self):
         """ Create the container device required by this factory device. """
         parents = self._get_parent_devices()
+        # pylint: disable=attribute-defined-outside-init
         self.container = self._get_new_container(name=self.container_name,
                                                  data_level=self.container_raid_level,
                                                  parents=parents)

--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -300,11 +300,6 @@ class DeviceFactory(object):
             :type min_luks_entropy: int
 
         """
-
-        if encrypted and size:
-            # encrypted, bump size up with LUKS metadata size
-            size += get_format("luks").min_size
-
         self.storage = storage          # a Blivet instance
         self.size = size                # the requested size for this device
         self.disks = disks              # the set of disks to allocate from
@@ -348,6 +343,20 @@ class DeviceFactory(object):
         self.__actions = []
         self.__names = []
         self.__roots = []
+
+    @property
+    def encrypted(self):
+        return self._encrypted
+
+    @encrypted.setter
+    def encrypted(self, value):
+        if not self.encrypted and value and self.size:
+            # encrypted, bump size up with LUKS metadata size
+            self.size += get_format("luks").min_size
+        elif self.encrypted and not value and self.size:
+            self.size -= get_format("luks").min_size
+
+        self._encrypted = value
 
     @property
     def raid_level(self):

--- a/tests/devicefactory_test.py
+++ b/tests/devicefactory_test.py
@@ -73,7 +73,6 @@ class DeviceFactoryTestCase(unittest.TestCase):
         """ Validate the factory device against the factory args. """
         device = args[0]
         device_type = args[1]
-        size = args[2]
 
         if kwargs.get("encrypted"):
             device_class = LUKSDevice
@@ -92,7 +91,7 @@ class DeviceFactoryTestCase(unittest.TestCase):
             self.assertEqual(device.format.label,
                              kwargs.get('label'))
 
-        self.assertLessEqual(device.size, size)
+        self.assertLessEqual(device.size, kwargs.get("size"))
         self.assertGreaterEqual(device.size, device.format.min_size)
         if device.format.max_size:
             self.assertLessEqual(device.size, device.format.max_size)
@@ -105,19 +104,19 @@ class DeviceFactoryTestCase(unittest.TestCase):
 
     def test_device_factory(self):
         device_type = self.device_type
-        size = Size('400 MiB')
         kwargs = {"disks": self.b.disks,
+                  "size": Size("400 MiB"),
                   "fstype": 'ext4',
                   "mountpoint": '/factorytest'}
-        device = self._factory_device(device_type, size, **kwargs)
-        self._validate_factory_device(device, device_type, size, **kwargs)
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
         self.b.recursive_remove(device)
 
         if self.encryption_supported:
             # Encrypt the leaf device
             kwargs["encrypted"] = True
-            device = self._factory_device(device_type, size, **kwargs)
-            self._validate_factory_device(device, device_type, size, **kwargs)
+            device = self._factory_device(device_type, **kwargs)
+            self._validate_factory_device(device, device_type, **kwargs)
             for partition in self.b.partitions:
                 self.b.recursive_remove(partition)
 
@@ -126,32 +125,32 @@ class DeviceFactoryTestCase(unittest.TestCase):
         ##
 
         # Create a basic stack
-        size = Size('800 MiB')
         kwargs = {"disks": self.b.disks,
+                  "size": Size('800 MiB'),
                   "fstype": 'ext4',
                   "mountpoint": '/factorytest'}
-        device = self._factory_device(device_type, size, **kwargs)
-        self._validate_factory_device(device, device_type, size, **kwargs)
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
 
         if self.encryption_supported:
             # Encrypt the leaf device
             kwargs["encrypted"] = True
             kwargs["device"] = device
-            device = self._factory_device(device_type, size, **kwargs)
-            self._validate_factory_device(device, device_type, size, **kwargs)
+            device = self._factory_device(device_type, **kwargs)
+            self._validate_factory_device(device, device_type, **kwargs)
 
         # Change the mountpoint
         kwargs["mountpoint"] = "/a/different/dir"
         kwargs["device"] = device
-        device = self._factory_device(device_type, size, **kwargs)
-        self._validate_factory_device(device, device_type, size, **kwargs)
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
 
         # Change the fstype and size.
         kwargs["fstype"] = "xfs"
         kwargs["device"] = device
-        size = Size("650 MiB")
-        device = self._factory_device(device_type, size, **kwargs)
-        self._validate_factory_device(device, device_type, size, **kwargs)
+        kwargs["size"] = Size("650 MiB")
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
 
     def _get_test_factory_args(self):
         """ Return kwarg dict of type-specific factory ctor args. """
@@ -169,10 +168,9 @@ class DeviceFactoryTestCase(unittest.TestCase):
     def test_get_free_disk_space(self):
         # get_free_disk_space should return the total free space on disks
         kwargs = self._get_test_factory_args()
-        size = Size("500 MiB")
+        kwargs["size"] = Size("500 MiB")
         factory = devicefactory.get_device_factory(self.b,
                                                    self.device_type,
-                                                   size,
                                                    disks=self.b.disks,
                                                    **kwargs)
         # disks contain empty disklabels, so free space is sum of disk sizes
@@ -186,7 +184,6 @@ class DeviceFactoryTestCase(unittest.TestCase):
         device_space = factory._get_device_space()
         factory = devicefactory.get_device_factory(self.b,
                                                    self.device_type,
-                                                   size,
                                                    disks=self.b.disks,
                                                    **kwargs)
         # disks contain a 500 MiB device, which includes varying amounts of
@@ -204,9 +201,9 @@ class DeviceFactoryTestCase(unittest.TestCase):
         self.assertTrue(size > ext2.max_size)
 
         kwargs = self._get_test_factory_args()
+        kwargs["size"] = size
         factory = devicefactory.get_device_factory(self.b,
                                                    self.device_type,
-                                                   size,
                                                    disks=self.b.disks,
                                                    fstype=fstype,
                                                    **kwargs)
@@ -227,10 +224,10 @@ class DeviceFactoryTestCase(unittest.TestCase):
         # device, in case the factory is to be modifying a defined device
         # must be a couple MiB smaller than the disk to accommodate
         # PartitionFactory
-        size = self.b.disks[0].size - Size("4 MiB")
-        device = self._factory_device(self.device_type, size,
+        kwargs["size"] = self.b.disks[0].size - Size("4 MiB")
+        device = self._factory_device(self.device_type,
                                       disks=self.b.disks, **kwargs)
-        self.assertAlmostEqual(device.size, size, delta=self._get_size_delta())
+        self.assertAlmostEqual(device.size, kwargs["size"], delta=self._get_size_delta())
 
         factory.size = None
         factory.device = device
@@ -247,6 +244,15 @@ class DeviceFactoryTestCase(unittest.TestCase):
         factory = devicefactory.get_device_factory(self.b)
         self.assertIsInstance(factory, devicefactory.LVMFactory)
 
+    def test_factory_defaults(self):
+        ctor_kwargs = self._get_test_factory_args()
+        factory = devicefactory.get_device_factory(self.b, self.device_type, **ctor_kwargs)
+        for setting, value in factory._default_settings.items():
+            if setting not in ctor_kwargs:
+                self.assertEqual(getattr(factory, setting), value)
+
+        self.assertEqual(factory.fstype, self.b.get_fstype())
+
 
 class PartitionFactoryTestCase(DeviceFactoryTestCase):
     device_class = PartitionDevice
@@ -256,17 +262,17 @@ class PartitionFactoryTestCase(DeviceFactoryTestCase):
         # Test a change of format and size where old size is too large for the
         # new format but not for the old one.
         device_type = self.device_type
-        size = Size('400 MiB')
         kwargs = {"disks": self.b.disks,
+                  "size": Size('400 MiB'),
                   "fstype": 'ext4',
                   "mountpoint": '/factorytest'}
-        device = self._factory_device(device_type, size, **kwargs)
-        self._validate_factory_device(device, device_type, size, **kwargs)
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
 
         kwargs["device"] = device
         kwargs["fstype"] = "prepboot"
-        device = self._factory_device(device_type, size, **kwargs)
-        self._validate_factory_device(device, device_type, size, **kwargs)
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
 
     def _get_size_delta(self, devices=None):
         delta = Size("2 MiB")
@@ -311,8 +317,8 @@ class LVMFactoryTestCase(DeviceFactoryTestCase):
         # New device
         ##
         device_type = self.device_type
-        size = Size('400 MiB')
         kwargs = {"disks": self.b.disks,
+                  "size": Size('400 MiB'),
                   "fstype": 'ext4',
                   "mountpoint": '/factorytest'}
 
@@ -320,16 +326,16 @@ class LVMFactoryTestCase(DeviceFactoryTestCase):
             # encrypt the PVs
             kwargs["encrypted"] = False
             kwargs["container_encrypted"] = True
-            device = self._factory_device(device_type, size, **kwargs)
-            self._validate_factory_device(device, device_type, size, **kwargs)
+            device = self._factory_device(device_type, **kwargs)
+            self._validate_factory_device(device, device_type, **kwargs)
             for partition in self.b.partitions:
                 self.b.recursive_remove(partition)
 
         # Add mirroring of PV using MD
         kwargs["container_encrypted"] = False
         kwargs["container_raid_level"] = "raid1"
-        device = self._factory_device(device_type, size, **kwargs)
-        self._validate_factory_device(device, device_type, size, **kwargs)
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
         for partition in self.b.partitions:
             self.b.recursive_remove(partition)
 
@@ -339,12 +345,12 @@ class LVMFactoryTestCase(DeviceFactoryTestCase):
 
         # Create a basic LVM stack
         device_type = self.device_type
-        size = Size('800 MiB')
         kwargs = {"disks": self.b.disks,
+                  "size": Size('800 MiB'),
                   "fstype": 'ext4',
                   "mountpoint": '/factorytest'}
-        device = self._factory_device(device_type, size, **kwargs)
-        self._validate_factory_device(device, device_type, size, **kwargs)
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
 
         if self.encryption_supported:
             # Encrypt the LV
@@ -353,45 +359,45 @@ class LVMFactoryTestCase(DeviceFactoryTestCase):
             # members in the next test.
             kwargs["encrypted"] = True
             kwargs["device"] = device
-            device = self._factory_device(device_type, size, **kwargs)
-            self._validate_factory_device(device, device_type, size, **kwargs)
+            device = self._factory_device(device_type, **kwargs)
+            self._validate_factory_device(device, device_type, **kwargs)
 
             # Decrypt the LV, but encrypt the PVs
             kwargs["encrypted"] = False
             kwargs["container_encrypted"] = True
             kwargs["device"] = device
-            device = self._factory_device(device_type, size, **kwargs)
-            self._validate_factory_device(device, device_type, size, **kwargs)
+            device = self._factory_device(device_type, **kwargs)
+            self._validate_factory_device(device, device_type, **kwargs)
 
         # Switch to an encrypted raid0 md pv
         kwargs["container_raid_level"] = "raid0"
         kwargs["device"] = device
-        size = Size("400 MiB")
-        device = self._factory_device(device_type, size, **kwargs)
-        self._validate_factory_device(device, device_type, size, **kwargs)
+        kwargs["size"] = Size("400 MiB")
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
 
         # remove encryption from the md pv
         kwargs["container_encrypted"] = False
         kwargs["device"] = device
-        device = self._factory_device(device_type, size, **kwargs)
-        self._validate_factory_device(device, device_type, size, **kwargs)
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
 
         # switch back to normal partition pvs
         kwargs["container_raid_level"] = None
         kwargs["device"] = device
-        size = Size("750 MiB")
-        device = self._factory_device(device_type, size, **kwargs)
-        self._validate_factory_device(device, device_type, size, **kwargs)
+        kwargs["size"] = Size("750 MiB")
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
 
         # limit the vg to the first disk
         kwargs["disks"] = self.b.disks[:1]
-        device = self._factory_device(device_type, size, **kwargs)
-        self._validate_factory_device(device, device_type, size, **kwargs)
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
 
         # expand it back to all disks
         kwargs["disks"] = self.b.disks
-        device = self._factory_device(device_type, size, **kwargs)
-        self._validate_factory_device(device, device_type, size, **kwargs)
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
 
     def _get_size_delta(self, devices=None):
         if not devices:
@@ -411,7 +417,7 @@ class LVMFactoryTestCase(DeviceFactoryTestCase):
 
         factory = devicefactory.get_device_factory(self.b,
                                                    self.device_type,
-                                                   Size("500 MiB"),
+                                                   size=Size("500 MiB"),
                                                    fstype="xfs")
 
         # get_container on lvm factory should return the lone non-existent vg
@@ -460,30 +466,30 @@ class MDFactoryTestCase(DeviceFactoryTestCase):
     def test_device_factory(self):
         # RAID0 across two disks
         device_type = self.device_type
-        size = Size('1 GiB')
         kwargs = {"disks": self.b.disks,
+                  "size": Size('1 GiB'),
                   "fstype": 'ext4',
                   "raid_level": "raid0",
                   "mountpoint": '/factorytest'}
-        device = self._factory_device(device_type, size, **kwargs)
-        self._validate_factory_device(device, device_type, size, **kwargs)
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
         self.b.recursive_remove(device)
 
         # Encrypt the leaf device
         kwargs["encrypted"] = True
-        device = self._factory_device(device_type, size, **kwargs)
-        self._validate_factory_device(device, device_type, size, **kwargs)
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
         for partition in self.b.partitions:
             self.b.recursive_remove(partition)
 
         # RAID1 across two disks
-        size = Size('500 MiB')
         kwargs = {"disks": self.b.disks,
+                  "size": Size('500 MiB'),
                   "fstype": 'ext4',
                   "raid_level": "raid1",
                   "mountpoint": '/factorytest'}
-        device = self._factory_device(device_type, size, **kwargs)
-        self._validate_factory_device(device, device_type, size, **kwargs)
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
         for partition in self.b.partitions:
             self.b.recursive_remove(partition)
 
@@ -492,30 +498,30 @@ class MDFactoryTestCase(DeviceFactoryTestCase):
         ##
 
         # RAID0 across two disks w/ swap
-        size = Size('800 MiB')
         kwargs = {"disks": self.b.disks,
+                  "size": Size('800 MiB'),
                   "fstype": 'swap',
                   "raid_level": "raid0",
                   "label": 'SWAP00'}
-        device = self._factory_device(device_type, size, **kwargs)
-        self._validate_factory_device(device, device_type, size, **kwargs)
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
 
         # Encrypt the leaf device
         kwargs["encrypted"] = True
         kwargs["device"] = device
-        device = self._factory_device(device_type, size, **kwargs)
-        self._validate_factory_device(device, device_type, size, **kwargs)
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
 
         # Change the mountpoint
-        size = Size('400 MiB')
+        kwargs["size"] = Size('400 MiB')
         kwargs["raid_level"] = "raid1"
         kwargs["mountpoint"] = "/a/different/dir"
         kwargs["label"] = "fedora 53 root"
         kwargs["fstype"] = "xfs"
         kwargs["device"] = device
         # kwargs["encrypted"] = False
-        device = self._factory_device(device_type, size, **kwargs)
-        self._validate_factory_device(device, device_type, size, **kwargs)
+        device = self._factory_device(device_type, **kwargs)
+        self._validate_factory_device(device, device_type, **kwargs)
 
     def _get_size_delta(self, devices=None):
         return Size("2 MiB") * len(self.b.disks)
@@ -532,19 +538,19 @@ class MDFactoryTestCase(DeviceFactoryTestCase):
     def test_mdfactory(self):
         factory1 = devicefactory.get_device_factory(self.b,
                                                     devicefactory.DEVICE_TYPE_MD,
-                                                    Size("1 GiB"),
+                                                    size=Size("1 GiB"),
                                                     raid_level=raid.RAID1)
 
         factory2 = devicefactory.get_device_factory(self.b,
                                                     devicefactory.DEVICE_TYPE_MD,
-                                                    Size("1 GiB"),
+                                                    size=Size("1 GiB"),
                                                     raid_level=0)
 
         with self.assertRaisesRegex(devicefactory.DeviceFactoryError, "must have some RAID level"):
             devicefactory.get_device_factory(
                 self.b,
                 devicefactory.DEVICE_TYPE_MD,
-                Size("1 GiB"))
+                size=Size("1 GiB"))
 
         with self.assertRaisesRegex(RaidError, "requires at least"):
             factory1._get_device_space()

--- a/tests/devicefactory_test.py
+++ b/tests/devicefactory_test.py
@@ -253,6 +253,22 @@ class DeviceFactoryTestCase(unittest.TestCase):
 
         self.assertEqual(factory.fstype, self.b.get_fstype())
 
+        kwargs = self._get_test_factory_args()
+        kwargs.update({"disks": self.b.disks[:],
+                       "fstype": "swap",
+                       "size": Size("2GiB"),
+                       "label": "SWAP"})
+        device = self._factory_device(self.device_type, **kwargs)
+        factory = devicefactory.get_device_factory(self.b, self.device_type,
+                                                   device=device)
+        self.assertEqual(factory.size, getattr(device, "req_size", device.size))
+        if self.device_type == devicefactory.DEVICE_TYPE_PARTITION:
+            self.assertIn(device.disk, factory.disks)
+        else:
+            self.assertEqual(factory.disks, device.disks)
+        self.assertEqual(factory.fstype, device.format.type)
+        self.assertEqual(factory.label, device.format.label)
+
 
 class PartitionFactoryTestCase(DeviceFactoryTestCase):
     device_class = PartitionDevice


### PR DESCRIPTION
See the commit message for 72170b1f for the point. My thinking before I started was that this would be significant usability improvement for `DeviceFactory`.

Since it breaks the API (`Blivet.factory_device`, `devicefactory.get_device_factory`, and `DeviceFactory`) it has to go onto 3.0-devel.