### PR TITLE
Shallow copy another alignment property (#1408282)

### DIFF
--- a/blivet/formats/disklabel.py
+++ b/blivet/formats/disklabel.py
@@ -90,7 +90,8 @@ class DiskLabel(DeviceFormat):
             We can't do copy.deepcopy on parted objects, which is okay.
         """
         return util.variable_copy(self, memo,
-                                  shallow=('_parted_device', '_optimal_alignment', '_minimal_alignment',),
+                                  shallow=('_parted_device', '_optimal_alignment', '_minimal_alignment',
+                                           '_disk_label_alignment'),
                                   duplicate=('_parted_disk', '_orig_parted_disk'))
 
     def __repr__(self):


### PR DESCRIPTION
Several blivet classes use custom __deepcopy__ methods to avoid
deep copying some parted objects which we know can't be deep
copied. Unfortunately the list of attributes excepted from deep
copying for `DiskLabel` was missing one parted Alignment object,
and with Python 3.6, we blow up trying to deepcopy that. This
fixes the problem by adding that attribute to the list of ones
we know have to be shallow copied.