### PR TITLE
Respect thin pool's min size when setting its req_size

### DIFF
--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -2306,7 +2306,7 @@ def growLVM(storage):
         for lv in fatlvs:
             if lv in vg.thinpools:
                 # make sure the pool's base size is at least the sum of its lvs'
-                lv.req_size = max(lv.req_size, lv.usedSpace)
+                lv.req_size = max(lv.minSize, lv.req_size, lv.usedSpace)
                 lv.size = lv.req_size
 
         # establish sizes for the percentage-based requests (which are fixed)


### PR DESCRIPTION
When setting thin pool's size based on the sum of its thin LVs we
need respect its minimum size. That can for example be its actual
size if it already exists.

Together with the recent changes for thin pool padding this

Resolves: rhbz#1435180