### PR TITLE
formats/fs: Set NTFS to be formattable

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -1026,6 +1026,7 @@ class NTFS(FS):
     _type = "ntfs"
     _labelfs = fslabeling.NTFSLabeling()
     _resizable = True
+    _formattable = True
     _min_size = Size("1 MiB")
     _max_size = Size("16 TiB")
     _packages = ["ntfsprogs"]


### PR DESCRIPTION
During running the test suite I found that while `MKNTFS_APP` is available, the tests for NTFS are skipped because it's not marked to be formattable.