### PR TITLE
Fix root-only unit tests on 2.1-devel

### DIFF
--- a/tests/formats_test/luks_test.py
+++ b/tests/formats_test/luks_test.py
@@ -49,6 +49,10 @@ class LUKSTestCase(loopbackedtestcase.LoopBackedTestCase):
         self.fmt.update_size_info()
         self.assertEqual(self.fmt.current_size, new_size)
 
+    def tearDown(self):
+        self.fmt.teardown()
+        super(LUKSTestCase, self).tearDown()
+
 
 class LUKSNodevTestCase(unittest.TestCase):
     def test_create_discard_option(self):

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -62,7 +62,8 @@ class setupDiskImagesNonZeroSizeTestCase(unittest.TestCase):
         # this is an image install. Somewhere along the line this will
         # execute setup_disk_images() once more and the DMLinearDevice created
         # in this second execution has size 0
-        storage_initialize(self.blivet, ksdata, [])
+        with patch('blivet.osinstall.flags'):
+            storage_initialize(self.blivet, ksdata, [])
 
     def tearDown(self):
         self.blivet.reset()

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -75,8 +75,11 @@ class setupDiskImagesNonZeroSizeTestCase(unittest.TestCase):
         flags.image_install = False
 
     def runTest(self):
+        disk = self.blivet.disks[0]
+        self.assertEqual(disk.name, list(self.disks.keys())[0])
         for d in self.blivet.devicetree.devices:
-            self.assertTrue(d.size > 0)
+            if d == disk or disk.depends_on(d):
+                self.assertTrue(d.size > 0)
 
 
 class PopulatorHelperTestCase(unittest.TestCase):


### PR DESCRIPTION
Apparently pointing blivet's tests at an uncompiled anaconda git clone is not the same as having the anaconda-core package installed -- go figure.