### PR TITLE
Device name now checked only for new devices

### DIFF
--- a/blivet/devices/device.py
+++ b/blivet/devices/device.py
@@ -78,13 +78,7 @@ class Device(util.ObjectID, metaclass=SynchronizedMeta):
             :type parents: list of :class:`Device` instances
         """
         util.ObjectID.__init__(self)
-
-        # Copy only the validity check from _set_name so we don't try to check a
-        # bunch of inappropriate state properties during __init__ in subclasses
-        if not self.is_name_valid(name):
-            raise ValueError("%s is not a valid name for this device" % name)
         self._name = name
-
         if parents is not None and not isinstance(parents, list):
             raise ValueError("parents must be a list of Device instances")
 

--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -133,6 +133,12 @@ class StorageDevice(Device):
         self._protected = False
         self.controllable = not flags.testing
 
+        # Copy only the validity check from Device._set_name() so we don't try
+        # to check a bunch of inappropriate state properties during
+        # __init__ in subclasses
+        # Has to be here because Device does not have exists attribute
+        if not self.exists and not self.is_name_valid(name):
+            raise ValueError("%s is not a valid name for this device" % name)
         super(StorageDevice, self).__init__(name, parents=parents)
 
         self.format = fmt

--- a/tests/devices_test/device_names_test.py
+++ b/tests/devices_test/device_names_test.py
@@ -26,6 +26,30 @@ class DeviceNameTestCase(unittest.TestCase):
         for name in bad_names:
             self.assertFalse(sd.is_name_valid(name))
 
+        # Check that name validity check is omitted (only) when
+        # device already exists
+        # This test was added to prevent regression (see #1379145)
+        for name in good_names:
+            try:
+                StorageDevice(name, exists=True)
+            except ValueError:
+                self.fail("Name check should not be performed nor failing")
+
+            try:
+                StorageDevice(name, exists=False)
+            except ValueError:
+                self.fail("Device name check failed when it shouldn't")
+
+        for name in bad_names:
+            try:
+                StorageDevice(name, exists=True)
+            except ValueError as e:
+                if ' is not a valid name for this device' in str(e):
+                    self.fail("Device name checked on already existing device")
+
+            with self.assertRaisesRegex(ValueError, ' is not a valid name for this device'):
+                StorageDevice(name, exists=False)
+
     def test_volume_group(self):
         good_names = ['vg00', 'group-name', 'groupname-']
         bad_names = ['-leading-hyphen', 'únicode', 'sp aces']


### PR DESCRIPTION
Device name check moved from Device to StorageDevice. Now is the name checked only when
device does not exist.

Added tests to check this behavior.