### PR TITLE
Loop devices w/o backing file are now ignored

### DIFF
--- a/blivet/populator/helpers/disk.py
+++ b/blivet/populator/helpers/disk.py
@@ -46,6 +46,7 @@ class DiskDevicePopulator(DevicePopulator):
         return (udev.device_is_disk(data) and
                 not udev.device_is_cdrom(data) and
                 not udev.device_is_partition(data) and
+                not udev.device_is_loop(data) and
                 not udev.device_is_dm(data) and
                 not (udev.device_is_md(data) and not udev.device_get_md_container(data)))
 

--- a/blivet/populator/helpers/loop.py
+++ b/blivet/populator/helpers/loop.py
@@ -33,14 +33,15 @@ from .devicepopulator import DevicePopulator
 class LoopDevicePopulator(DevicePopulator):
     @classmethod
     def match(cls, data):
-        return (udev.device_is_loop(data) and
-                bool(blockdev.loop.get_backing_file(udev.device_get_name(data))))
+        return udev.device_is_loop(data)
 
     def run(self):
         name = udev.device_get_name(self.data)
         log_method_call(self, name=name)
         sysfs_path = udev.device_get_sysfs_path(self.data)
         backing_file = blockdev.loop.get_backing_file(name)
+        if backing_file is None:
+            return None
         file_device = self._devicetree.get_device_by_name(backing_file)
         if not file_device:
             file_device = FileDevice(backing_file, exists=True)

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -317,9 +317,8 @@ def device_is_partition(info):
 
 
 def device_is_loop(info):
-    """ Return True if the device is a configured loop device. """
-    return (device_get_name(info).startswith("loop") and
-            os.path.isdir("%s/loop" % device_get_sysfs_path(info)))
+    """ Return True if the device is a loop device. """
+    return device_get_name(info).startswith("loop")
 
 
 @util.deprecated("3.0", "udev.device_is_disk provides same functionality in 3.0")

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -179,22 +179,12 @@ class DMDevicePopulatorTestCase(PopulatorHelperTestCase):
 class LoopDevicePopulatorTestCase(PopulatorHelperTestCase):
     helper_class = LoopDevicePopulator
 
-    @patch("blivet.populator.helpers.loop.blockdev.loop.get_backing_file")
-    @patch("blivet.udev.device_get_name")
-    @patch("blivet.udev.device_is_loop", return_value=True)
     def test_match(self, *args):
         """Test matching of loop device populator."""
-        device_is_loop = args[0]
-        get_backing_file = args[2]
-        get_backing_file.return_value = True
-        self.assertTrue(self.helper_class.match(None))
-
-        get_backing_file.return_value = False
-        self.assertFalse(self.helper_class.match(None))
-        get_backing_file.return_value = True
-
-        device_is_loop.return_value = False
-        self.assertFalse(self.helper_class.match(None))
+        # LoopDevicePopulator.match just runs the check if device is loop
+        # The backing file check is now performed in the "run" method.
+        # Test intentionally left empty
+        pass
 
     @patch("blivet.populator.helpers.loop.blockdev.loop.get_backing_file")
     @patch("blivet.udev.device_get_name")
@@ -213,7 +203,7 @@ class LoopDevicePopulatorTestCase(PopulatorHelperTestCase):
         self.assertEqual(get_device_helper(data), self.helper_class)
 
         get_backing_file.return_value = False
-        self.assertNotEqual(get_device_helper(data), self.helper_class)
+        self.assertEqual(get_device_helper(data), self.helper_class)
         get_backing_file.return_value = True
 
         # verify that setting one of the required True return values to False prevents success
@@ -244,8 +234,14 @@ class LoopDevicePopulatorTestCase(PopulatorHelperTestCase):
         device_name = "loop3"
         device_get_name.return_value = device_name
         backing_file = "/some/file"
-        get_backing_file.return_value = backing_file
+
+        get_backing_file.return_value = None
         helper = self.helper_class(devicetree, data)
+        device = helper.run()
+
+        self.assertIsNone(device)
+
+        get_backing_file.return_value = backing_file
 
         device = helper.run()
 


### PR DESCRIPTION
Populator now skips all detached loop devices (i.e. without backing file)