### PR TITLE
Use all ancestors when adding RAID disks to exclusiveDisks

### DIFF
--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -1271,9 +1271,9 @@ class DeviceTree(object):
         mdclasses = (DMRaidArrayDevice, MDRaidArrayDevice, MultipathDevice)
         if device.isDisk and isinstance(device, mdclasses):
             if device.name in self.exclusiveDisks:
-                for parent in device.parents:
-                    if parent.name not in self.exclusiveDisks:
-                        self.exclusiveDisks.append(parent.name)
+                for ancestor in device.ancestors:
+                    if ancestor.isDisk and ancestor.name not in self.exclusiveDisks:
+                        self.exclusiveDisks.append(ancestor.name)
 
         log.info("got device: %r", device.name)
 


### PR DESCRIPTION
For some BIOS RAIDs the hierarchy of devices looks like
[sdb, sdc] -> imsm0 -> md126 (= Volume0_0) so when adding Volume0_0
to exclusiveDisks we need to check for all ancestors, not only
parents, to add the disks to exclusiveDisks.

Resolves: rhbz#1327463

Submitted-by: Masahiro Matsuya <mmatsuya@redhat.com>