### PR TITLE
Add HW RAID properties to DiskDevice

### DIFF
--- a/blivet/devicelibs/disk.py
+++ b/blivet/devicelibs/disk.py
@@ -1,0 +1,111 @@
+from collections import namedtuple
+
+from . import raid
+from .. import errors
+from .. import util
+from ..size import Size
+
+lsm = None
+
+_HBA_PLUGIN_URIS = ("hpsa://", "megaraid://")
+LSMInfo = namedtuple('HBAVolumeInfo', ['system', 'nodes', 'raid_type', 'raid_stripe_size', 'raid_disk_count'])
+""" .. class:: LSMInfo
+
+        .. attribute:: system (str): descriptive name of HBA unit
+        .. attribute:: nodes (list[str]): list of device node paths for the volume
+        .. attribute:: raid_type (:class:`~.devicelibs.raid.RAIDLevel` or None): RAID level
+        .. attribute:: raid_stripe_size (:class:`~.size.Size` or None): stripe size
+        .. attribute:: raid_disk_count (int or None): number of disks in the RAID set
+"""
+volumes = dict()
+_raid_levels = dict()
+
+
+class _LSMRAIDLevelStub(raid.RAIDLevel):
+    def __init__(self, name):
+        self._name = name
+
+    @property
+    def name(self):
+        return self._name
+
+    @property
+    def names(self):
+        return [self.name]
+
+    @property
+    def min_members(self):
+        return 0
+
+    def has_redundancy(self):
+        return False
+
+    def is_uniform(self):
+        return False
+
+
+class _LSMDependencyGuard(util.DependencyGuard):
+    error_msg = "libstoragemgmt functionality not available"
+
+    def _check_avail(self):
+        global lsm
+        if lsm is None:
+            try:
+                import lsm  # pylint: disable=redefined-outer-name
+            except ImportError:
+                lsm = None
+
+        return lsm is not None
+
+_lsm_required = _LSMDependencyGuard()
+
+
+def _update_lsm_raid_levels():
+    """ Build a mapping of lsm.RAID_TYPE->blivet.devicelibs.raid.RAIDLevel """
+    global _raid_levels
+    _raid_levels = dict()
+    lsm_raid_levels = dict((k, v) for (k, v) in lsm.Volume.__dict__.items() if k.startswith("RAID_TYPE_"))
+    for constant_name, value in lsm_raid_levels.items():
+        name = constant_name[len("RAID_TYPE_"):]
+        try:
+            level = raid.get_raid_level(name)
+        except errors.RaidError:
+            level = _LSMRAIDLevelStub(name)
+
+        _raid_levels[value] = level
+
+
+def _get_lsm_raid_level(lsm_raid_type):
+    """ Return a blivet.devicelibs.raid.RAIDLevel corresponding the lsm-reported RAID level."""
+    return _raid_levels.get(lsm_raid_type, _raid_levels.get(lsm.Volume.RAID_TYPE_UNKNOWN))
+
+
+@_lsm_required(critical=False, eval_mode=util.EvalMode.always)
+def update_volume_info():
+    """ Build a dict of namedtuples containing basic HBA RAID info w/ device path keys. """
+    global volumes
+    volumes = dict()
+    _update_lsm_raid_levels()
+    for uri in _HBA_PLUGIN_URIS:
+        try:
+            client = lsm.Client(uri)
+        except lsm.LsmError:
+            continue
+
+        systems = dict((s.id, s) for s in client.systems())
+        for vol in client.volumes():
+            nodes = lsm.LocalDisk.vpd83_search(vol.vpd83)
+            system = systems[vol.system_id]
+            caps = client.capabilities(system)
+
+            raid_level = None
+            stripe_size = None
+            disk_count = None
+            if caps.supported(lsm.Capabilities.VOLUME_RAID_INFO):
+                raid_info = client.volume_raid_info(vol)[:3]
+                raid_level = _get_lsm_raid_level(raid_info[0])
+                stripe_size = Size(raid_info[1])
+                disk_count = raid_info[2]
+
+            info = LSMInfo(system.name, nodes, raid_level, stripe_size, disk_count)
+            volumes.update([(node, info) for node in nodes])

--- a/blivet/devicelibs/raid.py
+++ b/blivet/devicelibs/raid.py
@@ -658,7 +658,7 @@ class Linear(ErsatzRAID):
 
     """ subclass with canonical lvm name """
     name = 'linear'
-    names = [name]
+    names = [name, 'jbod']
 
 Linear = Linear()
 ALL_LEVELS.add_raid_level(Linear)

--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -29,6 +29,7 @@ import os
 
 from .. import errors
 from .. import util
+from ..devicelibs import disk as disklib
 from ..flags import flags
 from ..storage_log import log_method_call
 from .. import udev
@@ -139,6 +140,26 @@ class DiskDevice(StorageDevice):
             raise errors.DeviceError("cannot destroy disk with no media", self.name)
 
         StorageDevice._pre_destroy(self)
