### PR TITLE
Fix "unknown" SAS device sysfs parsing.

### DIFF
--- a/blivet/devicelibs/edd.py
+++ b/blivet/devicelibs/edd.py
@@ -316,8 +316,8 @@ class EddEntry(object):
                         self.sas_address = int(sas_match.group(1), base=16)
                         self.sas_lun = int(sas_match.group(2), base=16)
                     elif unknown_match:
-                        self.sas_address = int(unknown_match.group(1), base=16)
-                        self.sas_lun = int(unknown_match.group(2), base=16)
+                        self.sas_address = int(unknown_match.group(2), base=16)
+                        self.sas_lun = int(unknown_match.group(3), base=16)
                     else:
                         log.warning("edd: can not match interface for %s: %s",
                                     self.sysfspath, interface)


### PR DESCRIPTION
Since the regexp matches the device type as well as the identifying
numbers, we need to pull the numbers from match groups 2 and 3, not 1
and 2.

Resolves: rhbz#1394026

Signed-off-by: Peter Jones <pjones@redhat.com>