### PR TITLE
Fix detection of 'macefi' partitions (#1393846)

### DIFF
--- a/blivet/populator/helpers/boot.py
+++ b/blivet/populator/helpers/boot.py
@@ -54,6 +54,16 @@ class MacEFIFormatPopulator(BootFormatPopulator):
     _type_specifier = "macefi"
     _base_type_specifier = "hfsplus"
 
+    @classmethod
+    def match(cls, data, device):
+        fmt = formats.get_format(cls._type_specifier)
+        try:
+            return (super().match(data, device) and
+                    device.parted_partition.name == fmt.name)
+        except AttributeError:
+            # just in case device.parted_partition has no name attr
+            return False
+
 
 class AppleBootFormatPopulator(BootFormatPopulator):
     _type_specifier = "appleboot"

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -1114,7 +1114,22 @@ class MDFormatPopulatorTestCase(FormatPopulatorTestCase):
             self.assertEqual(array.name, array_name)
 
 
+class FakePartedPart(object):
+    """Fake parted_partition for testing the parted partition name
+    matching stuff. Has to provide size also.
+    """
+    def __init__(self, partition, name):
+        self.name = name
+        self.partition = partition
+
+    def getLength(self, unit):
+        """This is circular, but works okay."""
+        return self.partition._size.convert_to(unit)
+
+
 class BootFormatPopulatorTestCase(PopulatorHelperTestCase):
+    name_mismatch_ok = True
+
     def test_match(self):
         """Test boot format populator helper match method"""
         if self.helper_class is None:
@@ -1135,6 +1150,9 @@ class BootFormatPopulatorTestCase(PopulatorHelperTestCase):
         max_size = fmt_class._max_size
         partition._size = min_size
         storagedev._size = min_size
+
+        if fmt_class._name:
+            partition._parted_partition = FakePartedPart(partition, fmt_class._name)
 
         self.assertTrue(self.helper_class.match(data, partition))
 
@@ -1158,6 +1176,18 @@ class BootFormatPopulatorTestCase(PopulatorHelperTestCase):
         self.assertFalse(self.helper_class.match(data, partition))
         partition._size = min_size
 
+        # we don't always match on the parted partition name, so allow
+        # subclasses to decide
+        if not self.name_mismatch_ok:
+            orig = partition._parted_partition
+            partition._parted_partition = FakePartedPart(partition, 'dontmatchanything')
+            self.assertFalse(self.helper_class.match(data, partition))
+
+            # shouldn't crash
+            partition._parted_partition = None
+            self.assertFalse(self.helper_class.match(data, partition))
+            partition._parted_partition = orig
+
     @patch("blivet.udev.device_get_disklabel_type", return_value=None)
     # pylint: disable=unused-argument
     def test_get_helper(self, *args):
@@ -1175,6 +1205,8 @@ class BootFormatPopulatorTestCase(PopulatorHelperTestCase):
         data["DEVTYPE"] = "partition"
         partition._bootable = self.helper_class._bootable
         partition._size = fmt_class._min_size
+        if fmt_class._name:
+            partition._parted_partition = FakePartedPart(partition, fmt_class._name)
         self.assertEqual(get_format_helper(data, partition), self.helper_class)
 
 
@@ -1184,6 +1216,7 @@ class EFIFormatPopulatorTestCase(BootFormatPopulatorTestCase):
 
 class MacEFIFormatPopulatorTestCase(BootFormatPopulatorTestCase):
     helper_class = MacEFIFormatPopulator
+    name_mismatch_ok = False
 
 
 class AppleBootFormatPopulatorTestCase(BootFormatPopulatorTestCase):


### PR DESCRIPTION
368a4db6 lost a crucial condition in the detection of 'macefi'
partitions in the transition to the 'populator helper' design.
Previously we checked that the parted partition 'name' (which
is a GPT property, for GPT partitions) matched the expected
value according to the macefi format, which basically means we
will only detect partitions created by a previous anaconda run
as 'macefi' (because that name is a very specific one which is
only created by anaconda in the first place).

In the transition, that condition was lost, and now we treat
any device with an HFS+ filesystem that's over 50MiB in size
as a 'macefi' device, which means we mount it at /boot/efi and
try to write all kinds of stuff to it. Not surprisingly, this
borks the install. Fortunately, HFS+ filesystems are mounted
read-only unless they have journalling disabled, so this won't
result in us messing up people's OS X partitions with any luck.