### PR TITLE
Be more careful when checking for udisks-iscsi availability

### DIFF
--- a/blivet/iscsi.py
+++ b/blivet/iscsi.py
@@ -106,9 +106,9 @@ class iSCSIDependencyGuard(util.DependencyGuard):
     error_msg = "storaged iSCSI functionality not available"
 
     def _check_avail(self):
-        if not safe_dbus.check_object_available(STORAGED_SERVICE, STORAGED_MANAGER_PATH, MANAGER_IFACE):
-            return False
         try:
+            if not safe_dbus.check_object_available(STORAGED_SERVICE, STORAGED_MANAGER_PATH, MANAGER_IFACE):
+                return False
             # storaged is modular and we need to make sure it has the iSCSI module
             # loaded (this also autostarts storaged if it isn't running already)
             safe_dbus.call_sync(STORAGED_SERVICE, STORAGED_MANAGER_PATH, MANAGER_IFACE,


### PR DESCRIPTION
If udisks (storaged) is not installed at all, we may get an error
even when trying to find out if udisks (storaged) provides the
iSCSI functionality via its Manager object.

Resolves: rhbz#1429132