### PR TITLE
Use a list comprehension for _to_node_infos

### DIFF
--- a/blivet/iscsi.py
+++ b/blivet/iscsi.py
@@ -78,11 +78,7 @@ class LoginInfo(object):
 
 def _to_node_infos(variant):
     """Transforms an 'a(sisis)' GLib.Variant into a list of NodeInfo objects"""
-
-    ret = []
-    for info in variant:
-        ret.append(NodeInfo(*info))
-    return ret
+    return [NodeInfo(*info) for info in variant]
 
 
 class iSCSIDependencyGuard(util.DependencyGuard):


### PR DESCRIPTION
List comprehensions make the world a better place. At this point
the method is so trivial we could probably ditch it entirely,
but meh.
