### PR TITLE
Always mount & unmount an XFS file system when writing new UUID

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -1076,19 +1076,15 @@ class XFS(FS):
            Raises an FSError if the UUID can not be set.
         """
 
+        # try to mount and umount the FS first to make sure it is clean
+        tmpdir = tempfile.mkdtemp(prefix="fs-tmp-mnt")
         try:
-            super().write_uuid()
-        except FSWriteUUIDError:
-            # try to mount and umount the FS to make sure it is clean
-            tmpdir = tempfile.mkdtemp(prefix="fs-tmp-mnt")
-            try:
-                self.mount(mountpoint=tmpdir, options="nouuid")
-                self.unmount()
-            finally:
-                os.rmdir(tmpdir)
+            self.mount(mountpoint=tmpdir, options="nouuid")
+            self.unmount()
+        finally:
+            os.rmdir(tmpdir)
 
-            # and now try one more time
-            super().write_uuid()
+        super().write_uuid()
 
 register_device_format(XFS)
 


### PR DESCRIPTION
This is needed when the file system is not clean (e.g. if it was
created as a snapshot of some other mounted file system) which is
quite a common case. And since 'xfs_admin' exits with code 0 even
when it fails to set the UUID [1], we cannot do a second/fallback
try. The first one has to have the best chance to succeed, hence
this patch.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1450423