### PR TITLE
Update md boot metadata version selection.

### DIFF
--- a/blivet/devices/md.py
+++ b/blivet/devices/md.py
@@ -551,16 +551,8 @@ class MDRaidArrayDevice(ContainerDevice):
         """ Determine create parameters for this set """
         mountpoints = kwargs.pop("mountpoints")
         log_method_call(self, self.name, mountpoints)
-
-        if "/boot" in mountpoints:
-            bootmountpoint = "/boot"
-        else:
-            bootmountpoint = "/"
-
-        # If we are used to boot from we cannot use 1.1 metadata
-        if getattr(self.format, "mountpoint", None) == bootmountpoint or \
-           getattr(self.format, "mountpoint", None) == "/boot/efi" or \
-           self.format.type == "prepboot":
+        # UEFI firmware/bootloader cannot read 1.1 or 1.2 metadata arrays
+        if getattr(self.format, "mountpoint", None) == "/boot/efi":
             self.metadataVersion = "1.0"
 
     def _postCreate(self):

--- a/blivet/devices/md.py
+++ b/blivet/devices/md.py
@@ -547,10 +547,9 @@ class MDRaidArrayDevice(ContainerDevice):
 
         self._postTeardown(recursive=recursive)
 
-    def preCommitFixup(self, *args, **kwargs):
+    def preCommitFixup(self):
         """ Determine create parameters for this set """
-        mountpoints = kwargs.pop("mountpoints")
-        log_method_call(self, self.name, mountpoints)
+        log_method_call(self, self.name)
         # UEFI firmware/bootloader cannot read 1.1 or 1.2 metadata arrays
         if getattr(self.format, "mountpoint", None) == "/boot/efi":
             self.metadataVersion = "1.0"

--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -351,7 +351,7 @@ class PartitionDevice(StorageDevice):
     partedPartition = property(lambda d: d._getPartedPartition(),
                                lambda d,p: d._setPartedPartition(p))
 
-    def preCommitFixup(self, *args, **kwargs):
+    def preCommitFixup(self):
         """ Re-get self.partedPartition from the original disklabel. """
         log_method_call(self, self.name)
         if not self.exists or not self.disklabelSupported:

--- a/blivet/devices/storage.py
+++ b/blivet/devices/storage.py
@@ -715,7 +715,7 @@ class StorageDevice(Device):
                       lambda d,f: d._setFormat(f),
                       doc="The device's formatting.")
 
-    def preCommitFixup(self, *args, **kwargs):
+    def preCommitFixup(self):
         """ Do any necessary pre-commit fixups."""
         pass
 


### PR DESCRIPTION
This is a backport from master and has been verified to resolve the referenced bug. I don't see any risk, given that the behavior has not caused problems in recent fedora and the reporter verified the fix.