### PR TITLE
Fix the test dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,14 +20,11 @@ ZANATA_PUSH_ARGS = --srcdir ./po/ --push-type source --force
 MOCKCHROOT ?= fedora-rawhide-$(shell uname -m)
 
 TEST_DEPENDENCIES = $(shell rpm --specfile python-blivet.spec --requires | cut -d' ' -f1 | grep -v ^blivet)
-TEST_DEPENDENCIES += python-mock python3-mock
-TEST_DEPENDENCIES += cryptsetup-python cryptsetup-python3
-TEST_DEPENDENCIES += python3-gobject
-TEST_DEPENDENCIES += python-coverage python3-coverage
-TEST_DEPENDENCIES += xfsprogs hfsplus-tools
+TEST_DEPENDENCIES += python3-mock
+TEST_DEPENDENCIES += python3-coverage
+TEST_DEPENDENCIES += dosfstools e2fsprogs xfsprogs hfsplus-tools
 TEST_DEPENDENCIES += python3-pocketlint python3-bugzilla
-TEST_DEPENDENCIES += python3-pep8
-TEST_DEPENDENCIES += python3-kickstart
+TEST_DEPENDENCIES += python3-pep8 zanata-python-client
 TEST_DEPENDENCIES := $(shell echo $(sort $(TEST_DEPENDENCIES)) | uniq)
 
 all:

--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -19,7 +19,6 @@ Source0: http://github.com/rhinstaller/blivet/archive/%{realname}-%{realversion}
 %global pocketlintver 0.4
 %global partedver 1.8.1
 %global pypartedver 3.10.4
-%global e2fsver 1.41.0
 %global utillinuxver 2.15.1
 %global libblockdevver 2.1
 %global libbytesizever 0.3
@@ -47,8 +46,6 @@ Requires: python3-blockdev >= %{libblockdevver}
 Requires: libblockdev-plugins-all >= %{libblockdevver}
 Requires: python3-bytesize >= %{libbytesizever}
 Requires: util-linux >= %{utillinuxver}
-Requires: dosfstools
-Requires: e2fsprogs >= %{e2fsver}
 Requires: lsof
 Requires: python3-hawkey
 Requires: python3-gobject-base


### PR DESCRIPTION
We no longer require all the python2 packages, python3-kickstart is a hard
requirement now, cryptsetup is no longer used by blivet directly and we need the
anaconda-core stuff for pylint. Plus we need the zanata client to pull
translations and run the canary tests on them.

The file system utilities should all be just test dependencies because blivet
itself works without any of them.