### PR TITLE
FBA DASD should use the msdos disk label type

### DIFF
--- a/python-blivet.spec
+++ b/python-blivet.spec
@@ -20,7 +20,7 @@ Source0: http://github.com/rhinstaller/blivet/archive/%{realname}-%{realversion}
 %global partedver 1.8.1
 %global pypartedver 3.10.4
 %global utillinuxver 2.15.1
-%global libblockdevver 2.1
+%global libblockdevver 2.6
 %global libbytesizever 0.3
 %global pyudevver 0.18
 


### PR DESCRIPTION
There can be created up to three partitions on FBA DASD with the msdos
disk label type instead of only one, so we should prefer that.

Also the method requiredDiskLabelType can be removed, because it is not
needed anymore.

This pull request is based on https://github.com/rhinstaller/blivet/pull/546 and requires a new version of libblockdev 
https://github.com/rhinstaller/libblockdev/pull/170.