### PR TITLE
Change how we run e2fsck to check ext filesystems

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -296,8 +296,6 @@ class FS(DeviceFormat):
         """ Update this filesystem's current and minimum size (for resize). """
 
         #   This method ensures:
-        #   * If there are fsck errors, self._resizable is False.
-        #       Note that if there is no fsck program, no errors are possible.
         #   * If it is not possible to obtain the current size of the
         #       filesystem by interrogating the filesystem, self._resizable
         #       is False (and self._size is 0).
@@ -317,32 +315,26 @@ class FS(DeviceFormat):
         self._min_instance_size = Size(0)
         self._resizable = self.__class__._resizable
 
-        # We can't allow resize if the filesystem has errors.
+        # try to gather current size info
+        self._size = Size(0)
         try:
-            self.do_check()
-        except FSError:
-            self._resizable = False
-            raise
-        finally:
-            # try to gather current size info anyway
-            self._size = Size(0)
-            try:
-                if self._info.available:
-                    self._current_info = self._info.do_task()
-            except FSError as e:
-                log.info("Failed to obtain info for device %s: %s", self.device, e)
-            try:
-                self._size = self._size_info.do_task()
-                self._min_instance_size = self._size
-            except (FSError, NotImplementedError) as e:
-                log.warning("Failed to obtain current size for device %s: %s", self.device, e)
+            if self._info.available:
+                self._current_info = self._info.do_task()
+        except FSError as e:
+            log.info("Failed to obtain info for device %s: %s", self.device, e)
+        try:
+            self._size = self._size_info.do_task()
+        except (FSError, NotImplementedError) as e:
+            log.warning("Failed to obtain current size for device %s: %s", self.device, e)
+        else:
+            self._min_instance_size = self._size
 
-            # We absolutely need a current size to enable resize. To shrink the
-            # filesystem we need a real minimum size provided by the resize
-            # tool. Failing that, we can default to the current size,
-            # effectively disabling shrink.
-            if self._size == Size(0):
-                self._resizable = False
+        # We absolutely need a current size to enable resize. To shrink the
+        # filesystem we need a real minimum size provided by the resize
+        # tool. Failing that, we can default to the current size,
+        # effectively disabling shrink.
+        if self._size == Size(0):
+            self._resizable = False
 
         try:
             result = self._minsize.do_task()

--- a/blivet/tasks/fsck.py
+++ b/blivet/tasks/fsck.py
@@ -114,7 +114,9 @@ class Ext2FSCK(FSCK):
                     128: "Shared library error."}
 
     ext = availability.E2FSCK_APP
-    options = ["-f", "-p", "-C", "0"]
+    # "Force checking even if the file system seems clean." (we might get false results otherwise)
+    # + "Open the filesystem read-only, and assume an answer of `no' to all questions."
+    options = ["-f", "-n"]
 
     def _error_message(self, rc):
         msgs = (self._fsck_errors[c] for c in self._fsck_errors.keys() if rc & c)


### PR DESCRIPTION
The '-p' option means "Automatically repair ("preen") the file system.  This
option will cause e2fsck to automatically fix any filesystem problems that can
be safely fixed without human intervention." which is something we really
shouldn't do as part of reset()/populate(). We should use '-n' instead "Open the
filesystem read-only, and assume an answer of `no' to all questions." which
guaranties no changes to be made on the file system.

We might want to add the '-p' functionality back at some point, but it needs to
be explicitly triggered by the user code (e.g. Anaconda). I think we need to add
a 'clean' property and a 'repair' method to the formats.FS class so that users
can see where the problem is (if any) and explicitly trigger a safe fixup
attempt if they want to.

Related: rhbz#1170803