### PR TITLE
Add device symlinks to the PVs dictionary for MD RAID PVs (#1389130)

### DIFF
--- a/blivet/static_data/lvm_info.py
+++ b/blivet/static_data/lvm_info.py
@@ -57,7 +57,23 @@ class PVsInfo(object):
     def cache(self):
         if self._pvs_cache is None:
             pvs = blockdev.lvm.pvs()
-            self._pvs_cache = dict((pv.pv_name, pv) for pv in pvs)  # pylint: disable=attribute-defined-outside-init
+            self._pvs_cache = dict()  # pylint: disable=attribute-defined-outside-init
+            for pv in pvs:
+                self._pvs_cache[pv.pv_name] = pv
+                # TODO: add get_all_device_symlinks() and resolve_device_symlink() functions to
+                #       libblockdev and use them here
+                if pv.pv_name.startswith("/dev/md/"):
+                    try:
+                        md_node = blockdev.md.node_from_name(pv.pv_name[len("/dev/md/"):])
+                        self._pvs_cache["/dev/" + md_node] = pv
+                    except blockdev.MDRaidError:
+                        pass
+                elif pv.pv_name.startswith("/dev/md"):
+                    try:
+                        md_named_dev = blockdev.md.name_from_node(pv.pv_name[len("/dev/"):])
+                        self._pvs_cache["/dev/md/" + md_named_dev] = pv
+                    except blockdev.MDRaidError:
+                        pass
 
         return self._pvs_cache
 


### PR DESCRIPTION
Otherwise if the symlink is used to search for the PV info, it's not found and
everything on that PV is ignored which leads e.g. to issues when removing the PV
(as described in the bug) and others.