### PR TITLE
Add 'discard' option to crypttab for newly created LUKS

### DIFF
--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -121,6 +121,14 @@ class LUKS(DeviceFormat):
             # if you want current/min size you have to call update_size_info
             self.update_size_info()
 
+        # add the discard option for newly created LUKS formats during the
+        # installation (rhbz#1421596)
+        if not self.exists and flags.installer_mode:
+            if not self.options:
+                self.options = "discard"
+            elif "discard" not in self.options:
+                self.options += ",discard"
+
     def __repr__(self):
         s = DeviceFormat.__repr__(self)
         if self.__passphrase:


### PR DESCRIPTION
As has been suggested and approved in the Fedora 26 change
https://fedoraproject.org//wiki/Changes/EnableTrimOnDmCrypt,
crypttab entries for newly created LUKS devices/formats should
use the 'discard' option by default.