### PR TITLE
Updated calls to avoid log spamming

### DIFF
--- a/blivet/udev.py
+++ b/blivet/udev.py
@@ -24,36 +24,56 @@
 import os
 import re
 import subprocess
+import logging
+import pyudev
 
 from . import util
 from .size import Size
 from .flags import flags
 
-import pyudev
 global_udev = pyudev.Context()
-
-import logging
 log = logging.getLogger("blivet")
 
 INSTALLER_BLACKLIST = (r'^mtd', r'^mmcblk.+boot', r'^mmcblk.+rpmb', r'^zram', r'ndblk', r'pmem')
 """ device name regexes to ignore when flags.installer_mode is True """
 
 
+def device_to_dict(device):
+    # Transform Device to dictionary
+    # Originally it was possible to use directly Device where needed,
+    # but it lead to unfixable excessive deprecation warnings from udev.
+    # Sice blivet uses Device.properties only (with couple of exceptions)
+    # this is a functional workaround. (japokorn May 2017)
+
+    result = dict(device.properties)
+    result["SYS_NAME"] = device.sys_name
+    result["SYS_PATH"] = device.sys_path
+    return result
+
+
 def get_device(sysfs_path):
     try:
-        dev = pyudev.Devices.from_sys_path(global_udev, sysfs_path)
+        device = pyudev.Devices.from_sys_path(global_udev, sysfs_path)
     except pyudev.DeviceNotFoundError as e:
         log.error(e)
-        dev = None
+        result = None
+    else:
+        result = device_to_dict(device)
 
-    return dev
+    return result
 
 
 def get_devices(subsystem="block"):
     if not flags.uevents:
         settle()
-    return [d for d in global_udev.list_devices(subsystem=subsystem)
-            if not __is_blacklisted_blockdev(d.sys_name)]
+
+    result = []
+    for device in global_udev.list_devices(subsystem=subsystem):
+        if not __is_blacklisted_blockdev(device.sys_name):
+            dev = device_to_dict(device)
+            result.append(dev)
+
+    return result
 
 
 def settle(quiet=False):
@@ -101,7 +121,7 @@ def resolve_devspec(devspec, sysname=False):
             if device_get_uuid(dev) == devspec[5:]:
                 ret = dev
                 break
-        elif device_get_name(dev) == devname or dev.sys_name == devname:
+        elif device_get_name(dev) == devname or dev["SYS_NAME"] == devname:
             ret = dev
             break
         else:
@@ -115,7 +135,7 @@ def resolve_devspec(devspec, sysname=False):
                     break
 
     if ret:
-        return ret.sys_name if sysname else device_get_name(ret)
+        return ret["SYS_NAME"] if sysname else device_get_name(ret)
 
 
 def resolve_glob(glob):
@@ -176,7 +196,7 @@ def device_get_name(udev_info):
         # md partitions have MD_DEVNAME set to the partition's parent/disk
         name = udev_info["MD_DEVNAME"]
     else:
-        name = udev_info.sys_name
+        name = udev_info["SYS_NAME"]
 
     return name
 
@@ -396,7 +416,7 @@ def device_get_by_path(info):
 
 
 def device_get_sysfs_path(info):
-    return info.sys_path
+    return info["SYS_PATH"]
 
 
 def device_get_major(info):
@@ -669,7 +689,7 @@ def device_get_partition_disk(info):
                 disk = resolve_devspec(parents[0].replace('!', '/'))
     else:
         _disk = os.path.basename(os.path.dirname(sysfs_path).replace('!', '/'))
-        if info.sys_name.startswith(_disk):
+        if info["SYS_NAME"].startswith(_disk):
             disk = resolve_devspec(_disk)
 
     return disk

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -120,7 +120,7 @@ class DMDevicePopulatorTestCase(PopulatorHelperTestCase):
         """Test get_device_helper for dm devices."""
         device_is_dm = args[0]
         device_is_dm_lvm = args[6]
-        data = Mock()
+        data = {'SYS_PATH': 'dummy'}
         self.assertEqual(get_device_helper(data), self.helper_class)
 
         # verify that setting one of the required True return values to False prevents success
@@ -202,7 +202,7 @@ class LoopDevicePopulatorTestCase(PopulatorHelperTestCase):
         """Test get_device_helper for loop devices."""
         device_is_loop = args[0]
         get_backing_file = args[7]
-        data = Mock()
+        data = {'SYS_PATH': 'dummy'}
         get_backing_file.return_value = True
         self.assertEqual(get_device_helper(data), self.helper_class)
 
@@ -280,7 +280,7 @@ class LVMDevicePopulatorTestCase(PopulatorHelperTestCase):
     def test_get_helper(self, *args):
         """Test get_device_helper for lvm devices."""
         device_is_dm_lvm = args[0]
-        data = Mock()
+        data = {'SYS_PATH': 'dummy'}
         self.assertEqual(get_device_helper(data), self.helper_class)
 
         # verify that setting one of the required True return values to False prevents success
@@ -367,7 +367,7 @@ class OpticalDevicePopulatorTestCase(PopulatorHelperTestCase):
     def test_get_helper(self, *args):
         """Test get_device_helper for optical devices."""
         device_is_cdrom = args[0]
-        data = Mock()
+        data = {'SYS_PATH': 'dummy'}
         self.assertEqual(get_device_helper(data), self.helper_class)
 
         # verify that setting one of the required True return values to False prevents success
@@ -431,7 +431,7 @@ class PartitionDevicePopulatorTestCase(PopulatorHelperTestCase):
         """Test get_device_helper for partitions."""
         device_is_partition = args[0]
         device_is_loop = args[2]
-        data = Mock()
+        data = {'SYS_PATH': 'dummy'}
         self.assertEqual(get_device_helper(data), self.helper_class)
 
         # verify that setting one of the required True return values to False prevents success
@@ -465,7 +465,7 @@ class PartitionDevicePopulatorTestCase(PopulatorHelperTestCase):
         get_device_by_name = args[2]
 
         devicetree = DeviceTree()
-        data = Mock()
+        data = {'SYS_PATH': 'dummy'}
 
         # for every case:
         #   1. device(s) in tree
@@ -548,7 +548,7 @@ class DiskDevicePopulatorTestCase(PopulatorHelperTestCase):
         device_get_name = args[0]
 
         devicetree = DeviceTree()
-        data = Mock()
+        data = {'SYS_PATH': 'dummy'}
 
         device_name = "nop"
         device_get_name.return_value = device_name


### PR DESCRIPTION
Fix of excessive deprecation warnings in the logs.

Due to nature of deprecation warnings origin (e.g. __getitem__ or
__iter__ methods) it was almost impossible to find and fix all of its
sources. Instead the Device class was substituted with its 'properties'
attribute which directly fixes the problem.
Couple of other minor changes was neccessary, though.