### PR TITLE
Fix resolve_devspec to fully support raid devices (#1445723)

### DIFF
--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -84,6 +84,7 @@ def resolve_devspec(devspec, sysname=False):
     from . import devices
 
     devname = devices.devicePathToName(devspec)
+    get_name = device_get_name
 
     ret = None
     for dev in get_devices():
@@ -98,6 +99,10 @@ def resolve_devspec(devspec, sysname=False):
         elif device_get_name(dev) == devname or dev.sys_name == devname:
             ret = dev
             break
+        elif device_get_md_name(dev) == devname:
+            get_name = device_get_md_name
+            ret = dev
+            break
         else:
             spec = devspec
             if not spec.startswith("/dev/"):
@@ -109,7 +114,7 @@ def resolve_devspec(devspec, sysname=False):
                     break
 
     if ret:
-        return ret.sys_name if sysname else device_get_name(ret)
+        return ret.sys_name if sysname else get_name(ret)
 
 def resolve_glob(glob):
     import fnmatch


### PR DESCRIPTION
Return md name if it matches a device name for the given device
specification, so the device names are consistent when we work
with udev module and a devicetree.

Resolves: rhbz#1445723