### PR TITLE
Require BlockDev 2.0 in the gi.require_version() call

### DIFF
--- a/blivet/__init__.py
+++ b/blivet/__init__.py
@@ -75,7 +75,7 @@ log_bd_message = lambda level, msg: program_log.info(msg)
 
 import gi
 gi.require_version("GLib", "2.0")
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 # initialize the libblockdev library
 from gi.repository import GLib

--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -37,7 +37,7 @@ from .size import Size
 from .static_data import luks_data
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -27,7 +27,7 @@ from collections import namedtuple
 import itertools
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devices/btrfs.py
+++ b/blivet/devices/btrfs.py
@@ -24,7 +24,7 @@ import copy
 import tempfile
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devices/dm.py
+++ b/blivet/devices/dm.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devices/loop.py
+++ b/blivet/devices/loop.py
@@ -20,7 +20,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -30,7 +30,7 @@ from functools import wraps
 from enum import Enum
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devices/md.py
+++ b/blivet/devices/md.py
@@ -23,7 +23,7 @@ import os
 import six
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -24,7 +24,7 @@ import parted
 import _ped
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -25,7 +25,7 @@ import pprint
 import re
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/formats/__init__.py
+++ b/blivet/formats/__init__.py
@@ -22,7 +22,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/formats/lvmpv.py
+++ b/blivet/formats/lvmpv.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/formats/mdraid.py
+++ b/blivet/formats/mdraid.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/formats/swap.py
+++ b/blivet/formats/swap.py
@@ -27,7 +27,7 @@ from . import DeviceFormat, register_device_format
 from ..size import Size
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/osinstall.py
+++ b/blivet/osinstall.py
@@ -26,7 +26,7 @@ import stat
 import time
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -25,7 +25,7 @@ from decimal import Decimal
 import functools
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/populator/helpers/disk.py
+++ b/blivet/populator/helpers/disk.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/populator/helpers/dmraid.py
+++ b/blivet/populator/helpers/dmraid.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/populator/helpers/loop.py
+++ b/blivet/populator/helpers/loop.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 from gi.repository import BlockDev as blockdev
 
 from ... import udev

--- a/blivet/populator/helpers/luks.py
+++ b/blivet/populator/helpers/luks.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/populator/helpers/lvm.py
+++ b/blivet/populator/helpers/lvm.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/populator/helpers/mdraid.py
+++ b/blivet/populator/helpers/mdraid.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/populator/helpers/partition.py
+++ b/blivet/populator/helpers/partition.py
@@ -23,7 +23,7 @@
 import copy
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 from gi.repository import BlockDev as blockdev
 
 from ... import udev

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -26,7 +26,7 @@ import copy
 import parted
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/static_data/lvm_info.py
+++ b/blivet/static_data/lvm_info.py
@@ -21,7 +21,7 @@
 #
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/static_data/mpath_info.py
+++ b/blivet/static_data/mpath_info.py
@@ -20,7 +20,7 @@
 
 import os
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/tasks/availability.py
+++ b/blivet/tasks/availability.py
@@ -26,7 +26,7 @@ import hawkey
 from six import add_metaclass
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/tasks/lukstasks.py
+++ b/blivet/tasks/lukstasks.py
@@ -20,7 +20,7 @@
 # Red Hat Author(s): Anne Mulhern <amulhern@redhat.com>
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/tasks/pvtask.py
+++ b/blivet/tasks/pvtask.py
@@ -21,7 +21,7 @@
 # Red Hat Author(s): Vojtěch Trefný <vtrefny@redhat.com>
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -22,7 +22,7 @@ from enum import Enum
 from .errors import DependencyError
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/blivet/zfcp.py
+++ b/blivet/zfcp.py
@@ -26,7 +26,7 @@ from .i18n import _
 from .util import stringize, unicodeize
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -21,7 +21,7 @@ Source0: http://github.com/rhinstaller/blivet/archive/%{realname}-%{realversion}
 %global pypartedver 3.10.4
 %global e2fsver 1.41.0
 %global utillinuxver 2.15.1
-%global libblockdevver 1.9
+%global libblockdevver 2.1
 %global libbytesizever 0.3
 %global pyudevver 0.18
 

--- a/tests/devices_test/device_properties_test.py
+++ b/tests/devices_test/device_properties_test.py
@@ -3,7 +3,7 @@
 import unittest
 
 import gi
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -3,7 +3,7 @@ import os
 import unittest
 from unittest.mock import call, patch, sentinel, Mock, PropertyMock
 
-gi.require_version("BlockDev", "1.0")
+gi.require_version("BlockDev", "2.0")
 from gi.repository import BlockDev as blockdev
 
 from blivet import Blivet


### PR DESCRIPTION
We now have libblockdev-2.0. Unfortunately, the useless function
gi.require_version() is stupid and doesn't support anything like ">= 1.0", which
is what we really need. So unless we want to add more useless code trying both
"1.0" and "2.0", we are doomed to fail on systems that have libblockdev-1.x
installed even if that's just fine for us. To prevent this let's also bump the
requires in the spec file.

Resolves: rhbz#1395791