+
+    @property
+    def _volume(self):
+        return disklib.volumes.get(self.path)
+
+    @property
+    def raid_system(self):
+        return self._volume.system if self._volume is not None else None
+
+    @property
+    def raid_level(self):
+        return self._volume.raid_type if self._volume is not None else None
+
+    @property
+    def raid_stripe_size(self):
+        return self._volume.raid_stripe_size if self._volume is not None else None
+
+    @property
+    def raid_disk_count(self):
+        return self._volume.raid_disk_count if self._volume is not None else None
 
 
 class DiskFile(DiskDevice):

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -36,6 +36,7 @@ from ..devices import FileDevice, LoopDevice
 from ..devices import MDRaidArrayDevice
 from ..devices import MultipathDevice
 from ..devices import NoDevice
+from ..devicelibs import disk as disklib
 from ..devicelibs import lvm
 from .. import formats
 from .. import udev
@@ -485,6 +486,7 @@ class PopulatorMixin(object, metaclass=SynchronizedMeta):
         log.info("DeviceTree.populate: ignored_disks is %s ; exclusive_disks is %s",
                  self.ignored_disks, self.exclusive_disks)
 
+        disklib.update_volume_info()
         self.drop_lvm_cache()
         mpath_members.drop_cache()
 

--- a/tests/devicelibs_test/disk_test.py
+++ b/tests/devicelibs_test/disk_test.py
@@ -1,0 +1,120 @@
+# pylint: skip-file
+import unittest
+from unittest.mock import Mock, patch, sentinel
+
+from blivet.devicelibs import disk as disklib
+from blivet.size import Size
+
+
+class FakeLsmError(Exception):
+    pass
+
+
+class OtherError(Exception):
+    pass
+
+
+def raise_lsm_error(*args):
+    raise FakeLsmError("fake message")
+
+
+def raise_other_error(*args):
+    raise OtherError("other message")
+
+
+class DiskLibTestCase(unittest.TestCase):
+    def test_lsm_dependency_guard(self):
+        """Validate handling of missing lsm dependency."""
+        # If lsm cannot be imported update_volume_info should yield an empty volume list.
+        with patch("blivet.devicelibs.disk._lsm_required._check_avail", return_value=False):
+            disklib.update_volume_info()
+            self.assertEqual(disklib.volumes, dict())
+
+    def test_lsm_error_handling(self):
+        """Validate handling of potential lsm errors."""
+        with patch("blivet.devicelibs.disk._lsm_required._check_avail", return_value=True):
+            with patch("blivet.devicelibs.disk.lsm") as _lsm:
+                _lsm.LsmError = FakeLsmError
+
+                # verify that we end up with an empty dict if lsm.Client() raises LsmError
+                _lsm.Client.side_effect = raise_lsm_error
+                disklib.update_volume_info()
+                self.assertEqual(disklib.volumes, dict())
+
+                # verify that any error other than LsmError gets raised
+                _lsm.Client.side_effect = raise_other_error
+                with self.assertRaises(OtherError):
+                    disklib.update_volume_info()
+
+    def test_update_volume_list(self):
+        """Validate conversion of lsm data."""
+        _client_systems = [Mock(), Mock(), Mock()]
+        _client_systems[0].configure_mock(name="Smart Array P840 in Slot 1", raid=True)
+        _client_systems[1].configure_mock(name="LSI MegaRAID SAS", raid=True)
+        _client_systems[2].configure_mock(name="Supermicro Superchassis", raid=False)
+
+        _client_volumes = [Mock(system_id=_client_systems[0].id,
+                                nodes=["/dev/sda"],
+                                vpd83=0,
+                                raid_type=sentinel.RAID_TYPE_RAID0,
+                                stripe_size=262144,
+                                drives=4,
+                                min_io=262144,
+                                opt_io=1048576),
+                           Mock(system_id=_client_systems[1].id,
+                                nodes=["/dev/sdb"],
+                                vpd83=1,
+                                raid_type=sentinel.RAID_TYPE_OTHER,
+                                stripe_size=524288,
+                                drives=2,
+                                min_io=524288,
+                                opt_io=1048576),
+                           Mock(system_id=_client_systems[2].id,
+                                nodes=["/dev/sdc"],
+                                vpd83=2,
+                                raid_type=None,
+                                strip_size=None,
+                                drives=None,
+                                min_io=None,
+                                opt_io=None)]
+
+        def client_capabilities(system):
+            caps = Mock(name="Client.capabilities(%s)" % system.name)
+            caps.configure_mock(**{"supported.return_value": system.raid})
+            return caps
+
+        def client_volume_raid_info(volume):
+            return (volume.raid_type, volume.stripe_size, volume.drives, volume.min_io, volume.opt_io)
+
+        def vpd83_search(vpd83):
+            return next((vol.nodes for vol in _client_volumes if vol.vpd83 == vpd83), None)
+
+        def system_by_id(sys_id):
+            return next((sys for sys in _client_systems if sys.id == sys_id), None)
+
+        with patch("blivet.devicelibs.disk._lsm_required._check_avail", return_value=True):
+            with patch("blivet.devicelibs.disk.lsm") as _lsm:
+                _lsm.Volume.RAID_TYPE_RAID0 = sentinel.RAID_TYPE_RAID0
+                _lsm.Volume.RAID_TYPE_OTHER = sentinel.RAID_TYPE_OTHER
+                _lsm.Capabilities.VOLUME_RAID_INFO = sentinel.VOLUME_RAID_INFO
+                _lsm.LocalDisk.vpd83_search.side_effect = vpd83_search
+                client_mock = Mock(name="lsm.Client")
+                client_mock.configure_mock(**{"return_value": client_mock,
+                                              "volumes.return_value": _client_volumes,
+                                              "systems.return_value": _client_systems,
+                                              "capabilities.side_effect": client_capabilities,
+                                              "volume_raid_info.side_effect": client_volume_raid_info})
+                _lsm.Client = client_mock
+                disklib.update_volume_info()
+                for (i, lvol) in enumerate(_client_volumes):
+                    bvol = disklib.volumes[lvol.nodes[0]]
+                    system = system_by_id(lvol.system_id)
+                    self.assertEqual(bvol.system, system.name)
+                    if client_mock.capabilities(system).supported(sentinel.VOLUME_RAID_INFO):
+                        self.assertEqual(bvol.raid_type, disklib._get_lsm_raid_level(lvol.raid_type))
+                        self.assertEqual(bvol.raid_stripe_size, Size(lvol.stripe_size))
+                        self.assertEqual(bvol.raid_disk_count, lvol.drives)
+                    else:
+                        self.assertIsNone(bvol.raid_type)
+                        self.assertIsNone(bvol.raid_stripe_size)
+                        self.assertIsNone(bvol.raid_disk_count)

