### PR TITLE
Use distutils.spawn.find_executable instead of our custom code

### DIFF
--- a/blivet/iscsi.py
+++ b/blivet/iscsi.py
@@ -29,6 +29,7 @@ import shutil
 import time
 import itertools
 from collections import namedtuple
+from distutils.spawn import find_executable
 
 import gi
 gi.require_version("GLib", "2.0")
@@ -57,7 +58,7 @@ def has_iscsi():
         return False
 
     if not ISCSID:
-        location = util.find_program_in_path("iscsid")
+        location = find_executable("iscsid")
         if not location:
             return False
         ISCSID = location
@@ -339,14 +340,13 @@ class iSCSI(object):
         util.run_program(['modprobe', '-a'] + ISCSI_MODULES)
         # iscsiuio is needed by Broadcom offload cards (bnx2i). Currently
         # not present in iscsi-initiator-utils for Fedora.
-        try:
-            iscsiuio = util.find_program_in_path('iscsiuio',
-                                                 raise_on_error=True)
-        except RuntimeError:
-            log.info("iscsi: iscsiuio not found.")
-        else:
+        iscsiuio = find_executable('iscsiuio')
+        if iscsiuio:
             log.debug("iscsi: iscsiuio is at %s", iscsiuio)
             util.run_program([iscsiuio])
+        else:
+            log.info("iscsi: iscsiuio not found.")
+
         # run the daemon
         util.run_program([ISCSID])
         time.sleep(1)

--- a/blivet/tasks/availability.py
+++ b/blivet/tasks/availability.py
@@ -21,6 +21,7 @@
 
 import abc
 from distutils.version import LooseVersion
+from distutils.spawn import find_executable
 import hawkey
 
 from six import add_metaclass
@@ -30,7 +31,6 @@ gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 
-from .. import util
 from ..errors import AvailabilityError
 
 import logging
@@ -109,7 +109,7 @@ class Path(Method):
             :returns: [] if the name of the application is in the path
             :rtype: list of str
         """
-        if not util.find_program_in_path(resource.name):
+        if not find_executable(resource.name):
             return ["application %s is not in $PATH" % resource.name]
         else:
             return []

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -496,16 +496,6 @@ def reset_file_context(path, root=None):
 ##
 
 
-def find_program_in_path(prog, raise_on_error=False):
-    for d in os.environ["PATH"].split(os.pathsep):
-        full = os.path.join(d, prog)
-        if os.access(full, os.X_OK):
-            return full
-
-    if raise_on_error:
-        raise RuntimeError("Unable to locate a needed executable: '%s'" % prog)
-
-
 def makedirs(path):
     if not os.path.isdir(path):
         os.makedirs(path, 0o755)


### PR DESCRIPTION
It is the same except that it doesn't raise an exception if the
executable is not found. Which we, however, don't need.