### PR TITLE
Introduce the discard_new flag and use it

### DIFF
--- a/blivet/flags.py
+++ b/blivet/flags.py
@@ -84,6 +84,10 @@ class Flags(object):
         # whether to include nodev filesystems in the devicetree
         self.include_nodev = False
 
+        # whether to enable discard for newly created devices
+        # (so far only for LUKS)
+        self.discard_new = False
+
         self.boot_cmdline = {}
 
         self.update_from_boot_cmdline()

--- a/blivet/formats/luks.py
+++ b/blivet/formats/luks.py
@@ -121,9 +121,9 @@ class LUKS(DeviceFormat):
             # if you want current/min size you have to call update_size_info
             self.update_size_info()
 
-        # add the discard option for newly created LUKS formats during the
-        # installation (rhbz#1421596)
-        if not self.exists and flags.installer_mode:
+        # add the discard option for newly created LUKS formats if requested
+        # (e.g. during the installation -- see rhbz#1421596)
+        if not self.exists and flags.discard_new:
             if not self.options:
                 self.options = "discard"
             elif "discard" not in self.options:

--- a/blivet/osinstall.py
+++ b/blivet/osinstall.py
@@ -149,6 +149,7 @@ def enable_installer_mode():
     flags.auto_dev_updates = True
     flags.selinux_reset_fcon = True
     flags.keep_empty_ext_partitions = False
+    flags.discard_new = True
 
     udev.device_name_blacklist = [r'^mtd', r'^mmcblk.+boot', r'^mmcblk.+rpmb', r'^zram', '^ndblk', '^pmem']
 

--- a/tests/formats_test/luks_test.py
+++ b/tests/formats_test/luks_test.py
@@ -52,15 +52,15 @@ class LUKSTestCase(loopbackedtestcase.LoopBackedTestCase):
 
 class LUKSNodevTestCase(unittest.TestCase):
     def test_create_discard_option(self):
-        # no installer mode --> no discard
+        # flags.discard_new=False --> no discard
         fmt = LUKS(exists=False)
         self.assertEqual(fmt.options, None)
 
         fmt = LUKS(exists=True)
         self.assertEqual(fmt.options, None)
 
-        # installer mode --> discard if creating new
-        with patch("blivet.flags.installer_mode", True):
+        # flags.discard_new=True --> discard if creating new
+        with patch("blivet.flags.flags.discard_new", True):
             fmt = LUKS(exists=True)
             self.assertEqual(fmt.options, None)
 


### PR DESCRIPTION
Instead of the old non-specific 'installer_mode' flag we no
longer have on 3.0-devel and master.