--- a/tests/devices_test/disk_test.py
+++ b/tests/devices_test/disk_test.py
@@ -1,0 +1,50 @@
+# pylint: skip-file
+import unittest
+from unittest.mock import patch
+
+from blivet.devices import DiskDevice
+from blivet.devicelibs import disk as disklib
+from blivet.devicelibs import raid
+from blivet.size import Size
+
+
+class DiskDeviceRAIDPropertiesTestCase(unittest.TestCase):
+    def test_disk_raid_properties(self):
+        volumes = {"/dev/test1": disklib.LSMInfo("Test 1",
+                                                 ["/dev/test1"],
+                                                 raid.get_raid_level("raid0"),
+                                                 Size("512 KiB"),
+                                                 4),
+                   "/dev/test2": disklib.LSMInfo("Test 2",
+                                                 ["/dev/test2"],
+                                                 None,
+                                                 None,
+                                                 None)}
+
+        test1 = DiskDevice("test1")
+        test2 = DiskDevice("test2")
+        test3 = DiskDevice("test3")
+        # DiskDevice attributes should have the same values as the corresponding LSMInfo, or None
+        with patch("blivet.devices.disk.disklib") as _disklib:
+            _disklib.volumes = volumes
+
+            test1_volume = volumes[test1.path]
+            self.assertEqual(test1._volume, volumes[test1.path])
+            self.assertEqual(test1.raid_system, test1_volume.system)
+            self.assertEqual(test1.raid_level, test1_volume.raid_type)
+            self.assertEqual(test1.raid_stripe_size, test1_volume.raid_stripe_size)
+            self.assertEqual(test1.raid_disk_count, test1_volume.raid_disk_count)
+
+            test2_volume = volumes[test2.path]
+            self.assertEqual(test2._volume, volumes[test2.path])
+            self.assertEqual(test2._volume, test2_volume)
+            self.assertEqual(test2.raid_system, test2_volume.system)
+            self.assertEqual(test2.raid_level, test2_volume.raid_type)
+            self.assertEqual(test2.raid_stripe_size, test2_volume.raid_stripe_size)
+            self.assertEqual(test2.raid_disk_count, test2_volume.raid_disk_count)
+
+            self.assertIsNone(test3._volume)
+            self.assertIsNone(test3.raid_system)
+            self.assertIsNone(test3.raid_level)
+            self.assertIsNone(test3.raid_stripe_size)
+            self.assertIsNone(test3.raid_disk_count)


### PR DESCRIPTION
This adds a few properties to `DiskDevice` describing RAID characteristics where applicable. The data is taken from [`lsm.Client.volume_raid_info`](https://libstorage.github.io/libstoragemgmt-doc/doc/py_api_user_guide.html#query-volume-raid-information----lsmclientvolumeraidinfo) and converted to blivet data types.

A useful followup would be to use `DiskDevice.raid_system` as `DiskDevice.description` when available since it should convey much more information than the existing method. This would be a freebie for anaconda usability.