### PR TITLE
iSCSI: set `iscsi.initiator_set` when setting initiator

### DIFF
--- a/blivet/iscsi.py
+++ b/blivet/iscsi.py
@@ -124,7 +124,6 @@ class iSCSI(object):
         # This list contains nodes discovered through iBFT (or other firmware)
         self.ibft_nodes = []
         self._initiator = ""
-        self.initiator_set = False
         self.started = False
         self.ifaces = {}
 
@@ -134,7 +133,6 @@ class iSCSI(object):
             try:
                 initiatorname = self._call_initiator_method("GetFirmwareInitiatorName")[0]
                 self._initiator = initiatorname
-                self.initiator_set = True
             except Exception:  # pylint: disable=broad-except
                 log_exception_info(fmt_str="failed to get initiator name from iscsi firmware")
 
@@ -170,6 +168,11 @@ class iSCSI(object):
         return safe_dbus.call_sync(STORAGED_SERVICE, STORAGED_MANAGER_PATH,
                                    INITIATOR_IFACE, method, args,
                                    connection=self._connection)
+
+    @property
+    def initiator_set(self):
+        """True if initiator is set at our level."""
+        return self._initiator != ""
 
     @property
     @storaged_iscsi_required(critical=False, eval_mode=util.EvalMode.onetime)


### PR DESCRIPTION
The iSCSI class has an `initiator_set` property whose meaning
feels a bit slippery these days. It has always been set to
True in `__init__()` if iBFT is active, right after we get the
initiator name from the firmware. Prior to 9280eff7, it was
also set true by `startup()` after it wrote out INITIATOR_FILE.
In 9280eff7, that was removed, without any kind of replacement.
Now `initiator_set` will never be True unless iBFT is being
used.

This is a problem because `iscsi.write()` checks if it's True,
and immediately bails if it isn't. The result of this is that
when you do an iSCSI install with anaconda, the contents of
`/var/lib/iscsi` from the installer environment are no longer
copied in the installed system.

I wasn't entirely sure how to fix this, but this seems like the
simplest way, at least: just have the `initiator` setter set
`initiator_set` to True after it sets `self._initiator`. I'm
not sure if it might be better to ditch this flag entirely, or
make it a property that just returns True if `self._initiator`
is set, or what. I'm not really sure why we have it any more,
it kinda feels a bit vestigial.
