### PR TITLE
Fix iscsi problems: type of arg passed to storaged, store auth info when logging in with it

### DIFF
--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -452,12 +452,11 @@ class iScsiDiskDevice(DiskDevice, NetworkStorageDevice):
             address = "[%s]" % address
 
         netroot = "netroot=iscsi:"
-        auth = self.node.get_auth()
-        if auth:
-            netroot += "%s:%s" % (auth.username, auth.password)
-            if len(auth.reverse_username) or len(auth.reverse_password):
-                netroot += ":%s:%s" % (auth.reverse_username,
-                                       auth.reverse_password)
+        if self.node.username and self.node.password:
+            netroot += "%s:%s" % (self.node.username, self.node.password)
+            if self.node.r_username and self.node.r_password:
+                netroot += ":%s:%s" % (self.node.r_username,
+                                       self.node.r_password)
 
         iface_spec = ""
         if self.nic != "default":

--- a/blivet/iscsi.py
+++ b/blivet/iscsi.py
@@ -365,7 +365,7 @@ class iSCSI(object):
             if r_password:
                 auth_info["r_password"] = GLib.Variant("s", r_password)
 
-            args = GLib.Variant("(sqa{sv})", (ipaddr, port, auth_info))
+            args = GLib.Variant("(sqa{sv})", (ipaddr, int(port), auth_info))
             nodes, _n_nodes = self._call_initiator_method("DiscoverSendTargets", args)
 
             found_nodes = _to_node_infos(nodes)

--- a/blivet/iscsi.py
+++ b/blivet/iscsi.py
@@ -66,8 +66,29 @@ def has_iscsi():
     return True
 
 
-NodeInfo = namedtuple("NodeInfo", ["name", "tpgt", "address", "port", "iface"])
 TargetInfo = namedtuple("TargetInfo", ["ipaddr", "port"])
+
+
+class NodeInfo(object):
+    """Simple representation of node information."""
+    def __init__(self, name, tpgt, address, port, iface):
+        self.name = name
+        self.tpgt = tpgt
+        self.address = address
+        self.port = port
+        self.iface = iface
+        # These get set by log_into_node, but *NOT* _login
+        self.username = None
+        self.password = None
+        self.r_username = None
+        self.r_password = None
+
+    @property
+    def conn_info(self):
+        """The 5-tuple of connection info (no auth info). This form
+        is useful for interacting with storaged.
+        """
+        return (self.name, self.tpgt, self.address, self.port, self.iface)
 
 
 class LoginInfo(object):
@@ -235,7 +256,7 @@ class iSCSI(object):
             extra = dict()
         extra["node.startup"] = GLib.Variant("s", "automatic")
 
-        args = GLib.Variant("(sisisa{sv})", tuple(list(node_info) + [extra]))
+        args = GLib.Variant("(sisisa{sv})", node_info.conn_info + (extra,))
         self._call_initiator_method("Login", args)
 
     @storaged_iscsi_required(critical=False, eval_mode=util.EvalMode.onetime)
@@ -410,6 +431,14 @@ class iSCSI(object):
                      node.name, node.address, node.port, node.iface)
             if not self._mark_node_active(node):
                 log.error("iSCSI: node not found among discovered")
+            if username:
+                node.username = username
+            if password:
+                node.password = password
+            if r_username:
+                node.r_username = r_username
+            if r_password:
+                node.r_password = r_password
         except safe_dbus.DBusCallError as e:
             msg = str(e)
             log.warning("iSCSI: could not log into %s: %s", node.name, msg)


### PR DESCRIPTION
These commits fix a couple of problems in iSCSI support. The first is simple: the type of the `port` arg doesn't match the type string (`q` is an int). The second is more complicated; when we moved from libiscsi to storaged the `node` objects were changed from libiscsi `PyIscsiNode` instances to a new namedtuple class called `NodeInfo`...but as a consequence of that, they no longer provide any access to the usernames and passwords used to authenticate to the target, which both  blivet and anaconda actually expect. This restores that information in a different form (it just gets stuffed into the `NodeInfo` tuple) and adapts blivet to the change; I'll send a corresponding PR for anaconda.
