### PR TITLE
Add a WWN attribute to disk-like device classes.

### DIFF
--- a/blivet/populator/helpers/disk.py
+++ b/blivet/populator/helpers/disk.py
@@ -57,7 +57,8 @@ class DiskDevicePopulator(DevicePopulator):
             "serial": udev.device_get_serial(self.data),
             "vendor": util.get_sysfs_attr(sysfs_path, "device/vendor"),
             "model": util.get_sysfs_attr(sysfs_path, "device/model"),
-            "bus": udev.device_get_bus(self.data)
+            "bus": udev.device_get_bus(self.data),
+            "wwn": udev.device_get_wwn(self.data)
         }
 
         if self._device_class == DiskDevice:

--- a/blivet/populator/helpers/dmraid.py
+++ b/blivet/populator/helpers/dmraid.py
@@ -81,4 +81,6 @@ class DMRaidFormatPopulator(FormatPopulator):
                 dm_array.update_sysfs_path()
                 dm_array.update_size()
                 dm_array_info = udev.get_device(dm_array.sysfs_path)
+                if dm_array_info:
+                    dm_array.wwn = udev.device_get_wwn(dm_array_info)
                 self._devicetree.handle_device(dm_array_info, update_orig_fmt=True)

--- a/blivet/populator/helpers/multipath.py
+++ b/blivet/populator/helpers/multipath.py
@@ -22,7 +22,6 @@
 
 from ... import udev
 from ...devices import MultipathDevice
-from ...errors import DeviceTreeError
 from ...storage_log import log_method_call
 from .devicepopulator import DevicePopulator
 from .formatpopulator import FormatPopulator
@@ -45,15 +44,9 @@ class MultipathDevicePopulator(DevicePopulator):
 
         device = None
         if slave_devices:
-            try:
-                serial = self.data["DM_UUID"].split("-", 1)[1]
-            except (IndexError, AttributeError):
-                log.error("multipath device %s has no DM_UUID", name)
-                raise DeviceTreeError("multipath %s has no DM_UUID" % name)
-
             device = MultipathDevice(name, parents=slave_devices,
                                      sysfs_path=udev.device_get_sysfs_path(self.data),
-                                     serial=serial)
+                                     wwn=udev.device_get_wwn(self.data))
             self._devicetree._add_device(device)
 
         return device

--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -351,11 +351,8 @@ def device_get_serial(udev_info):
     return udev_info.get("ID_SERIAL_RAW", udev_info.get("ID_SERIAL", udev_info.get("ID_SERIAL_SHORT")))
 
 
-def device_get_wwid(udev_info):
-    """ The WWID of a device is typically just its serial number, but with
-        colons in the name to make it more readable. """
-    serial = device_get_serial(udev_info)
-    return util.insert_colons(serial) if serial else ""
+def device_get_wwn(udev_info):
+    return udev_info.get("ID_WWN")
 
 
 def device_get_vendor(udev_info):

--- a/doc/api/devices.rst
+++ b/doc/api/devices.rst
@@ -17,6 +17,7 @@ devices
     * :class:`~blivet.devices.disk.DiskDevice` (see :ref:`inherited public API <StorageDeviceAPI>`)
         * :attr:`~blivet.devices.storage.StorageDevice.model`
         * :attr:`~blivet.devices.storage.StorageDevice.vendor`
+        * :attr:`~blivet.devices.storage.DiskDevice.wwn`
 
 * :mod:`~blivet.devices.file`
     * :class:`~blivet.devices.file.DirectoryDevice` (see :ref:`inherited public API <StorageDeviceAPI>`)

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -548,7 +548,15 @@ class DiskDevicePopulatorTestCase(PopulatorHelperTestCase):
         device_get_name = args[0]
 
         devicetree = DeviceTree()
+
+        # set up some fake udev data to verify handling of specific entries
         data = Mock()
+        _data = {"ID_WWN": "0x5000c50086fb75ca"}
+
+        def _getitem_(key, extra=None):
+            return _data.get(key, extra)
+        data.get = Mock(side_effect=_getitem_)
+        data.__getitem__ = Mock(side_effect=_getitem_)
 
         device_name = "nop"
         device_get_name.return_value = device_name
@@ -558,6 +566,7 @@ class DiskDevicePopulatorTestCase(PopulatorHelperTestCase):
         self.assertIsInstance(device, DiskDevice)
         self.assertTrue(device.exists)
         self.assertTrue(device.is_disk)
+        self.assertEqual(device.wwn, _data["ID_WWN"])
         self.assertEqual(device.name, device_name)
         self.assertTrue(device in devicetree.devices)
 
@@ -692,7 +701,15 @@ class MultipathDevicePopulatorTestCase(PopulatorHelperTestCase):
         add_slave_devices = args[1]
 
         devicetree = DeviceTree()
-        data = {"DM_UUID": "1-2-3-4"}
+        # set up some fake udev data to verify handling of specific entries
+        data = Mock()
+        _data = {"ID_WWN": "0x5000c50086fb75ca",
+                 "DM_UUID": "1-2-3-4"}
+
+        def _getitem_(key, extra=None):
+            return _data.get(key, extra)
+        data.get = Mock(side_effect=_getitem_)
+        data.__getitem__ = Mock(side_effect=_getitem_)
 
         device_name = "mpathtest"
         device_get_name.return_value = device_name
@@ -710,6 +727,7 @@ class MultipathDevicePopulatorTestCase(PopulatorHelperTestCase):
         self.assertIsInstance(device, MultipathDevice)
         self.assertTrue(device.exists)
         self.assertEqual(device.name, device_name)
+        self.assertEqual(device.wwn, _data["ID_WWN"])
         self.assertTrue(device in devicetree.devices)
 
 


### PR DESCRIPTION
One tricky bit is that I'm removing the `serial` constructor argument to `MultipathDevice`, which has until now been used as a stand-in for WWN. The `MultipathDevice` constructor is not listed as part of the public API, so I think this should be okay.

It's too bad that `DMRaidArrayDevice` and `MultipathDevice` do not derive from `DiskDevice` -- it would have made this (and #485) much simpler.