### PR TITLE
python2 compatibility, part 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ install-requires:
 
 test: check-requires
 	@echo "*** Running unittests with $(PYTHON) ***"
-	PYTHONPATH=. $(PYTHON) -m unittest discover -v -s tests/ -p '*_test.py'
+	PYTHONPATH=.:$(PYTHONPATH) $(PYTHON) -m unittest discover -v -s tests/ -p '*_test.py'
 
 coverage: check-requires
 	@echo "*** Running unittests with $(COVERAGE) for $(PYTHON) ***"

--- a/blivet/actionlist.py
+++ b/blivet/actionlist.py
@@ -22,6 +22,7 @@
 
 import copy
 from functools import wraps
+from six import add_metaclass
 
 from .callbacks import callbacks as _callbacks
 from .deviceaction import ActionCreateDevice
@@ -53,7 +54,8 @@ def with_flag(flag_attr):
     return run_func_with_flag_attr_set
 
 
-class ActionList(object, metaclass=SynchronizedMeta):
+@add_metaclass(SynchronizedMeta)
+class ActionList(object):
     _unsynchronized_methods = ['process']
 
     def __init__(self, addfunc=None, removefunc=None):

--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -27,6 +27,7 @@ import contextlib
 import time
 import parted
 import functools
+from six import add_metaclass
 
 from pykickstart.constants import AUTOPART_TYPE_LVM, CLEARPART_TYPE_ALL, CLEARPART_TYPE_LINUX, CLEARPART_TYPE_LIST, CLEARPART_TYPE_NONE
 
@@ -109,7 +110,8 @@ class StorageDiscoveryConfig(object):
         self.zero_mbr = ksdata.zerombr.zerombr
 
 
-class Blivet(object, metaclass=SynchronizedMeta):
+@add_metaclass(SynchronizedMeta)
+class Blivet(object):
 
     """ Top-level class for managing storage configuration. """
 

--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -27,7 +27,7 @@ import contextlib
 import time
 import parted
 import functools
-from six import add_metaclass
+import six
 
 from pykickstart.constants import AUTOPART_TYPE_LVM, CLEARPART_TYPE_ALL, CLEARPART_TYPE_LINUX, CLEARPART_TYPE_LIST, CLEARPART_TYPE_NONE
 
@@ -110,7 +110,7 @@ class StorageDiscoveryConfig(object):
         self.zero_mbr = ksdata.zerombr.zerombr
 
 
-@add_metaclass(SynchronizedMeta)
+@six.add_metaclass(SynchronizedMeta)
 class Blivet(object):
 
     """ Top-level class for managing storage configuration. """
@@ -1890,7 +1890,7 @@ class Blivet(object):
 
         devices.sort(key=lambda d: len(d.ancestors))
         for device in devices:
-            cls = next((c for c in ks_map if isinstance(device, c)), None)
+            cls = six.next((c for c in ks_map if isinstance(device, c)), None)
             if cls is None:
                 log.info("omitting ksdata: %s", device)
                 continue

--- a/blivet/callbacks.py
+++ b/blivet/callbacks.py
@@ -84,7 +84,7 @@ ReportProgressData = namedtuple("ReportProgressData",
 #
 # Callbacks for changes to the model.
 #
-class CallbackList:
+class CallbackList(object):
     def __init__(self):
         self._cb_list = list()
 
@@ -102,7 +102,7 @@ class CallbackList:
             cb(*args, **kwargs)
 
 
-class Callbacks:
+class Callbacks(object):
     """A collection of callbacks for various events
 
        Each trigger/event gets a list of callbacks to run, represented by an

--- a/blivet/dbus/action.py
+++ b/blivet/dbus/action.py
@@ -26,7 +26,7 @@ from .object import DBusObject
 class DBusAction(DBusObject):
     def __init__(self, action, manager):
         self._action = action
-        super().__init__(manager)
+        super(DBusAction, self).__init__(manager)
 
     @property
     def id(self):

--- a/blivet/dbus/blivet.py
+++ b/blivet/dbus/blivet.py
@@ -21,13 +21,13 @@ import sys
 
 import dbus
 
-from blivet import Blivet
-from blivet.callbacks import callbacks
-from blivet.devicefactory import DEVICE_TYPE_PARTITION, DEVICE_TYPE_LVM, DEVICE_TYPE_LVM_THINP
-from blivet.devicefactory import DEVICE_TYPE_MD, DEVICE_TYPE_BTRFS
-from blivet.errors import StorageError
-from blivet.size import Size
-from blivet.util import ObjectID
+from .. import Blivet
+from ..callbacks import callbacks
+from ..devicefactory import DEVICE_TYPE_PARTITION, DEVICE_TYPE_LVM, DEVICE_TYPE_LVM_THINP
+from ..devicefactory import DEVICE_TYPE_MD, DEVICE_TYPE_BTRFS
+from ..errors import StorageError
+from ..size import Size
+from ..util import ObjectID
 from .action import DBusAction
 from .constants import BLIVET_INTERFACE, BLIVET_OBJECT_PATH, BUS_NAME
 from .device import DBusDevice

--- a/blivet/dbus/blivet.py
+++ b/blivet/dbus/blivet.py
@@ -47,7 +47,7 @@ class DBusBlivet(DBusObject):
         state.
     """
     def __init__(self, manager):
-        super().__init__(manager)
+        super(DBusBlivet, self).__init__(manager)
         self._blivet = Blivet()
         self._id = ObjectID().id
         self._manager.add_object(self)

--- a/blivet/dbus/device.py
+++ b/blivet/dbus/device.py
@@ -26,7 +26,7 @@ from .object import DBusObject
 class DBusDevice(DBusObject):
     def __init__(self, device, manager):
         self._device = device
-        super().__init__(manager)
+        super(DBusDevice, self).__init__(manager)
 
     @property
     def id(self):

--- a/blivet/dbus/format.py
+++ b/blivet/dbus/format.py
@@ -26,7 +26,7 @@ from .object import DBusObject
 class DBusFormat(DBusObject):
     def __init__(self, fmt, manager):
         self._format = fmt
-        super().__init__(manager)
+        super(DBusFormat, self).__init__(manager)
 
     @property
     def id(self):

--- a/blivet/dbus/manager.py
+++ b/blivet/dbus/manager.py
@@ -33,8 +33,8 @@ class ObjectManager(dbus.service.Object):
         self._objects = list()
         self._by_id = dict()
         self._by_path = dict()
-        super().__init__(bus_name=dbus.service.BusName(BUS_NAME, dbus.SystemBus()),
-                         object_path=OBJECT_MANAGER_PATH)
+        super(ObjectManager, self).__init__(bus_name=dbus.service.BusName(BUS_NAME, dbus.SystemBus()),
+                                            object_path=OBJECT_MANAGER_PATH)
 
     @dbus.service.method(dbus_interface=OBJECT_MANAGER_INTERFACE, out_signature='a{oa{sa{sv}}}')
     def GetManagedObjects(self):

--- a/blivet/dbus/object.py
+++ b/blivet/dbus/object.py
@@ -36,8 +36,8 @@ class DBusObject(dbus.service.Object):
     # constructor from running during unit testing.
     def _init_dbus_object(self):
         """ Initialize superclass. """
-        super().__init__(bus_name=dbus.service.BusName(BUS_NAME, dbus.SystemBus()),
-                         object_path=self.object_path)
+        super(DBusObject, self).__init__(bus_name=dbus.service.BusName(BUS_NAME, dbus.SystemBus()),
+                                         object_path=self.object_path)
 
     @property
     def present(self):
@@ -50,7 +50,7 @@ class DBusObject(dbus.service.Object):
         self._present = state
 
     def remove_from_connection(self, connection=None, path=None):
-        super().remove_from_connection(connection=connection, path=path)
+        super(DBusObject, self).remove_from_connection(connection=connection, path=path)
         self._object_path = None
 
     @property

--- a/blivet/deviceaction.py
+++ b/blivet/deviceaction.py
@@ -20,6 +20,8 @@
 # Red Hat Author(s): Dave Lehman <dlehman@redhat.com>
 #
 
+from six import add_metaclass
+
 from . import util
 from . import udev
 from .util import get_current_entropy
@@ -100,7 +102,8 @@ def resize_type_from_string(type_string):
             return k
 
 
-class DeviceAction(util.ObjectID, metaclass=SynchronizedMeta):
+@add_metaclass(SynchronizedMeta)
+class DeviceAction(util.ObjectID):
 
     """ An action that will be carried out in the future on a Device.
 

--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -20,6 +20,8 @@
 # Red Hat Author(s): David Lehman <dlehman@redhat.com>
 #
 
+from six import raise_from
+
 from .storage_log import log_method_call
 from .errors import DeviceFactoryError, StorageError
 from .devices import BTRFSDevice, DiskDevice
@@ -653,7 +655,7 @@ class DeviceFactory(object):
         except (StorageError, blockdev.BlockDevError) as e:
             log.error("device post-create method failed: %s", e)
             self.storage.destroy_device(device)
-            raise StorageError from e
+            raise_from(StorageError, e)
         else:
             if not device.size:
                 self.storage.destroy_device(device)
@@ -831,7 +833,7 @@ class DeviceFactory(object):
                 self._revert_devicetree()
 
             if not isinstance(e, (StorageError, OverflowError)):
-                raise DeviceFactoryError from e
+                raise_from(DeviceFactoryError, e)
 
             raise
 

--- a/blivet/devicelibs/edd.py
+++ b/blivet/devicelibs/edd.py
@@ -267,6 +267,12 @@ class EddEntry(object):
     def __repr__(self):
         return "<EddEntry%s>" % (self._fmt(' ', ''),)
 
+    def __getitem__(self, idx):
+        return str(self)[idx]
+
+    def __len__(self):
+        return len(str(self))
+
     def load(self):
         interface = util.get_sysfs_attr(self.sysfspath, "interface")
         # save this so we can log it from the matcher.

--- a/blivet/devicelibs/lvm.py
+++ b/blivet/devicelibs/lvm.py
@@ -185,3 +185,23 @@ def determine_parent_lv(internal_lv, lvs, lv_info):
 
 def lvmetad_socket_exists():
     return os.path.exists(LVMETAD_SOCKET_PATH)
+
+
+def is_lvm_name_valid(name):
+    # No . or ..
+    if name == '.' or name == '..':
+        return False
+
+    # Check that all characters are in the allowed set and that the name
+    # does not start with a -
+    if not re.match('^[a-zA-Z0-9+_.][a-zA-Z0-9+_.-]*$', name):
+        return False
+
+    # According to the LVM developers, vgname + lvname is limited to 126 characters
+    # minus the number of hyphens, and possibly minus up to another 8 characters
+    # in some unspecified set of situations. Instead of figuring all of that out,
+    # no one gets a vg or lv name longer than, let's say, 55.
+    if len(name) > 55:
+        return False
+
+    return True

--- a/blivet/devices/device.py
+++ b/blivet/devices/device.py
@@ -21,6 +21,7 @@
 #
 
 import pprint
+from six import add_metaclass
 
 from .. import util
 from ..storage_log import log_method_call
@@ -32,7 +33,8 @@ log = logging.getLogger("blivet")
 from .lib import ParentList
 
 
-class Device(util.ObjectID, metaclass=SynchronizedMeta):
+@add_metaclass(SynchronizedMeta)
+class Device(util.ObjectID):
 
     """ A generic device.
 

--- a/blivet/devices/disk.py
+++ b/blivet/devices/disk.py
@@ -361,12 +361,12 @@ class MultipathDevice(DMDevice):
             self.parents.append(parent)
 
     def _add_parent(self, parent):
-        super()._add_parent(parent)
+        super(MultipathDevice, self)._add_parent(parent)
         if Tags.remote not in self.tags and Tags.remote in parent.tags:
             self.tags.add(Tags.remote)
 
     def _remove_parent(self, parent):
-        super()._remove_parent(parent)
+        super(MultipathDevice, self)._remove_parent(parent)
         if Tags.remote in self.tags and Tags.remote in parent.tags and \
            not any(p for p in self.parents if Tags.remote in p.tags and p != parent):
             self.tags.remove(Tags.remote)

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -28,6 +28,7 @@ import time
 from collections import namedtuple
 from functools import wraps
 from enum import Enum
+import six
 
 import gi
 gi.require_version("BlockDev", "2.0")
@@ -1557,8 +1558,8 @@ class LVMThinPoolMixin(object):
                 extra["profile"] = profile_name
             if self.chunk_size:
                 extra["chunksize"] = str(int(self.chunk_size))
-            data_lv = next(lv for lv in self._internal_lvs if lv.int_lv_type == LVMInternalLVtype.data)
-            meta_lv = next(lv for lv in self._internal_lvs if lv.int_lv_type == LVMInternalLVtype.meta)
+            data_lv = six.next(lv for lv in self._internal_lvs if lv.int_lv_type == LVMInternalLVtype.data)
+            meta_lv = six.next(lv for lv in self._internal_lvs if lv.int_lv_type == LVMInternalLVtype.meta)
             blockdev.lvm.thpool_convert(self.vg.name, data_lv.lvname, meta_lv.lvname, self.lvname, **extra)
             # TODO: update the names of the internal LVs here
         else:

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -538,10 +538,10 @@ class LVMVolumeGroupDevice(ContainerDevice):
             for pv in self.pvs:
                 pv.format.vg_name = None
 
-        super().remove_hook(modparent=modparent)
+        super(LVMVolumeGroupDevice, self).remove_hook(modparent=modparent)
 
     def add_hook(self, new=True):
-        super().add_hook(new=new)
+        super(LVMVolumeGroupDevice, self).add_hook(new=new)
         if new:
             return
 
@@ -865,7 +865,7 @@ class LVMLogicalVolumeBase(DMDevice, RaidDevice):
         if self.vg is not None:
             return "%s-%s" % (self.vg.name, self._name)
         else:
-            return super()._get_name()
+            return super(LVMLogicalVolumeBase, self)._get_name()
 
     def check_size(self):
         """ Check to make sure the size of the device is allowed by the
@@ -1887,7 +1887,7 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
     @type_specific
     def vg(self):
         """This Logical Volume's Volume Group."""
-        return super().vg
+        return super(LVMLogicalVolumeDevice, self).vg
 
     @type_specific
     def _set_size(self, newsize):
@@ -1919,7 +1919,7 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
     @type_specific
     def vg_space_used(self):
         """ Space occupied by this LV, not including snapshots. """
-        return super().vg_space_used
+        return super(LVMLogicalVolumeDevice, self).vg_space_used
 
     @type_specific
     def _set_format(self, fmt):
@@ -1946,12 +1946,12 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
     @property
     @type_specific
     def growable(self):
-        return super().growable
+        return super(LVMLogicalVolumeDevice, self).growable
 
     @property
     @type_specific
     def readonly(self):
-        return super().readonly
+        return super(LVMLogicalVolumeDevice, self).readonly
 
     @property
     @type_specific
@@ -2075,12 +2075,12 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
     @property
     @type_specific
     def resizable(self):
-        return super().resizable
+        return super(LVMLogicalVolumeDevice, self).resizable
 
     @property
     @type_specific
     def format_immutable(self):
-        return super().format_immutable
+        return super(LVMLogicalVolumeDevice, self).format_immutable
 
     @type_specific
     def depends_on(self, dep):

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -560,23 +560,7 @@ class LVMVolumeGroupDevice(ContainerDevice):
         # reserved percent/space
 
     def is_name_valid(self, name):
-        # No . or ..
-        if name == '.' or name == '..':
-            return False
-
-        # Check that all characters are in the allowed set and that the name
-        # does not start with a -
-        if not re.match('^[a-zA-Z0-9+_.][a-zA-Z0-9+_.-]*$', name):
-            return False
-
-        # According to the LVM developers, vgname + lvname is limited to 126 characters
-        # minus the number of hyphens, and possibly minus up to another 8 characters
-        # in some unspecified set of situations. Instead of figuring all of that out,
-        # no one gets a vg or lv name longer than, let's say, 55.
-        if len(name) > 55:
-            return False
-
-        return True
+        return lvm.is_lvm_name_valid(name)
 
 
 class LVMLogicalVolumeBase(DMDevice, RaidDevice):
@@ -2130,10 +2114,7 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
 
     @type_specific
     def is_name_valid(self, name):
-        # Check that the LV name is valid
-
-        # Start with the checks shared with volume groups
-        if not LVMVolumeGroupDevice.is_name_valid(self, name):
+        if not lvm.is_lvm_name_valid(name):
             return False
 
         # And now the ridiculous ones

--- a/blivet/devices/partition.py
+++ b/blivet/devices/partition.py
@@ -693,7 +693,7 @@ class PartitionDevice(StorageDevice):
 
     @property
     def protected(self):
-        protected = super().protected
+        protected = super(PartitionDevice, self).protected
 
         # extended partition is protected also when one of its logical partitions is protected
         if self.is_extended:

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -23,6 +23,7 @@
 import os
 import pprint
 import re
+from six import add_metaclass
 
 import gi
 gi.require_version("BlockDev", "2.0")
@@ -49,7 +50,8 @@ log = logging.getLogger("blivet")
 _LVM_DEVICE_CLASSES = (LVMLogicalVolumeDevice, LVMVolumeGroupDevice)
 
 
-class DeviceTreeBase(object, metaclass=SynchronizedMeta):
+@add_metaclass(SynchronizedMeta)
+class DeviceTreeBase(object):
     """ A quasi-tree that represents the devices in the system.
 
         The tree contains a list of :class:`~.devices.StorageDevice` instances,

--- a/blivet/devicetree.py
+++ b/blivet/devicetree.py
@@ -23,7 +23,7 @@
 import os
 import pprint
 import re
-from six import add_metaclass
+import six
 
 import gi
 gi.require_version("BlockDev", "2.0")
@@ -50,7 +50,7 @@ log = logging.getLogger("blivet")
 _LVM_DEVICE_CLASSES = (LVMLogicalVolumeDevice, LVMVolumeGroupDevice)
 
 
-@add_metaclass(SynchronizedMeta)
+@six.add_metaclass(SynchronizedMeta)
 class DeviceTreeBase(object):
     """ A quasi-tree that represents the devices in the system.
 
@@ -478,7 +478,7 @@ class DeviceTreeBase(object):
         result = None
         if path:
             devices = self._filter_devices(incomplete=incomplete, hidden=hidden)
-            result = next((d for d in devices if d.sysfs_path == path), None)
+            result = six.next((d for d in devices if d.sysfs_path == path), None)
         log_method_return(self, result)
         return result
 
@@ -495,7 +495,7 @@ class DeviceTreeBase(object):
         result = None
         if uuid:
             devices = self._filter_devices(incomplete=incomplete, hidden=hidden)
-            result = next((d for d in devices if d.uuid == uuid or d.format.uuid == uuid), None)
+            result = six.next((d for d in devices if d.uuid == uuid or d.format.uuid == uuid), None)
         log_method_return(self, result)
         return result
 
@@ -512,7 +512,7 @@ class DeviceTreeBase(object):
         result = None
         if label:
             devices = self._filter_devices(incomplete=incomplete, hidden=hidden)
-            result = next((d for d in devices if getattr(d.format, "label", None) == label), None)
+            result = six.next((d for d in devices if getattr(d.format, "label", None) == label), None)
         log_method_return(self, result)
         return result
 
@@ -529,9 +529,9 @@ class DeviceTreeBase(object):
         result = None
         if name:
             devices = self._filter_devices(incomplete=incomplete, hidden=hidden)
-            result = next((d for d in devices if d.name == name or
-                           (isinstance(d, _LVM_DEVICE_CLASSES) and d.name == name.replace("--", "-"))),
-                          None)
+            result = six.next((d for d in devices if d.name == name or
+                               (isinstance(d, _LVM_DEVICE_CLASSES) and d.name == name.replace("--", "-"))),
+                              None)
         log_method_return(self, result)
         return result
 
@@ -555,9 +555,9 @@ class DeviceTreeBase(object):
             # The usual order of the devices list is one where leaves are at
             # the end. So that the search can prefer leaves to interior nodes
             # the list that is searched is the reverse of the devices list.
-            result = next((d for d in reversed(list(devices)) if d.path == path or
-                           (isinstance(d, _LVM_DEVICE_CLASSES) and d.path == path.replace("--", "-"))),
-                          None)
+            result = six.next((d for d in reversed(list(devices)) if d.path == path or
+                               (isinstance(d, _LVM_DEVICE_CLASSES) and d.path == path.replace("--", "-"))),
+                              None)
 
         log_method_return(self, result)
         return result
@@ -573,7 +573,7 @@ class DeviceTreeBase(object):
         """
         log_method_call(self, id_num=id_num, incomplete=incomplete, hidden=hidden)
         devices = self._filter_devices(incomplete=incomplete, hidden=hidden)
-        result = next((d for d in devices if d.id == id_num), None)
+        result = six.next((d for d in devices if d.id == id_num), None)
         log_method_return(self, result)
         return result
 

--- a/blivet/errors.py
+++ b/blivet/errors.py
@@ -202,7 +202,7 @@ class UnusableConfigurationError(StorageError):
     suggestion = ""
 
     def __init__(self, message, dev_name=None):
-        super().__init__(message)
+        super(UnusableConfigurationError, self).__init__(message)
         self.dev_name = dev_name
 
 

--- a/blivet/events/handler.py
+++ b/blivet/events/handler.py
@@ -38,7 +38,7 @@ event_log = logging.getLogger("blivet.event")
 
 
 @add_metaclass(SynchronizedMeta)
-class EventHandlerMixin:
+class EventHandlerMixin(object):
     def __init__(self):
         event_manager.handler_cb = self.handle_event
 

--- a/blivet/events/handler.py
+++ b/blivet/events/handler.py
@@ -20,6 +20,8 @@
 # Red Hat Author(s): David Lehman <dlehman@redhat.com>
 #
 
+from six import add_metaclass
+
 from ..callbacks import callbacks
 from ..errors import DeviceError, EventHandlingError
 from ..devices import DM_MAJORS, MD_MAJORS
@@ -35,7 +37,8 @@ log = logging.getLogger("blivet")
 event_log = logging.getLogger("blivet.event")
 
 
-class EventHandlerMixin(metaclass=SynchronizedMeta):
+@add_metaclass(SynchronizedMeta)
+class EventHandlerMixin:
     def __init__(self):
         event_manager.handler_cb = self.handle_event
 

--- a/blivet/events/manager.py
+++ b/blivet/events/manager.py
@@ -270,8 +270,8 @@ class EventManager(object):
 
         t = Thread(target=self._run_event_handler,
                    name="event%d" % event.id,
-                   kwargs={"event": event},
-                   daemon=True)
+                   kwargs={"event": event})
+        t.daemon = True  # py2 compat
         t.start()
 
     def _run_event_handler(self, event):

--- a/blivet/events/manager.py
+++ b/blivet/events/manager.py
@@ -298,7 +298,7 @@ class EventManager(object):
 
 class UdevEventManager(EventManager):
     def __init__(self, handler_cb=None, notify_cb=None):
-        super().__init__(handler_cb=handler_cb, notify_cb=notify_cb)
+        super(UdevEventManager, self).__init__(handler_cb=handler_cb, notify_cb=notify_cb)
         self._pyudev_observer = None
 
     @property
@@ -307,7 +307,7 @@ class UdevEventManager(EventManager):
 
     def enable(self):
         """ Enable monitoring and handling of block device uevents. """
-        super().enable()
+        super(UdevEventManager, self).enable()
         monitor = pyudev.Monitor.from_netlink(udev.global_udev)
         monitor.filter_by("block")
         self._pyudev_observer = pyudev.MonitorObserver(monitor,
@@ -319,7 +319,7 @@ class UdevEventManager(EventManager):
 
     def disable(self):
         """ Disable monitoring and handling of block device uevents. """
-        super().disable()
+        super(UdevEventManager, self).disable()
         if self.enabled:
             self._pyudev_observer.stop()
 

--- a/blivet/events/manager.py
+++ b/blivet/events/manager.py
@@ -49,22 +49,18 @@ def validate_cb(cb, kwargs=None, arg_count=None):
     kwargs = kwargs or []
     arg_count = arg_count or 0
 
-    params = inspect.signature(cb).parameters
+    if six.PY2:
+        argspec = inspect.getargspec(cb)  # pylint: disable=deprecated-method
+        if argspec.varargs or argspec.keywords:
+            return True
+        params = argspec.args
+    else:
+        params = list(inspect.signature(cb).parameters.keys())
+
     if len(params) < arg_count:
         return False
 
-    if not all(kw in params for kw in kwargs):
-        return False
-
-    for kw in kwargs:
-        if kw not in params:
-            return False
-
-        p = params[kw]
-        if p.kind not in (p.KEYWORD_ONLY, p.POSITIONAL_OR_KEYWORD):
-            return False
-
-    return True
+    return all(kw in params for kw in kwargs)
 
 
 #

--- a/blivet/events/manager.py
+++ b/blivet/events/manager.py
@@ -24,6 +24,7 @@ import abc
 import inspect
 from threading import current_thread, RLock, Thread
 import pyudev
+from six import add_metaclass
 import sys
 import time
 import traceback
@@ -129,7 +130,8 @@ class EventMask(util.ObjectID):
 #
 # EventManager
 #
-class EventManager(object, metaclass=abc.ABCMeta):
+@add_metaclass(abc.ABCMeta)
+class EventManager(object):
     def __init__(self, handler_cb=None, notify_cb=None, error_cb=None):
         self._handler_cb = None
         """ event handler (must accept 'event', 'notify_cb' kwargs """

--- a/blivet/events/manager.py
+++ b/blivet/events/manager.py
@@ -24,7 +24,7 @@ import abc
 import inspect
 from threading import current_thread, RLock, Thread
 import pyudev
-from six import add_metaclass
+import six
 import sys
 import time
 import traceback
@@ -130,7 +130,7 @@ class EventMask(util.ObjectID):
 #
 # EventManager
 #
-@add_metaclass(abc.ABCMeta)
+@six.add_metaclass(abc.ABCMeta)
 class EventManager(object):
     def __init__(self, handler_cb=None, notify_cb=None, error_cb=None):
         self._handler_cb = None
@@ -218,7 +218,7 @@ class EventManager(object):
     def _mask_event(self, event):
         """ Return True if this event should be ignored """
         with self._lock:
-            return next((m for m in self._mask_list if m.match(event)), None) is not None
+            return six.next((m for m in self._mask_list if m.match(event)), None) is not None
 
     def add_mask(self, device=None, action=None, partitions=False):
         """ Add an event mask and return the new :class:`EventMask`.

--- a/blivet/formats/__init__.py
+++ b/blivet/formats/__init__.py
@@ -28,6 +28,7 @@ from gi.repository import BlockDev as blockdev
 
 import os
 import importlib
+from six import add_metaclass
 
 from ..util import get_sysfs_path_by_name
 from ..util import run_program
@@ -132,7 +133,8 @@ def get_device_format_class(fmt_type):
     return fmt
 
 
-class DeviceFormat(ObjectID, metaclass=SynchronizedMeta):
+@add_metaclass(SynchronizedMeta)
+class DeviceFormat(ObjectID):
 
     """ Generic device format.
 

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -1084,7 +1084,7 @@ class XFS(FS):
         finally:
             os.rmdir(tmpdir)
 
-        super().write_uuid()
+        super(XFS, self).write_uuid()
 
 register_device_format(XFS)
 

--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -1060,8 +1060,9 @@ class PartitionRequest(Request):
         sector_size = Size(partition.parted_partition.disk.device.sectorSize)
 
         if partition.req_grow:
-            req_format_max_size = min((size for size in (partition.req_max_size, partition.format.max_size)
-                                       if size > 0), default=Size(0))
+            mins = [size for size in (partition.req_max_size, partition.format.max_size)
+                    if size > 0]
+            req_format_max_size = min(mins) if mins else Size(0)
             limits = [l for l in (size_to_sectors(req_format_max_size, sector_size),
                                   partition.parted_partition.disk.maxPartitionLength) if l > 0]
 

--- a/blivet/populator/helpers/__init__.py
+++ b/blivet/populator/helpers/__init__.py
@@ -1,4 +1,5 @@
 import inspect as _inspect
+import six as _six
 
 from .devicepopulator import DevicePopulator
 from .formatpopulator import FormatPopulator
@@ -49,7 +50,7 @@ def get_device_helper(data):
         The helper lists are sorted according to priorities defined within each
         class. This function returns the first matching class.
     """
-    return next((h for h in _device_helpers if h.match(data)), None)
+    return _six.next((h for h in _device_helpers if h.match(data)), None)
 
 
 def get_format_helper(data, device):
@@ -58,4 +59,4 @@ def get_format_helper(data, device):
         The helper lists are sorted according to priorities defined within each
         class. This function returns the first matching class.
     """
-    return next((h for h in _format_helpers if h.match(data, device=device)), None)
+    return _six.next((h for h in _format_helpers if h.match(data, device=device)), None)

--- a/blivet/populator/helpers/boot.py
+++ b/blivet/populator/helpers/boot.py
@@ -58,7 +58,7 @@ class MacEFIFormatPopulator(BootFormatPopulator):
     def match(cls, data, device):
         fmt = formats.get_format(cls._type_specifier)
         try:
-            return (super().match(data, device) and
+            return (super(MacEFIFormatPopulator, MacEFIFormatPopulator).match(data, device) and
                     device.parted_partition.name == fmt.name)
         except AttributeError:
             # just in case device.parted_partition has no name attr

--- a/blivet/populator/helpers/btrfs.py
+++ b/blivet/populator/helpers/btrfs.py
@@ -35,7 +35,7 @@ class BTRFSFormatPopulator(FormatPopulator):
     _type_specifier = "btrfs"
 
     def _get_kwargs(self):
-        kwargs = super()._get_kwargs()
+        kwargs = super(BTRFSFormatPopulator, self)._get_kwargs()
         # the format's uuid attr will contain the UUID_SUB, while the
         # overarching volume UUID will be stored as vol_uuid
         kwargs["uuid"] = self.data["ID_FS_UUID_SUB"]
@@ -43,7 +43,7 @@ class BTRFSFormatPopulator(FormatPopulator):
         return kwargs
 
     def run(self):
-        super().run()
+        super(BTRFSFormatPopulator, self).run()
         uuid = udev.device_get_uuid(self.data)
 
         btrfs_dev = None

--- a/blivet/populator/helpers/disk.py
+++ b/blivet/populator/helpers/disk.py
@@ -85,13 +85,13 @@ class iScsiDevicePopulator(DiskDevicePopulator):
     @classmethod
     def match(cls, data):
         from ...iscsi import iscsi
-        return (super().match(data) and
+        return (super(iScsiDevicePopulator, iScsiDevicePopulator).match(data) and
                 udev.device_is_iscsi(data) and iscsi.initiator and
                 iscsi.initiator == udev.device_get_iscsi_initiator(data))
 
     def _get_kwargs(self):
         from ...iscsi import iscsi
-        kwargs = super()._get_kwargs()
+        kwargs = super(iScsiDevicePopulator, self)._get_kwargs()
         name = udev.device_get_name(self.data)
         initiator = udev.device_get_iscsi_initiator(self.data)
         target = udev.device_get_iscsi_name(self.data)
@@ -124,11 +124,11 @@ class FCoEDevicePopulator(DiskDevicePopulator):
 
     @classmethod
     def match(cls, data):
-        return (super().match(data) and
+        return (super(FCoEDevicePopulator, FCoEDevicePopulator).match(data) and
                 udev.device_is_fcoe(data))
 
     def _get_kwargs(self):
-        kwargs = super()._get_kwargs()
+        kwargs = super(FCoEDevicePopulator, self)._get_kwargs()
         kwargs["nic"] = udev.device_get_fcoe_nic(self.data)
         kwargs["identifier"] = udev.device_get_fcoe_identifier(self.data)
         log.info("%s is an fcoe disk", udev.device_get_name(self.data))
@@ -142,11 +142,11 @@ class MDBiosRaidDevicePopulator(DiskDevicePopulator):
 
     @classmethod
     def match(cls, data):
-        return (super().match(data) and
+        return (super(MDBiosRaidDevicePopulator, MDBiosRaidDevicePopulator).match(data) and
                 udev.device_get_md_container(data))
 
     def _get_kwargs(self):
-        kwargs = super()._get_kwargs()
+        kwargs = super(MDBiosRaidDevicePopulator, self)._get_kwargs()
         parent_path = udev.device_get_md_container(self.data)
         parent_name = device_path_to_name(parent_path)
         container = self._devicetree.get_device_by_name(parent_name)
@@ -187,11 +187,11 @@ class DASDDevicePopulator(DiskDevicePopulator):
 
     @classmethod
     def match(cls, data):
-        return (super().match(data) and
+        return (super(DASDDevicePopulator, DASDDevicePopulator).match(data) and
                 udev.device_is_dasd(data))
 
     def _get_kwargs(self):
-        kwargs = super()._get_kwargs()
+        kwargs = super(DASDDevicePopulator, self)._get_kwargs()
         kwargs["busid"] = udev.device_get_dasd_bus_id(self.data)
         kwargs["opts"] = {}
         for attr in ['readonly', 'use_diag', 'erplog', 'failfast']:
@@ -208,11 +208,11 @@ class ZFCPDevicePopulator(DiskDevicePopulator):
 
     @classmethod
     def match(cls, data):
-        return (super().match(data) and
+        return (super(ZFCPDevicePopulator, ZFCPDevicePopulator).match(data) and
                 udev.device_is_zfcp(data))
 
     def _get_kwargs(self):
-        kwargs = super()._get_kwargs()
+        kwargs = super(ZFCPDevicePopulator, self)._get_kwargs()
 
         for attr in ['hba_id', 'wwpn', 'fcp_lun']:
             kwargs[attr] = udev.device_get_zfcp_attribute(self.data, attr=attr)

--- a/blivet/populator/helpers/disklabel.py
+++ b/blivet/populator/helpers/disklabel.py
@@ -46,7 +46,7 @@ class DiskLabelFormatPopulator(FormatPopulator):
                 not (device.is_disk and mpath_members.is_mpath_member(device.path)))
 
     def _get_kwargs(self):
-        kwargs = super()._get_kwargs()
+        kwargs = super(DiskLabelFormatPopulator, self)._get_kwargs()
         kwargs["uuid"] = udev.device_get_disklabel_uuid(self.data)
         return kwargs
 

--- a/blivet/populator/helpers/disklabel.py
+++ b/blivet/populator/helpers/disklabel.py
@@ -21,6 +21,7 @@
 #
 
 import os
+import six
 
 from ... import formats
 from ... import udev
@@ -111,22 +112,22 @@ class DiskLabelFormatPopulator(FormatPopulator):
             start_sector = partition.parted_partition.geometry.start
             udev_device = None
             if self.device.format.label_type == "gpt":
-                udev_device = next((ud for ud in udev_devices
-                                    if udev.device_get_partition_uuid(ud) == partition.uuid),
-                                   None)
+                udev_device = six.next((ud for ud in udev_devices
+                                        if udev.device_get_partition_uuid(ud) == partition.uuid),
+                                       None)
             else:
-                udev_device = next((ud for ud in udev_devices
-                                    if udev.device_get_partition_disk(ud) == self.device.name and
-                                    int(ud.get("ID_PART_ENTRY_OFFSET")) == start_sector),
-                                   None)
+                udev_device = six.next((ud for ud in udev_devices
+                                        if udev.device_get_partition_disk(ud) == self.device.name and
+                                        int(ud.get("ID_PART_ENTRY_OFFSET")) == start_sector),
+                                       None)
 
             if udev_device is None:
                 self._devicetree.recursive_remove(partition, modparent=False, actions=False)
                 continue
 
-            parted_partition = next((pp for pp in parted_partitions
-                                     if os.path.basename(pp.path) == udev.device_get_name(udev_device)),
-                                    None)
+            parted_partition = six.next((pp for pp in parted_partitions
+                                         if os.path.basename(pp.path) == udev.device_get_name(udev_device)),
+                                        None)
             log.debug("got parted_partition %s for partition %s",
                       parted_partition.path.split("/")[-1], partition.name)
             partition.parted_partition = parted_partition
@@ -135,10 +136,10 @@ class DiskLabelFormatPopulator(FormatPopulator):
         for parted_partition in self.device.format.partitions:
             partition_name = os.path.basename(parted_partition.path)
             start_sector = parted_partition.geometry.start
-            udev_device = next((ud for ud in udev_devices
-                                if udev.device_get_name(ud) == partition_name and
-                                int(ud.get("ID_PART_ENTRY_OFFSET")) == start_sector),
-                               None)
+            udev_device = six.next((ud for ud in udev_devices
+                                    if udev.device_get_name(ud) == partition_name and
+                                    int(ud.get("ID_PART_ENTRY_OFFSET")) == start_sector),
+                                   None)
 
             if udev_device is None:
                 continue

--- a/blivet/populator/helpers/dmraid.py
+++ b/blivet/populator/helpers/dmraid.py
@@ -40,7 +40,7 @@ class DMRaidFormatPopulator(FormatPopulator):
     _type_specifier = "dmraidmember"
 
     def run(self):
-        super().run()
+        super(DMRaidFormatPopulator, self).run()
 
         # if dmraid usage is disabled skip any dmraid set activation
         if not flags.dmraid:

--- a/blivet/populator/helpers/luks.py
+++ b/blivet/populator/helpers/luks.py
@@ -57,12 +57,12 @@ class LUKSFormatPopulator(FormatPopulator):
     _type_specifier = "luks"
 
     def _get_kwargs(self):
-        kwargs = super()._get_kwargs()
+        kwargs = super(LUKSFormatPopulator, self)._get_kwargs()
         kwargs["name"] = "luks-%s" % udev.device_get_uuid(self.data)
         return kwargs
 
     def run(self):
-        super().run()
+        super(LUKSFormatPopulator, self).run()
         if not self.device.format.uuid:
             log.info("luks device %s has no uuid", self.device.path)
             return

--- a/blivet/populator/helpers/lvm.py
+++ b/blivet/populator/helpers/lvm.py
@@ -85,7 +85,7 @@ class LVMFormatPopulator(FormatPopulator):
     _type_specifier = "lvmpv"
 
     def _get_kwargs(self):
-        kwargs = super()._get_kwargs()
+        kwargs = super(LVMFormatPopulator, self)._get_kwargs()
 
         pv_info = pvs_info.cache.get(self.device.path, None)
 
@@ -395,7 +395,7 @@ class LVMFormatPopulator(FormatPopulator):
 
     def run(self):
         log_method_call(self, pv=self.device.name)
-        super().run()
+        super(LVMFormatPopulator, self).run()
         self._add_vg_device()
         self._update_lvs()
 

--- a/blivet/populator/helpers/mdraid.py
+++ b/blivet/populator/helpers/mdraid.py
@@ -97,7 +97,7 @@ class MDFormatPopulator(FormatPopulator):
     _type_specifier = "mdmember"
 
     def _get_kwargs(self):
-        kwargs = super()._get_kwargs()
+        kwargs = super(MDFormatPopulator, self)._get_kwargs()
         try:
             # ID_FS_UUID contains the array UUID
             kwargs["md_uuid"] = udev.device_get_uuid(self.data)
@@ -112,7 +112,7 @@ class MDFormatPopulator(FormatPopulator):
         return kwargs
 
     def run(self):
-        super().run()
+        super(MDFormatPopulator, self).run()
         try:
             md_info = blockdev.md.examine(self.device.path)
         except blockdev.MDRaidError as e:

--- a/blivet/populator/helpers/multipath.py
+++ b/blivet/populator/helpers/multipath.py
@@ -57,7 +57,7 @@ class MultipathFormatPopulator(FormatPopulator):
     _type_specifier = "multipath_member"
 
     def _get_kwargs(self):
-        kwargs = super()._get_kwargs()
+        kwargs = super(MultipathFormatPopulator, self)._get_kwargs()
         # blkid does not care that the UUID it sees on a multipath member is
         # for the multipath set's (and not the member's) formatting, so we
         # have to discard it.

--- a/blivet/populator/helpers/partition.py
+++ b/blivet/populator/helpers/partition.py
@@ -21,6 +21,7 @@
 #
 
 import copy
+import six
 
 import gi
 gi.require_version("BlockDev", "2.0")
@@ -62,8 +63,8 @@ class PartitionDevicePopulator(DevicePopulator):
             disk = self._devicetree.get_device_by_name(disk_name)
             if disk is None:
                 # create a device instance for the disk
-                disk_info = next((i for i in udev.get_devices()
-                                  if udev.device_get_name(i) == disk_name), None)
+                disk_info = six.next((i for i in udev.get_devices()
+                                      if udev.device_get_name(i) == disk_name), None)
                 if disk_info is not None:
                     self._devicetree.handle_device(disk_info)
                     disk = self._devicetree.get_device_by_name(disk_name)

--- a/blivet/populator/helpers/populatorhelper.py
+++ b/blivet/populator/helpers/populatorhelper.py
@@ -21,7 +21,7 @@
 #
 
 
-class PopulatorHelper:
+class PopulatorHelper(object):
     """ Class to hold type-specific code for populating the devicetree. """
 
     priority = 100

--- a/blivet/populator/populator.py
+++ b/blivet/populator/populator.py
@@ -24,6 +24,7 @@ import os
 import pprint
 import copy
 import parted
+from six import add_metaclass
 
 import gi
 gi.require_version("BlockDev", "2.0")
@@ -65,7 +66,8 @@ def parted_exn_handler(exn_type, exn_options, exn_msg):
     return ret
 
 
-class PopulatorMixin(object, metaclass=SynchronizedMeta):
+@add_metaclass(SynchronizedMeta)
+class PopulatorMixin(object):
     def __init__(self, conf=None, passphrase=None, luks_dict=None):
         """
             :keyword conf: storage discovery configuration

--- a/blivet/tasks/fssize.py
+++ b/blivet/tasks/fssize.py
@@ -22,7 +22,7 @@
 import abc
 from collections import namedtuple
 
-from six import add_metaclass
+import six
 
 from ..errors import FSError
 from ..size import Size
@@ -36,7 +36,7 @@ _tags = ("count", "size")
 _Tags = namedtuple("_Tags", _tags)
 
 
-@add_metaclass(abc.ABCMeta)
+@six.add_metaclass(abc.ABCMeta)
 class FSSize(fstask.FSTask):
 
     """ An abstract class that represents size information extraction. """
@@ -78,7 +78,7 @@ class FSSize(fstask.FSTask):
 
         # Attempt to set values from info
         for line in (l.strip() for l in self.fs._current_info.splitlines()):
-            key = next((k for k in _tags if line.startswith(getattr(self.tags, k))), None)
+            key = six.next((k for k in _tags if line.startswith(getattr(self.tags, k))), None)
             if not key:
                 continue
 
@@ -96,7 +96,7 @@ class FSSize(fstask.FSTask):
                     continue
 
         # Raise an error if a value is missing
-        missing = next((k for k in _tags if values[k] is None), None)
+        missing = six.next((k for k in _tags if values[k] is None), None)
         if missing is not None:
             raise FSError("Failed to parse info for %s." % missing)
 

--- a/blivet/threads.py
+++ b/blivet/threads.py
@@ -24,6 +24,7 @@ from threading import RLock, current_thread, main_thread
 from types import FunctionType
 from abc import ABCMeta
 from six import raise_from, wraps
+import functools
 
 from .errors import ThreadError
 from .flags import flags
@@ -33,7 +34,7 @@ blivet_lock = RLock(verbose=flags.debug_threads)
 
 def exclusive(m):
     """ Run a callable while holding the global lock. """
-    @wraps(m)
+    @wraps(m, set(functools.WRAPPER_ASSIGNMENTS) & set(dir(m)))
     def run_with_lock(*args, **kwargs):
         with blivet_lock:
             if current_thread() == main_thread():

--- a/blivet/threads.py
+++ b/blivet/threads.py
@@ -24,6 +24,7 @@ from threading import RLock, current_thread, main_thread
 from functools import wraps
 from types import FunctionType
 from abc import ABCMeta
+from six import raise_from
 
 from .errors import ThreadError
 from .flags import flags
@@ -40,7 +41,7 @@ def exclusive(m):
                 exn_info = get_thread_exception()
                 if exn_info[1]:
                     clear_thread_exception()
-                    raise ThreadError("raising queued exception") from exn_info[1]
+                    raise_from(ThreadError("raising queued exception"), exn_info[1])
 
             return m(*args, **kwargs)
 

--- a/blivet/threads.py
+++ b/blivet/threads.py
@@ -21,10 +21,9 @@
 #
 
 from threading import RLock, current_thread, main_thread
-from functools import wraps
 from types import FunctionType
 from abc import ABCMeta
-from six import raise_from
+from six import raise_from, wraps
 
 from .errors import ThreadError
 from .flags import flags

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -310,7 +310,7 @@ def total_memory():
     from .size import Size
 
     with open("/proc/meminfo") as lines:
-        line = next(l for l in lines if l.startswith("MemTotal:"))
+        line = six.next(l for l in lines if l.startswith("MemTotal:"))
         mem = Size("%s KiB" % line.split()[1])
 
     # Because /proc/meminfo only gives us the MemTotal (total physical RAM

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -1070,7 +1070,8 @@ class EvalMode(Enum):
     # TODO: no_sooner_than, if_changed,...
 
 
-class DependencyGuard(object, metaclass=abc.ABCMeta):
+@six.add_metaclass(abc.ABCMeta)
+class DependencyGuard(object):
 
     error_msg = abc.abstractproperty(doc="Error message to report when a dependency is missing")
 

--- a/tests/blivet_test.py
+++ b/tests/blivet_test.py
@@ -1,6 +1,6 @@
-import test_compat
+import test_compat  # pylint: disable=unused-import
 
-from six.moves.mock import PropertyMock, patch
+from six.moves.mock import PropertyMock, patch  # pylint: disable=no-name-in-module,import-error
 import unittest
 from pykickstart.version import returnClassForVersion
 from blivet import Blivet

--- a/tests/blivet_test.py
+++ b/tests/blivet_test.py
@@ -1,6 +1,7 @@
+import test_compat
+
+from six.moves.mock import PropertyMock, patch
 import unittest
-from unittest.mock import PropertyMock
-from unittest.mock import patch
 from pykickstart.version import returnClassForVersion
 from blivet import Blivet
 from blivet.devices import PartitionDevice

--- a/tests/dbus_test.py
+++ b/tests/dbus_test.py
@@ -1,6 +1,8 @@
+import test_compat
+
 import random
+from six.moves.mock import Mock, patch
 from unittest import TestCase
-from unittest.mock import Mock, patch
 
 import dbus
 

--- a/tests/dbus_test.py
+++ b/tests/dbus_test.py
@@ -1,7 +1,7 @@
-import test_compat
+import test_compat  # pylint: disable=unused-import
 
 import random
-from six.moves.mock import Mock, patch
+from six.moves.mock import Mock, patch  # pylint: disable=no-name-in-module,import-error
 from unittest import TestCase
 
 import dbus

--- a/tests/devicefactory_test.py
+++ b/tests/devicefactory_test.py
@@ -1,4 +1,5 @@
 
+import six
 import unittest
 from decimal import Decimal
 import os
@@ -544,16 +545,16 @@ class MDFactoryTestCase(DeviceFactoryTestCase):
                                                     Size("1 GiB"),
                                                     raid_level=0)
 
-        with self.assertRaisesRegex(devicefactory.DeviceFactoryError, "must have some RAID level"):
+        with six.assertRaisesRegex(self, devicefactory.DeviceFactoryError, "must have some RAID level"):
             devicefactory.get_device_factory(
                 self.b,
                 devicefactory.DEVICE_TYPE_MD,
                 Size("1 GiB"))
 
-        with self.assertRaisesRegex(RaidError, "requires at least"):
+        with six.assertRaisesRegex(self, RaidError, "requires at least"):
             factory1._get_device_space()
 
-        with self.assertRaisesRegex(RaidError, "requires at least"):
+        with six.assertRaisesRegex(self, RaidError, "requires at least"):
             factory1._configure()
 
         self.assertEqual(factory1.container_list, [])
@@ -566,7 +567,7 @@ class MDFactoryTestCase(DeviceFactoryTestCase):
         ]
         self.assertIsNotNone(factory1._get_new_device(parents=parents))
 
-        with self.assertRaisesRegex(RaidError, "requires at least"):
+        with six.assertRaisesRegex(self, RaidError, "requires at least"):
             factory2._get_device_space()
 
         self.assertEqual(factory2.container_list, [])

--- a/tests/devicelibs_test/disk_test.py
+++ b/tests/devicelibs_test/disk_test.py
@@ -1,7 +1,9 @@
 # pylint: skip-file
-import unittest
-from unittest.mock import Mock, patch, sentinel
+import test_compat
+
 import six
+from six.moves.mock import Mock, patch, sentinel
+import unittest
 
 from blivet.devicelibs import disk as disklib
 from blivet.size import Size

--- a/tests/devicelibs_test/disk_test.py
+++ b/tests/devicelibs_test/disk_test.py
@@ -1,6 +1,7 @@
 # pylint: skip-file
 import unittest
 from unittest.mock import Mock, patch, sentinel
+import six
 
 from blivet.devicelibs import disk as disklib
 from blivet.size import Size
@@ -87,10 +88,10 @@ class DiskLibTestCase(unittest.TestCase):
             return (volume.raid_type, volume.stripe_size, volume.drives, volume.min_io, volume.opt_io)
 
         def vpd83_search(vpd83):
-            return next((vol.nodes for vol in _client_volumes if vol.vpd83 == vpd83), None)
+            return six.next((vol.nodes for vol in _client_volumes if vol.vpd83 == vpd83), None)
 
         def system_by_id(sys_id):
-            return next((sys for sys in _client_systems if sys.id == sys_id), None)
+            return six.next((sys for sys in _client_systems if sys.id == sys_id), None)
 
         with patch("blivet.devicelibs.disk._lsm_required._check_avail", return_value=True):
             with patch("blivet.devicelibs.disk.lsm") as _lsm:

--- a/tests/devicelibs_test/raid_test.py
+++ b/tests/devicelibs_test/raid_test.py
@@ -1,3 +1,4 @@
+import six
 import unittest
 
 import blivet.devicelibs.raid as raid
@@ -14,7 +15,7 @@ class RaidTestCase(unittest.TestCase):
 
     def test_raid(self):
 
-        with self.assertRaisesRegex(TypeError, "Can't instantiate abstract class"):
+        with six.assertRaisesRegex(self, TypeError, "Can't instantiate abstract class"):
             raid.ErsatzRAID()
 
         ##
@@ -151,11 +152,11 @@ class RaidTestCase(unittest.TestCase):
         ##
         # __init__
         ##
-        with self.assertRaisesRegex(errors.RaidError, "invalid RAID level"):
+        with six.assertRaisesRegex(self, errors.RaidError, "invalid RAID level"):
             self.levels_none.raid_level(10)
 
-        with self.assertRaisesRegex(errors.RaidError, "invalid RAID level"):
+        with six.assertRaisesRegex(self, errors.RaidError, "invalid RAID level"):
             self.levels_some.raid_level(10)
 
-        with self.assertRaisesRegex(errors.RaidError, "invalid standard RAID level descriptor"):
+        with six.assertRaisesRegex(self, errors.RaidError, "invalid standard RAID level descriptor"):
             raid.RAIDLevels(["raid3.1415"])

--- a/tests/devices_test/device_methods_test.py
+++ b/tests/devices_test/device_methods_test.py
@@ -1,5 +1,8 @@
+import test_compat
+
+import six
+from six.moves.mock import patch, Mock, PropertyMock
 import unittest
-from unittest.mock import patch, Mock, PropertyMock
 
 from blivet.devices import StorageDevice
 from blivet.devices import DiskDevice, PartitionDevice

--- a/tests/devices_test/device_methods_test.py
+++ b/tests/devices_test/device_methods_test.py
@@ -107,7 +107,7 @@ class StorageDeviceMethodsTestCase(unittest.TestCase):
         self.device.exists = True
         self.patches["status"].return_value = True
         with patch.object(self.device, "_create"):
-            self.assertRaisesRegex(DeviceError, "has already been created", self.device.create)
+            six.assertRaisesRegex(self, DeviceError, "has already been created", self.device.create)
             self.assertFalse(self.device._create.called)
         self.device.exists = False
 
@@ -118,7 +118,7 @@ class StorageDeviceMethodsTestCase(unittest.TestCase):
         with patch.object(self.device, "_create"):
             with patch.object(self.device, "_post_create"):
                 self.device._create.side_effect = _create
-                self.assertRaisesRegex(RuntimeError, "problems", self.device.create)
+                six.assertRaisesRegex(self, RuntimeError, "problems", self.device.create)
                 self.assertTrue(self.device._create.called)
                 self.assertFalse(self.device._post_create.called)
 
@@ -138,7 +138,7 @@ class StorageDeviceMethodsTestCase(unittest.TestCase):
         self.device.exists = False
         self.patches["status"].return_value = True
         with patch.object(self.device, "_destroy"):
-            self.assertRaisesRegex(DeviceError, "has not been created", self.device.destroy)
+            six.assertRaisesRegex(self, DeviceError, "has not been created", self.device.destroy)
             self.assertFalse(self.device._destroy.called)
         self.device.exists = True
 
@@ -149,7 +149,7 @@ class StorageDeviceMethodsTestCase(unittest.TestCase):
         with patch.object(self.device, "_destroy"):
             with patch.object(self.device, "_post_destroy"):
                 self.device._destroy.side_effect = _destroy
-                self.assertRaisesRegex(RuntimeError, "problems", self.device.destroy)
+                six.assertRaisesRegex(self, RuntimeError, "problems", self.device.destroy)
                 self.assertTrue(self.device._destroy.called)
                 self.assertFalse(self.device._post_destroy.called)
 
@@ -169,7 +169,7 @@ class StorageDeviceMethodsTestCase(unittest.TestCase):
         self.device.exists = False
         self.patches["status"].return_value = False
         with patch.object(self.device, "_setup"):
-            self.assertRaisesRegex(DeviceError, "has not been created", self.device.setup)
+            six.assertRaisesRegex(self, DeviceError, "has not been created", self.device.setup)
             self.assertFalse(self.device._setup.called)
 
         self.device.exists = True
@@ -212,7 +212,7 @@ class StorageDeviceMethodsTestCase(unittest.TestCase):
     def test_teardown(self):
         self.device.exists = False
         with patch.object(self.device, "_teardown"):
-            self.assertRaisesRegex(DeviceError, "has not been created", self.device.teardown)
+            six.assertRaisesRegex(self, DeviceError, "has not been created", self.device.teardown)
             self.assertFalse(self.device._teardown.called)
 
         self.device.exists = True

--- a/tests/devices_test/device_methods_test.py
+++ b/tests/devices_test/device_methods_test.py
@@ -15,7 +15,7 @@ class StorageDeviceMethodsTestCase(unittest.TestCase):
     device_class = StorageDevice
 
     def __init__(self, methodName='runTest'):
-        super().__init__(methodName=methodName)
+        super(StorageDeviceMethodsTestCase, self).__init__(methodName=methodName)
         self.patchers = dict()
         self.patches = dict()
 
@@ -245,7 +245,7 @@ class PartitionDeviceMethodsTestCase(StorageDeviceMethodsTestCase):
     device_class = PartitionDevice
 
     def set_patches(self):
-        super().set_patches()
+        super(PartitionDeviceMethodsTestCase, self).set_patches()
         self.patchers["parted_partition"] = patch.object(self.device_class, "parted_partition",
                                                          new=PropertyMock())
         self.patchers["disk"] = patch.object(self.device_class, "disk", new=PropertyMock())
@@ -253,7 +253,7 @@ class PartitionDeviceMethodsTestCase(StorageDeviceMethodsTestCase):
     @patch("blivet.devices.partition.DeviceFormat")
     def test_create(self, *args):  # pylint: disable=unused-argument,arguments-differ
         with patch.object(self.device, "_wipe"):
-            super().test_create()
+            super(PartitionDeviceMethodsTestCase, self).test_create()
 
         with patch.object(self.device, "_wipe"):
             self.device._create()
@@ -261,7 +261,7 @@ class PartitionDeviceMethodsTestCase(StorageDeviceMethodsTestCase):
             self.assertTrue(self.device.disk.format.commit.called)
 
     def test_destroy(self):
-        super().test_destroy()
+        super(PartitionDeviceMethodsTestCase, self).test_destroy()
 
         self.device._destroy()
         self.assertTrue(self.device.disk.original_format.remove_partition.called)
@@ -289,12 +289,12 @@ class LVMVolumeGroupDeviceMethodsTestCase(StorageDeviceMethodsTestCase):
         return False
 
     def set_patches(self):
-        super().set_patches()
+        super(LVMVolumeGroupDeviceMethodsTestCase, self).set_patches()
         self.patchers["complete"] = patch.object(self.device_class, "complete",
                                                  new=PropertyMock(return_value=True))
 
     def test_create(self):
-        super().test_create()
+        super(LVMVolumeGroupDeviceMethodsTestCase, self).test_create()
 
         with patch("blivet.devices.lvm.blockdev.lvm") as lvm:
             self.device._create()
@@ -302,7 +302,7 @@ class LVMVolumeGroupDeviceMethodsTestCase(StorageDeviceMethodsTestCase):
 
     def test_destroy(self):
         with patch.object(self.device, "teardown"):
-            super().test_destroy()
+            super(LVMVolumeGroupDeviceMethodsTestCase, self).test_destroy()
 
         with patch("blivet.devices.lvm.blockdev.lvm") as lvm:
             self.device._destroy()
@@ -319,7 +319,7 @@ class LVMLogicalVolumeDeviceMethodsTestCase(StorageDeviceMethodsTestCase):
     device_class = LVMLogicalVolumeDevice
 
     def _ctor_kwargs(self):
-        kwargs = super()._ctor_kwargs()
+        kwargs = super(LVMLogicalVolumeDeviceMethodsTestCase, self)._ctor_kwargs()
         vg_mock = Mock(name="testvg", spec=LVMVolumeGroupDevice)
         vg_mock.name = "testvg"
         vg_mock.pvs = vg_mock.parents = [Mock(name="pv.1", protected=False)]
@@ -334,28 +334,28 @@ class LVMLogicalVolumeDeviceMethodsTestCase(StorageDeviceMethodsTestCase):
         return False
 
     def test_setup(self):
-        super().test_setup()
+        super(LVMLogicalVolumeDeviceMethodsTestCase, self).test_setup()
         with patch("blivet.devices.lvm.blockdev.lvm") as lvm:
             self.device._setup()
             self.assertTrue(lvm.lvactivate.called)
 
     def test_teardown(self):
         with patch("blivet.devicelibs.lvm.lvmetad_socket_exists", return_value=False):
-            super().test_teardown()
+            super(LVMLogicalVolumeDeviceMethodsTestCase, self).test_teardown()
 
         with patch("blivet.devices.lvm.blockdev.lvm") as lvm:
             self.device._teardown()
             self.assertTrue(lvm.lvdeactivate.called)
 
     def test_create(self):
-        super().test_create()
+        super(LVMLogicalVolumeDeviceMethodsTestCase, self).test_create()
         with patch("blivet.devices.lvm.blockdev.lvm") as lvm:
             self.device._create()
             self.assertTrue(lvm.lvcreate.called)
 
     def test_destroy(self):
         with patch.object(self.device, "teardown"):
-            super().test_destroy()
+            super(LVMLogicalVolumeDeviceMethodsTestCase, self).test_destroy()
 
         with patch("blivet.devices.lvm.blockdev.lvm") as lvm:
             self.device._destroy()
@@ -366,7 +366,7 @@ class MDRaidArrayDeviceMethodsTestCase(StorageDeviceMethodsTestCase):
     device_class = MDRaidArrayDevice
 
     def _ctor_kwargs(self):
-        kwargs = super()._ctor_kwargs()
+        kwargs = super(MDRaidArrayDeviceMethodsTestCase, self)._ctor_kwargs()
         kwargs["level"] = "raid0"
         kwargs["parents"] = [Mock(name="member1", spec=StorageDevice),
                              Mock(name="member2", spec=StorageDevice)]
@@ -378,7 +378,7 @@ class MDRaidArrayDeviceMethodsTestCase(StorageDeviceMethodsTestCase):
         return kwargs
 
     def set_patches(self):
-        super().set_patches()
+        super(MDRaidArrayDeviceMethodsTestCase, self).set_patches()
         self.patchers["md"] = patch("blivet.devices.md.blockdev.md")
         self.patchers["is_disk"] = patch.object(self.device_class, "is_disk",
                                                 new=PropertyMock(return_value=False))
@@ -390,15 +390,15 @@ class MDRaidArrayDeviceMethodsTestCase(StorageDeviceMethodsTestCase):
     def test_teardown(self):
         with patch("blivet.devices.md.os.path.exists") as exists:
             exists.return_value = True
-            super().test_teardown()
+            super(MDRaidArrayDeviceMethodsTestCase, self).test_teardown()
 
     def test_setup(self):
-        super().test_setup()
+        super(MDRaidArrayDeviceMethodsTestCase, self).test_setup()
         self.patches["md"].reset_mock()
         self.device._setup()
         self.assertTrue(self.patches["md"].activate.called)
 
     def test_create(self):
-        super().test_create()
+        super(MDRaidArrayDeviceMethodsTestCase, self).test_create()
         self.device._create()
         self.assertTrue(self.patches["md"].create.called)

--- a/tests/devices_test/device_methods_test.py
+++ b/tests/devices_test/device_methods_test.py
@@ -1,7 +1,7 @@
-import test_compat
+import test_compat  # pylint: disable=unused-import
 
 import six
-from six.moves.mock import patch, Mock, PropertyMock
+from six.moves.mock import patch, Mock, PropertyMock  # pylint: disable=no-name-in-module,import-error
 import unittest
 
 from blivet.devices import StorageDevice

--- a/tests/devices_test/device_names_test.py
+++ b/tests/devices_test/device_names_test.py
@@ -1,4 +1,5 @@
 # vim:set fileencoding=utf-8
+import test_compat
 
 import six
 import unittest
@@ -11,10 +12,11 @@ import blivet
 
 
 class DeviceNameTestCase(unittest.TestCase):
-
     """Test device name validation"""
-
-    def test_storage_device(self):
+    @six.moves.mock.patch.object(StorageDevice, "status", return_value=True)
+    @six.moves.mock.patch.object(StorageDevice, "update_sysfs_path", return_value=None)
+    @six.moves.mock.patch.object(StorageDevice, "read_current_size", return_value=None)
+    def test_storage_device(self, *patches):  # pylint: disable=unused-argument
         # Check that / and NUL are rejected along with . and ..
         good_names = ['sda1', '1sda', 'good-name', 'cciss/c0d0']
         bad_names = ['sda/1', 'sda\x00', '.', '..', 'cciss/..']

--- a/tests/devices_test/device_names_test.py
+++ b/tests/devices_test/device_names_test.py
@@ -1,5 +1,6 @@
 # vim:set fileencoding=utf-8
 
+import six
 import unittest
 
 from blivet.devices import LVMVolumeGroupDevice
@@ -47,7 +48,7 @@ class DeviceNameTestCase(unittest.TestCase):
                 if ' is not a valid name for this device' in str(e):
                     self.fail("Device name checked on already existing device")
 
-            with self.assertRaisesRegex(ValueError, ' is not a valid name for this device'):
+            with six.assertRaisesRegex(self, ValueError, ' is not a valid name for this device'):
                 StorageDevice(name, exists=False)
 
     def test_volume_group(self):

--- a/tests/devices_test/device_names_test.py
+++ b/tests/devices_test/device_names_test.py
@@ -1,6 +1,7 @@
 # vim:set fileencoding=utf-8
-import test_compat
+import test_compat  # pylint: disable=unused-import
 
+from six.moves.mock import patch  # pylint: disable=no-name-in-module,import-error
 import six
 import unittest
 
@@ -13,9 +14,9 @@ import blivet
 
 class DeviceNameTestCase(unittest.TestCase):
     """Test device name validation"""
-    @six.moves.mock.patch.object(StorageDevice, "status", return_value=True)
-    @six.moves.mock.patch.object(StorageDevice, "update_sysfs_path", return_value=None)
-    @six.moves.mock.patch.object(StorageDevice, "read_current_size", return_value=None)
+    @patch.object(StorageDevice, "status", return_value=True)
+    @patch.object(StorageDevice, "update_sysfs_path", return_value=None)
+    @patch.object(StorageDevice, "read_current_size", return_value=None)
     def test_storage_device(self, *patches):  # pylint: disable=unused-argument
         # Check that / and NUL are rejected along with . and ..
         good_names = ['sda1', '1sda', 'good-name', 'cciss/c0d0']

--- a/tests/devices_test/device_properties_test.py
+++ b/tests/devices_test/device_properties_test.py
@@ -1,5 +1,5 @@
 # vim:set fileencoding=utf-8
-import test_compat
+import test_compat  # pylint: disable=unused-import
 
 import six
 import unittest
@@ -9,7 +9,7 @@ gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 
-from six.moves.mock import Mock, patch
+from six.moves.mock import Mock, patch  # pylint: disable=no-name-in-module,import-error
 
 import blivet
 

--- a/tests/devices_test/device_properties_test.py
+++ b/tests/devices_test/device_properties_test.py
@@ -1,6 +1,7 @@
 # vim:set fileencoding=utf-8
 import test_compat
 
+import six
 import unittest
 
 import gi
@@ -75,7 +76,7 @@ class DeviceStateTestCase(unittest.TestCase):
             "parents": xform(lambda x, m: self.assertEqual(len(x), 0, m) and
                              self.assertIsInstance(x, ParentList, m)),
             "partitionable": xform(self.assertFalse),
-            "path": xform(lambda x, m: self.assertRegex(x, "^/dev", m)),
+            "path": xform(lambda x, m: six.assertRegex(self, x, "^/dev", m)),
             "raw_device": xform(self.assertIsNotNone),
             "resizable": xform(self.assertFalse),
             "size": xform(lambda x, m: self.assertEqual(x, Size(0), m)),
@@ -548,35 +549,35 @@ class MDRaidArrayDeviceTestCase(DeviceStateTestCase):
                          parents=xform(lambda x, m: self.assertEqual(len(x), 2, m)),
                          uuid=xform(lambda x, m: self.assertEqual(x, self.dev20.uuid, m)))
 
-        with self.assertRaisesRegex(DeviceError, "invalid"):
+        with six.assertRaisesRegex(self, DeviceError, "invalid"):
             MDRaidArrayDevice("dev")
 
-        with self.assertRaisesRegex(DeviceError, "invalid"):
+        with six.assertRaisesRegex(self, DeviceError, "invalid"):
             MDRaidArrayDevice("dev", level="raid2")
 
-        with self.assertRaisesRegex(DeviceError, "invalid"):
+        with six.assertRaisesRegex(self, DeviceError, "invalid"):
             MDRaidArrayDevice(
                 "dev",
                 parents=[StorageDevice("parent", fmt=get_format("mdmember"))])
 
-        with self.assertRaisesRegex(DeviceError, "at least 2 members"):
+        with six.assertRaisesRegex(self, DeviceError, "at least 2 members"):
             MDRaidArrayDevice(
                 "dev",
                 level="raid0",
                 parents=[StorageDevice("parent", fmt=get_format("mdmember"))])
 
-        with self.assertRaisesRegex(DeviceError, "invalid"):
+        with six.assertRaisesRegex(self, DeviceError, "invalid"):
             MDRaidArrayDevice("dev", level="junk")
 
-        with self.assertRaisesRegex(DeviceError, "at least 2 members"):
+        with six.assertRaisesRegex(self, DeviceError, "at least 2 members"):
             MDRaidArrayDevice("dev", level=0, member_devices=2)
 
     def test_mdraid_array_device_methods(self):
         """Test for method calls on initialized MDRaidDevices."""
-        with self.assertRaisesRegex(DeviceError, "invalid"):
+        with six.assertRaisesRegex(self, DeviceError, "invalid"):
             self.dev7.level = "junk"
 
-        with self.assertRaisesRegex(DeviceError, "invalid"):
+        with six.assertRaisesRegex(self, DeviceError, "invalid"):
             self.dev7.level = None
 
 
@@ -649,27 +650,27 @@ class BTRFSDeviceTestCase(DeviceStateTestCase):
                          size=xform(lambda x, m: self.assertEqual(x, Size("500 MiB"), m)),
                          type=xform(lambda x, m: self.assertEqual(x, "btrfs volume", m)))
 
-        with self.assertRaisesRegex(ValueError, "BTRFSDevice.*must have at least one parent"):
+        with six.assertRaisesRegex(self, ValueError, "BTRFSDevice.*must have at least one parent"):
             BTRFSVolumeDevice("dev")
 
-        with self.assertRaisesRegex(ValueError, "format"):
+        with six.assertRaisesRegex(self, ValueError, "format"):
             BTRFSVolumeDevice("dev", parents=[StorageDevice("deva", size=BTRFS_MIN_MEMBER_SIZE)])
 
-        with self.assertRaisesRegex(DeviceError, "btrfs subvolume.*must be a btrfs volume"):
+        with six.assertRaisesRegex(self, DeviceError, "btrfs subvolume.*must be a btrfs volume"):
             fmt = blivet.formats.get_format("btrfs")
             device = StorageDevice("deva", fmt=fmt, size=BTRFS_MIN_MEMBER_SIZE)
             BTRFSSubVolumeDevice("dev1", parents=[device])
 
         deva = OpticalDevice("deva", fmt=blivet.formats.get_format("btrfs", exists=True),
                              exists=True)
-        with self.assertRaisesRegex(BTRFSValueError, "at least"):
+        with six.assertRaisesRegex(self, BTRFSValueError, "at least"):
             BTRFSVolumeDevice("dev1", data_level="raid1", parents=[deva])
 
         deva = StorageDevice("deva", fmt=blivet.formats.get_format("btrfs"), size=BTRFS_MIN_MEMBER_SIZE)
         self.assertIsNotNone(BTRFSVolumeDevice("dev1", metadata_level="dup", parents=[deva]))
 
         deva = StorageDevice("deva", fmt=blivet.formats.get_format("btrfs"), size=BTRFS_MIN_MEMBER_SIZE)
-        with self.assertRaisesRegex(BTRFSValueError, "invalid"):
+        with six.assertRaisesRegex(self, BTRFSValueError, "invalid"):
             BTRFSVolumeDevice("dev1", data_level="dup", parents=[deva])
 
         self.assertEqual(self.dev1.isleaf, False)
@@ -694,24 +695,24 @@ class BTRFSDeviceTestCase(DeviceStateTestCase):
         self.assertIsNotNone(self.dev2.volume)
 
         # size
-        with self.assertRaisesRegex(RuntimeError, "cannot directly set size of btrfs volume"):
+        with six.assertRaisesRegex(self, RuntimeError, "cannot directly set size of btrfs volume"):
             self.dev1.size = Size("500 MiB")
 
     def test_btrfssnap_shot_device_init(self):
         parents = [StorageDevice("p1", fmt=blivet.formats.get_format("btrfs"), size=BTRFS_MIN_MEMBER_SIZE)]
         vol = BTRFSVolumeDevice("test", parents=parents)
-        with self.assertRaisesRegex(ValueError, "non-existent btrfs snapshots must have a source"):
+        with six.assertRaisesRegex(self, ValueError, "non-existent btrfs snapshots must have a source"):
             BTRFSSnapShotDevice("snap1", parents=[vol])
 
-        with self.assertRaisesRegex(ValueError, "btrfs snapshot source must already exist"):
+        with six.assertRaisesRegex(self, ValueError, "btrfs snapshot source must already exist"):
             BTRFSSnapShotDevice("snap1", parents=[vol], source=vol)
 
-        with self.assertRaisesRegex(ValueError, "btrfs snapshot source must be a btrfs subvolume"):
+        with six.assertRaisesRegex(self, ValueError, "btrfs snapshot source must be a btrfs subvolume"):
             BTRFSSnapShotDevice("snap1", parents=[vol], source=parents[0])
 
         parents2 = [StorageDevice("p1", fmt=blivet.formats.get_format("btrfs"), size=BTRFS_MIN_MEMBER_SIZE, exists=True)]
         vol2 = BTRFSVolumeDevice("test2", parents=parents2, exists=True)
-        with self.assertRaisesRegex(ValueError, ".*snapshot and source must be in the same volume"):
+        with six.assertRaisesRegex(self, ValueError, ".*snapshot and source must be in the same volume"):
             BTRFSSnapShotDevice("snap1", parents=[vol], source=vol2)
 
         vol.exists = True

--- a/tests/devices_test/device_properties_test.py
+++ b/tests/devices_test/device_properties_test.py
@@ -1,4 +1,5 @@
 # vim:set fileencoding=utf-8
+import test_compat
 
 import unittest
 
@@ -7,7 +8,7 @@ gi.require_version("BlockDev", "2.0")
 
 from gi.repository import BlockDev as blockdev
 
-from mock import Mock, patch
+from six.moves.mock import Mock, patch
 
 import blivet
 

--- a/tests/devices_test/disk_test.py
+++ b/tests/devices_test/disk_test.py
@@ -1,6 +1,8 @@
 # pylint: skip-file
+import test_compat
+
+from six.moves.mock import patch
 import unittest
-from unittest.mock import patch
 
 from blivet.devices import DiskDevice
 from blivet.devicelibs import disk as disklib

--- a/tests/devices_test/lvm_test.py
+++ b/tests/devices_test/lvm_test.py
@@ -1,7 +1,8 @@
 # vim:set fileencoding=utf-8
+import test_compat
 
+from six.moves.mock import patch
 import unittest
-from unittest.mock import patch
 
 import blivet
 

--- a/tests/devices_test/lvm_test.py
+++ b/tests/devices_test/lvm_test.py
@@ -1,8 +1,8 @@
 # vim:set fileencoding=utf-8
-import test_compat
+import test_compat  # pylint: disable=unused-import
 
 import six
-from six.moves.mock import patch
+from six.moves.mock import patch  # pylint: disable=no-name-in-module,import-error
 import unittest
 
 import blivet

--- a/tests/devices_test/lvm_test.py
+++ b/tests/devices_test/lvm_test.py
@@ -1,6 +1,7 @@
 # vim:set fileencoding=utf-8
 import test_compat
 
+import six
 from six.moves.mock import patch
 import unittest
 
@@ -32,10 +33,10 @@ class LVMDeviceTest(unittest.TestCase):
         lv = LVMLogicalVolumeDevice("testlv", parents=[vg],
                                     fmt=blivet.formats.get_format("xfs"))
 
-        with self.assertRaisesRegex(ValueError, "lvm snapshot origin must be a logical volume"):
+        with six.assertRaisesRegex(self, ValueError, "lvm snapshot origin must be a logical volume"):
             LVMLogicalVolumeDevice("snap1", parents=[vg], origin=pv)
 
-        with self.assertRaisesRegex(ValueError, "only existing vorigin snapshots are supported"):
+        with six.assertRaisesRegex(self, ValueError, "only existing vorigin snapshots are supported"):
             LVMLogicalVolumeDevice("snap1", parents=[vg], vorigin=True)
 
         lv.exists = True
@@ -60,7 +61,7 @@ class LVMDeviceTest(unittest.TestCase):
         pool = LVMLogicalVolumeDevice("pool1", parents=[vg], size=Size("500 MiB"), seg_type="thin-pool")
         thinlv = LVMLogicalVolumeDevice("thinlv", parents=[pool], size=Size("200 MiB"), seg_type="thin")
 
-        with self.assertRaisesRegex(ValueError, "lvm snapshot origin must be a logical volume"):
+        with six.assertRaisesRegex(self, ValueError, "lvm snapshot origin must be a logical volume"):
             LVMLogicalVolumeDevice("snap1", parents=[pool], origin=pv, seg_type="thin")
 
         # now make the constructor succeed so we can test some properties
@@ -322,16 +323,16 @@ class LVMDeviceTest(unittest.TestCase):
         self.assertEqual(lv.size, orig_size)
 
         # ValueError if size smaller than min_size
-        with self.assertRaisesRegex(ValueError,
-                                    "size.*smaller than the minimum"):
+        with six.assertRaisesRegex(self, ValueError,
+                                   "size.*smaller than the minimum"):
             lv.target_size = Size("1 MiB")
 
         # target size should be unchanged
         self.assertEqual(lv.target_size, orig_size)
 
         # ValueError if size larger than max_size
-        with self.assertRaisesRegex(ValueError,
-                                    "size.*larger than the maximum"):
+        with six.assertRaisesRegex(self, ValueError,
+                                   "size.*larger than the maximum"):
             lv.target_size = Size("1 GiB")
 
         # target size should be unchanged

--- a/tests/devices_test/md_test.py
+++ b/tests/devices_test/md_test.py
@@ -1,3 +1,4 @@
+import six
 import unittest
 
 import blivet
@@ -42,8 +43,8 @@ class MDRaidArrayDeviceTest(unittest.TestCase):
 
         self.assertEqual(raid_array.chunk_size, Size("1024 KiB"))
 
-        with self.assertRaisesRegex(ValueError, "new chunk size must be of type Size"):
+        with six.assertRaisesRegex(self, ValueError, "new chunk size must be of type Size"):
             raid_array.chunk_size = 1
 
-        with self.assertRaisesRegex(ValueError, "new chunk size must be multiple of 4 KiB"):
+        with six.assertRaisesRegex(self, ValueError, "new chunk size must be multiple of 4 KiB"):
             raid_array.chunk_size = Size("5 KiB")

--- a/tests/devices_test/partition_test.py
+++ b/tests/devices_test/partition_test.py
@@ -1,12 +1,12 @@
 # vim:set fileencoding=utf-8
-import test_compat
+import test_compat  # pylint: disable=unused-import
 
 import os
 import six
 import unittest
 import parted
 
-from six.moves.mock import patch
+from six.moves.mock import patch  # pylint: disable=no-name-in-module,import-error
 
 from blivet.devices import DiskFile
 from blivet.devices import PartitionDevice

--- a/tests/devices_test/partition_test.py
+++ b/tests/devices_test/partition_test.py
@@ -2,6 +2,7 @@
 import test_compat
 
 import os
+import six
 import unittest
 import parted
 
@@ -51,28 +52,28 @@ class PartitionDeviceTestCase(unittest.TestCase):
             self.assertEqual(device.max_size, Size("9 MiB"))
 
             # ValueError if not Size
-            with self.assertRaisesRegex(ValueError,
-                                        "new size must.*type Size"):
+            with six.assertRaisesRegex(self, ValueError,
+                                       "new size must.*type Size"):
                 device.target_size = 22
 
             self.assertEqual(device.target_size, orig_size)
 
             # ValueError if size smaller than min_size
-            with self.assertRaisesRegex(ValueError,
-                                        "size.*smaller than the minimum"):
+            with six.assertRaisesRegex(self, ValueError,
+                                       "size.*smaller than the minimum"):
                 device.target_size = Size("1 MiB")
 
             self.assertEqual(device.target_size, orig_size)
 
             # ValueError if size larger than max_size
-            with self.assertRaisesRegex(ValueError,
-                                        "size.*larger than the maximum"):
+            with six.assertRaisesRegex(self, ValueError,
+                                       "size.*larger than the maximum"):
                 device.target_size = Size("11 MiB")
 
             self.assertEqual(device.target_size, orig_size)
 
             # ValueError if unaligned
-            with self.assertRaisesRegex(ValueError, "new size.*not.*aligned"):
+            with six.assertRaisesRegex(self, ValueError, "new size.*not.*aligned"):
                 device.target_size = Size("3.1 MiB")
 
             self.assertEqual(device.target_size, orig_size)

--- a/tests/devices_test/partition_test.py
+++ b/tests/devices_test/partition_test.py
@@ -1,10 +1,11 @@
 # vim:set fileencoding=utf-8
+import test_compat
 
 import os
 import unittest
 import parted
 
-from unittest.mock import patch
+from six.moves.mock import patch
 
 from blivet.devices import DiskFile
 from blivet.devices import PartitionDevice

--- a/tests/devices_test/tags_test.py
+++ b/tests/devices_test/tags_test.py
@@ -1,6 +1,7 @@
+import test_compat
 
+from six.moves.mock import patch
 import unittest
-from unittest.mock import patch
 
 from blivet.devices import DiskDevice, FcoeDiskDevice, iScsiDiskDevice, MultipathDevice, StorageDevice, ZFCPDiskDevice
 from blivet.devices.lib import Tags

--- a/tests/devices_test/tags_test.py
+++ b/tests/devices_test/tags_test.py
@@ -1,6 +1,6 @@
-import test_compat
+import test_compat  # pylint: disable=unused-import
 
-from six.moves.mock import patch
+from six.moves.mock import patch  # pylint: disable=no-name-in-module,import-error
 import unittest
 
 from blivet.devices import DiskDevice, FcoeDiskDevice, iScsiDiskDevice, MultipathDevice, StorageDevice, ZFCPDiskDevice

--- a/tests/devicetree_test.py
+++ b/tests/devicetree_test.py
@@ -1,5 +1,7 @@
+import test_compat
+
+from six.moves.mock import Mock, patch, sentinel
 import unittest
-from unittest.mock import Mock, patch, sentinel
 
 from tests.imagebackedtestcase import ImageBackedTestCase
 

--- a/tests/devicetree_test.py
+++ b/tests/devicetree_test.py
@@ -1,6 +1,7 @@
 import test_compat
 
 from six.moves.mock import Mock, patch, sentinel
+import six
 import unittest
 
 from tests.imagebackedtestcase import ImageBackedTestCase
@@ -121,13 +122,13 @@ class DeviceTreeTestCase(unittest.TestCase):
         self.assertTrue(dev1.add_hook.called)  # pylint: disable=no-member
 
         # adding an already-added device fails
-        self.assertRaisesRegex(ValueError, "already in tree", dt._add_device, dev1)
+        six.assertRaisesRegex(self, ValueError, "already in tree", dt._add_device, dev1)
 
         dev2 = StorageDevice("dev2", exists=False, parents=[])
         dev3 = StorageDevice("dev3", exists=False, parents=[dev1, dev2])
 
         # adding a device with one or more parents not already in the tree fails
-        self.assertRaisesRegex(DeviceTreeError, "parent.*not in tree", dt._add_device, dev3)
+        six.assertRaisesRegex(self, DeviceTreeError, "parent.*not in tree", dt._add_device, dev3)
         self.assertFalse(dev2 in dt.devices)
         self.assertFalse(dev2.name in dt.names)
 
@@ -146,7 +147,7 @@ class DeviceTreeTestCase(unittest.TestCase):
         dev1 = StorageDevice("dev1", exists=False, parents=[])
 
         # removing a device not in the tree raises an exception
-        self.assertRaisesRegex(ValueError, "not in tree", dt._remove_device, dev1)
+        six.assertRaisesRegex(self, ValueError, "not in tree", dt._remove_device, dev1)
 
         dt._add_device(dev1)
         with patch("blivet.devicetree.callbacks") as callbacks:
@@ -164,7 +165,7 @@ class DeviceTreeTestCase(unittest.TestCase):
         self.assertTrue(dev2.name in dt.names)
 
         # removal of a non-leaf device raises an exception
-        self.assertRaisesRegex(ValueError, "non-leaf device", dt._remove_device, dev1)
+        six.assertRaisesRegex(self, ValueError, "non-leaf device", dt._remove_device, dev1)
         self.assertTrue(dev1 in dt.devices)
         self.assertTrue(dev1.name in dt.names)
         self.assertTrue(dev2 in dt.devices)

--- a/tests/devicetree_test.py
+++ b/tests/devicetree_test.py
@@ -1,6 +1,6 @@
-import test_compat
+import test_compat  # pylint: disable=unused-import
 
-from six.moves.mock import Mock, patch, sentinel
+from six.moves.mock import Mock, patch, sentinel  # pylint: disable=no-name-in-module,import-error
 import six
 import unittest
 

--- a/tests/events_test.py
+++ b/tests/events_test.py
@@ -1,6 +1,6 @@
-import test_compat
+import test_compat  # pylint: disable=unused-import
 
-from six.moves.mock import Mock, patch
+from six.moves.mock import Mock, patch  # pylint: disable=no-name-in-module,import-error
 import time
 from unittest import TestCase
 

--- a/tests/events_test.py
+++ b/tests/events_test.py
@@ -1,6 +1,7 @@
 import test_compat
 
 from six.moves.mock import Mock, patch
+import time
 from unittest import TestCase
 
 from blivet.events.manager import Event, EventManager
@@ -29,6 +30,7 @@ class EventManagerTest(TestCase):
         device = "sdc"
         action = "add"
         mgr.handle_event(action, device)
+        time.sleep(1)
         self.assertEqual(handler_cb.call_count, 1)
         event = handler_cb.call_args[1]["event"]  # pylint: disable=unsubscriptable-object
         self.assertEqual(event.device, device)
@@ -38,6 +40,7 @@ class EventManagerTest(TestCase):
         handler_cb.reset_mock()
         mask = mgr.add_mask(device=device, action=action + 'x')
         mgr.handle_event(action, device)
+        time.sleep(1)
         self.assertEqual(handler_cb.call_count, 1)
         event = handler_cb.call_args[1]["event"]  # pylint: disable=unsubscriptable-object
         self.assertEqual(event.device, device)
@@ -47,6 +50,7 @@ class EventManagerTest(TestCase):
         handler_cb.reset_mock()
         mask = mgr.add_mask(device=device + 'x', action=action)
         mgr.handle_event(action, device)
+        time.sleep(1)
         self.assertEqual(handler_cb.call_count, 1)
         event = handler_cb.call_args[1]["event"]  # pylint: disable=unsubscriptable-object
         self.assertEqual(event.device, device)
@@ -57,6 +61,7 @@ class EventManagerTest(TestCase):
         mgr.remove_mask(mask)
         mask = mgr.add_mask(device=device, action=action)
         mgr.handle_event(action, device)
+        time.sleep(1)
         self.assertEqual(handler_cb.call_count, 0)
 
         # device-only mask matches -> event is ignored
@@ -64,6 +69,7 @@ class EventManagerTest(TestCase):
         mgr.remove_mask(mask)
         mask = mgr.add_mask(device=device)
         mgr.handle_event(action, device)
+        time.sleep(1)
         self.assertEqual(handler_cb.call_count, 0)
 
         # action-only mask matches -> event is ignored
@@ -71,5 +77,6 @@ class EventManagerTest(TestCase):
         mgr.remove_mask(mask)
         mask = mgr.add_mask(action=action)
         mgr.handle_event(action, device)
+        time.sleep(1)
         self.assertEqual(handler_cb.call_count, 0)
         mgr.remove_mask(mask)

--- a/tests/events_test.py
+++ b/tests/events_test.py
@@ -1,6 +1,7 @@
+import test_compat
 
+from six.moves.mock import Mock, patch
 from unittest import TestCase
-from unittest.mock import Mock, patch
 
 from blivet.events.manager import Event, EventManager
 

--- a/tests/formats_test/disklabel_test.py
+++ b/tests/formats_test/disklabel_test.py
@@ -1,7 +1,7 @@
-import test_compat
+import test_compat  # pylint: disable=unused-import
 
 import parted
-from six.moves import mock
+from six.moves import mock  # pylint: disable=no-name-in-module,import-error
 import unittest
 
 import blivet

--- a/tests/formats_test/disklabel_test.py
+++ b/tests/formats_test/disklabel_test.py
@@ -1,14 +1,11 @@
+import test_compat
+
 import parted
-import six
+from six.moves import mock
 import unittest
 
 import blivet
 from blivet.size import Size
-
-if six.PY2:
-    import mock
-else:
-    from unittest import mock
 
 patch = mock.patch
 

--- a/tests/formats_test/fslabeling.py
+++ b/tests/formats_test/fslabeling.py
@@ -1,13 +1,13 @@
 
 import abc
-from six import add_metaclass
+import six
 
 from tests import loopbackedtestcase
 from blivet.errors import FSError, FSReadLabelError
 from blivet.size import Size
 
 
-@add_metaclass(abc.ABCMeta)
+@six.add_metaclass(abc.ABCMeta)
 class LabelingAsRoot(loopbackedtestcase.LoopBackedTestCase):
 
     """Tests various aspects of labeling a filesystem where there
@@ -99,11 +99,11 @@ class LabelingWithRelabeling(LabelingAsRoot):
         self.assertIsNone(an_fs.write_label())
 
         an_fs.label = None
-        with self.assertRaisesRegex(FSError, "default label"):
+        with six.assertRaisesRegex(self, FSError, "default label"):
             an_fs.write_label()
 
         an_fs.label = self._invalid_label
-        with self.assertRaisesRegex(FSError, "bad label format"):
+        with six.assertRaisesRegex(self, FSError, "bad label format"):
             an_fs.write_label()
 
 
@@ -140,11 +140,11 @@ class CompleteLabelingAsRoot(LabelingAsRoot):
         self.assertEqual(an_fs.read_label(), an_fs.label)
 
         an_fs.label = None
-        with self.assertRaisesRegex(FSError, "default label"):
+        with six.assertRaisesRegex(self, FSError, "default label"):
             an_fs.write_label()
 
         an_fs.label = "n" * 129
-        with self.assertRaisesRegex(FSError, "bad label format"):
+        with six.assertRaisesRegex(self, FSError, "bad label format"):
             an_fs.write_label()
 
     def test_creating(self):

--- a/tests/formats_test/fsuuid.py
+++ b/tests/formats_test/fsuuid.py
@@ -1,6 +1,6 @@
 import sys
 import abc
-from six import add_metaclass
+import six
 from unittest import skipIf
 
 from tests import loopbackedtestcase
@@ -9,7 +9,7 @@ from blivet.size import Size
 from blivet.util import capture_output
 
 
-@add_metaclass(abc.ABCMeta)
+@six.add_metaclass(abc.ABCMeta)
 class SetUUID(loopbackedtestcase.LoopBackedTestCase):
 
     """Base class for UUID tests without any test methods."""
@@ -46,7 +46,7 @@ class SetUUIDWithMkFs(SetUUID):
         an_fs = self._fs_class(device=self.loop_devices[0],
                                uuid=self._invalid_uuid)
         if self._fs_class._type == "swap":
-            with self.assertRaisesRegex(FSWriteUUIDError, "bad UUID format"):
+            with six.assertRaisesRegex(self, FSWriteUUIDError, "bad UUID format"):
                 an_fs.create()
         else:
             with self.assertLogs('blivet', 'WARNING') as logs:
@@ -97,7 +97,7 @@ class SetUUIDAfterMkFs(SetUUID):
         self.assertIsNone(an_fs.create())
 
         an_fs.uuid = self._invalid_uuid
-        with self.assertRaisesRegex(FSError, "bad UUID format"):
+        with six.assertRaisesRegex(self, FSError, "bad UUID format"):
             an_fs.write_uuid()
 
     def test_reset_uuid(self):

--- a/tests/formats_test/luks_test.py
+++ b/tests/formats_test/luks_test.py
@@ -1,5 +1,7 @@
+import test_compat
+
+from six.moves.mock import patch
 import unittest
-from unittest.mock import patch
 
 from blivet.formats.luks import LUKS
 

--- a/tests/formats_test/luks_test.py
+++ b/tests/formats_test/luks_test.py
@@ -11,7 +11,7 @@ from tests import loopbackedtestcase
 class LUKSTestCase(loopbackedtestcase.LoopBackedTestCase):
 
     def __init__(self, methodName='run_test'):
-        super().__init__(methodName=methodName, device_spec=[Size("100 MiB")])
+        super(LUKSTestCase, self).__init__(methodName=methodName, device_spec=[Size("100 MiB")])
         self.fmt = LUKS(passphrase="password")
 
     def test_size(self):

--- a/tests/formats_test/luks_test.py
+++ b/tests/formats_test/luks_test.py
@@ -1,6 +1,6 @@
-import test_compat
+import test_compat  # pylint: disable=unused-import
 
-from six.moves.mock import patch
+from six.moves.mock import patch  # pylint: disable=no-name-in-module,import-error
 import unittest
 
 from blivet.formats.luks import LUKS

--- a/tests/formats_test/methods_test.py
+++ b/tests/formats_test/methods_test.py
@@ -1,7 +1,7 @@
-import test_compat
+import test_compat  # pylint: disable=unused-import
 
 import six
-from six.moves.mock import patch, sentinel, PropertyMock
+from six.moves.mock import patch, sentinel, PropertyMock  # pylint: disable=no-name-in-module,import-error
 import unittest
 
 from blivet.errors import DeviceFormatError

--- a/tests/formats_test/methods_test.py
+++ b/tests/formats_test/methods_test.py
@@ -1,5 +1,7 @@
+import test_compat
+
+from six.moves.mock import patch, sentinel, PropertyMock
 import unittest
-from unittest.mock import patch, sentinel, PropertyMock
 
 from blivet.errors import DeviceFormatError
 from blivet.formats import DeviceFormat

--- a/tests/formats_test/methods_test.py
+++ b/tests/formats_test/methods_test.py
@@ -1,5 +1,6 @@
 import test_compat
 
+import six
 from six.moves.mock import patch, sentinel, PropertyMock
 import unittest
 
@@ -85,7 +86,7 @@ class FormatMethodsTestCase(unittest.TestCase):
         self.format.exists = True
         with patch.object(self.format, "_create"):
             self.set_os_path_exists(True)
-            self.assertRaisesRegex(DeviceFormatError, "format already exists", self.format.create)
+            six.assertRaisesRegex(self, DeviceFormatError, "format already exists", self.format.create)
             self.assertFalse(self.format._create.called)  # pylint: disable=no-member
         self.format.exists = False
 
@@ -93,7 +94,7 @@ class FormatMethodsTestCase(unittest.TestCase):
         with patch.object(self.format, "_create"):
             # device must be accessible
             self.set_os_path_exists(False)
-            self.assertRaisesRegex(DeviceFormatError, "invalid device specification", self.format.create)
+            six.assertRaisesRegex(self, DeviceFormatError, "invalid device specification", self.format.create)
             self.assertFalse(self.format._create.called)  # pylint: disable=no-member
         self.set_os_path_exists(True)
 
@@ -107,14 +108,14 @@ class FormatMethodsTestCase(unittest.TestCase):
         with patch.object(self.format, "_create"):
             with patch.object(self.format, "_pre_create") as m:
                 m.side_effect = _fail
-                self.assertRaisesRegex(RuntimeError, "problems", self.format.create)
+                six.assertRaisesRegex(self, RuntimeError, "problems", self.format.create)
                 self.assertFalse(self.format._create.called)  # pylint: disable=no-member
                 self.assertFalse(self.format.exists)
 
         # _create raises -> no _post_create -> exists == False
         with patch.object(self.format, "_create") as m:
             m.side_effect = _fail
-            self.assertRaisesRegex(RuntimeError, "problems", self.format.create)
+            six.assertRaisesRegex(self, RuntimeError, "problems", self.format.create)
             self.assertTrue(self.format._create.called)  # pylint: disable=no-member
             self.assertFalse(self.format.exists)
 
@@ -138,7 +139,7 @@ class FormatMethodsTestCase(unittest.TestCase):
         self.format.exists = False
         with patch.object(self.format, "_destroy"):
             self.patches["os"].access.return_value = True
-            self.assertRaisesRegex(DeviceFormatError, "has not been created", self.format.destroy)
+            six.assertRaisesRegex(self, DeviceFormatError, "has not been created", self.format.destroy)
             self.assertFalse(self.format._destroy.called)  # pylint: disable=no-member
 
         self.format.exists = True
@@ -146,14 +147,14 @@ class FormatMethodsTestCase(unittest.TestCase):
         # format must be inactive
         with patch.object(self.format, "_destroy"):
             self.patches["status"].return_value = True
-            self.assertRaisesRegex(DeviceFormatError, "is active", self.format.destroy)
+            six.assertRaisesRegex(self, DeviceFormatError, "is active", self.format.destroy)
             self.assertFalse(self.format._destroy.called)  # pylint: disable=no-member
 
         # device must be accessible
         with patch.object(self.format, "_destroy"):
             self.patches["os"].access.return_value = False
             self.patches["status"].return_value = False
-            self.assertRaisesRegex(DeviceFormatError, "device path does not exist", self.format.destroy)
+            six.assertRaisesRegex(self, DeviceFormatError, "device path does not exist", self.format.destroy)
             self.assertFalse(self.format._destroy.called)  # pylint: disable=no-member
 
         self.patches["os"].access.return_value = True
@@ -167,14 +168,14 @@ class FormatMethodsTestCase(unittest.TestCase):
         with patch.object(self.format, "_destroy"):
             with patch.object(self.format, "_pre_destroy") as m:
                 m.side_effect = _fail
-                self.assertRaisesRegex(RuntimeError, "problems", self.format.destroy)
+                six.assertRaisesRegex(self, RuntimeError, "problems", self.format.destroy)
                 self.assertFalse(self.format._destroy.called)  # pylint: disable=no-member
                 self.assertTrue(self.format.exists)
 
         # _destroy raises -> no _post_destroy -> exists == True
         with patch.object(self.format, "_destroy") as m:
             m.side_effect = _fail
-            self.assertRaisesRegex(RuntimeError, "problems", self.format.destroy)
+            six.assertRaisesRegex(self, RuntimeError, "problems", self.format.destroy)
             self.assertTrue(self.format._destroy.called)  # pylint: disable=no-member
             self.assertTrue(self.format.exists)
 
@@ -198,7 +199,7 @@ class FormatMethodsTestCase(unittest.TestCase):
         self.format.exists = False
         with patch.object(self.format, "_setup"):
             self.set_os_path_exists(True)
-            self.assertRaisesRegex(DeviceFormatError, "has not been created", self.format.setup)
+            six.assertRaisesRegex(self, DeviceFormatError, "has not been created", self.format.setup)
             # _pre_setup raises exn -> no _setup
             self.assertFalse(self.format._setup.called)  # pylint: disable=no-member
         self.format.exists = True
@@ -206,7 +207,7 @@ class FormatMethodsTestCase(unittest.TestCase):
         # device must be accessible
         with patch.object(self.format, "_setup"):
             self.set_os_path_exists(False)
-            self.assertRaisesRegex(DeviceFormatError, "invalid|does not exist", self.format.setup)
+            six.assertRaisesRegex(self, DeviceFormatError, "invalid|does not exist", self.format.setup)
             # _pre_setup raises exn -> no _setup
             self.assertFalse(self.format._setup.called)  # pylint: disable=no-member
 
@@ -226,7 +227,7 @@ class FormatMethodsTestCase(unittest.TestCase):
 
         with patch.object(self.format, "_setup", side_effect=_fail):
             with patch.object(self.format, "_post_setup"):
-                self.assertRaisesRegex(RuntimeError, "problems", self.format.setup)
+                six.assertRaisesRegex(self, RuntimeError, "problems", self.format.setup)
                 self.assertFalse(self.format._post_setup.called)  # pylint: disable=no-member
 
         # _setup succeeds -> _post_setup
@@ -244,7 +245,7 @@ class FormatMethodsTestCase(unittest.TestCase):
         self.format.exists = False
         with patch.object(self.format, "_teardown"):
             self.set_os_path_exists(True)
-            self.assertRaisesRegex(DeviceFormatError, "has not been created", self.format.teardown)
+            six.assertRaisesRegex(self, DeviceFormatError, "has not been created", self.format.teardown)
             self.assertFalse(self.format._teardown.called)  # pylint: disable=no-member
         self.format.exists = True
 
@@ -252,7 +253,7 @@ class FormatMethodsTestCase(unittest.TestCase):
         # device must be accessible
         # with patch.object(self.format, "_teardown"):
         #    self.set_os_path_exists(False)
-        #    self.assertRaisesRegex(DeviceFormatError, "invalid device specification", self.format.teardown)
+        #    six.assertRaisesRegex(self, DeviceFormatError, "invalid device specification", self.format.teardown)
         #    self.assertFalse(self.format._teardown.called)  # pylint: disable=no-member
 
         # _teardown fails -> no _post_teardown
@@ -264,7 +265,7 @@ class FormatMethodsTestCase(unittest.TestCase):
 
         with patch.object(self.format, "_teardown", side_effect=_fail):
             with patch.object(self.format, "_post_teardown"):
-                self.assertRaisesRegex(RuntimeError, "problems", self.format.teardown)
+                six.assertRaisesRegex(self, RuntimeError, "problems", self.format.teardown)
                 self.assertFalse(self.format._post_teardown.called)  # pylint: disable=no-member
 
         # _teardown succeeds -> _post_teardown

--- a/tests/formats_test/methods_test.py
+++ b/tests/formats_test/methods_test.py
@@ -14,7 +14,7 @@ class FormatMethodsTestCase(unittest.TestCase):
     format_class = DeviceFormat
 
     def __init__(self, methodName='runTest'):
-        super().__init__(methodName=methodName)
+        super(FormatMethodsTestCase, self).__init__(methodName=methodName)
         self.patchers = dict()
         self.patches = dict()
 
@@ -278,7 +278,7 @@ class FSMethodsTestCase(FormatMethodsTestCase):
     format_class = None
 
     def set_patches(self):
-        super().set_patches()
+        super(FSMethodsTestCase, self).set_patches()
         self.patchers["udev"] = patch("blivet.formats.fs.udev")
         self.patchers["util"] = patch("blivet.formats.fs.util")
         self.patchers["system_mountpoint"] = patch.object(self.format_class,
@@ -290,10 +290,10 @@ class FSMethodsTestCase(FormatMethodsTestCase):
         if self.format_class is None:
             return unittest.skip('abstract base class')
 
-        super().setUp()
+        super(FSMethodsTestCase, self).setUp()
 
     def set_os_path_exists(self, value):
-        super().set_os_path_exists(value)
+        super(FSMethodsTestCase, self).set_os_path_exists(value)
         self.patches["fs_os"].path.exists.return_value = value
 
     def _test_create_backend(self):
@@ -321,24 +321,24 @@ class FSMethodsTestCase(FormatMethodsTestCase):
     def test_create(self):
         if self.format_class is None:
             return unittest.skip('abstract base class')
-        super().test_create()
+        super(FSMethodsTestCase, self).test_create()
 
     def test_destroy(self):
         if self.format_class is None:
             return unittest.skip('abstract base class')
-        super().test_destroy()
+        super(FSMethodsTestCase, self).test_destroy()
 
     def test_setup(self):
         if self.format_class is None:
             return unittest.skip('abstract base class')
         self.format.mountpoint = "/fake/mountpoint"
-        super().test_setup()
+        super(FSMethodsTestCase, self).test_setup()
 
     def test_teardown(self):
         if self.format_class is None:
             return unittest.skip('abstract base class')
 
-        super().test_teardown()
+        super(FSMethodsTestCase, self).test_teardown()
 
 
 class Ext4FSMethodsTestCase(FSMethodsTestCase):
@@ -353,7 +353,7 @@ class LUKSMethodsTestCase(FormatMethodsTestCase):
     format_class = LUKS
 
     def set_patches(self):
-        super().set_patches()
+        super(LUKSMethodsTestCase, self).set_patches()
         self.patchers["configured"] = patch.object(self.format_class, "configured", new=PropertyMock(return_value=True))
         self.patchers["has_key"] = patch.object(self.format_class, "has_key", new=PropertyMock(return_value=True))
         self.patchers["blockdev"] = patch("blivet.formats.luks.blockdev")
@@ -376,7 +376,7 @@ class LVMPhysicalVolumeMethodsTestCase(FormatMethodsTestCase):
     format_class = LVMPhysicalVolume
 
     def set_patches(self):
-        super().set_patches()
+        super(LVMPhysicalVolumeMethodsTestCase, self).set_patches()
         self.patchers["blockdev"] = patch("blivet.formats.lvmpv.blockdev")
 
     def _test_destroy_backend(self):
@@ -396,7 +396,7 @@ class MDRaidMemberMethodsTestCase(FormatMethodsTestCase):
     format_class = MDRaidMember
 
     def set_patches(self):
-        super().set_patches()
+        super(MDRaidMemberMethodsTestCase, self).set_patches()
         self.patchers["blockdev"] = patch("blivet.formats.mdraid.blockdev")
 
     def _test_destroy_backend(self):
@@ -410,7 +410,7 @@ class SwapMethodsTestCase(FormatMethodsTestCase):
     format_class = SwapSpace
 
     def set_patches(self):
-        super().set_patches()
+        super(SwapMethodsTestCase, self).set_patches()
         self.patchers["blockdev"] = patch("blivet.formats.swap.blockdev")
 
     def _test_create_backend(self):

--- a/tests/partitioning_test.py
+++ b/tests/partitioning_test.py
@@ -2,6 +2,8 @@ import test_compat
 
 import six
 from six.moves.mock import Mock, patch
+
+import six
 import unittest
 
 import parted
@@ -221,8 +223,8 @@ class PartitioningTestCase(unittest.TestCase):
             #
             # fail: add a logical partition to a primary free region
             #
-            with self.assertRaisesRegex(parted.PartitionException,
-                                        "no extended partition"):
+            with six.assertRaisesRegex(self, parted.PartitionException,
+                                       "no extended partition"):
                 part = add_partition(disk.format, free, parted.PARTITION_LOGICAL,
                                      Size("10 MiB"))
 
@@ -253,7 +255,7 @@ class PartitioningTestCase(unittest.TestCase):
             #
             # fail: add a primary partition to an extended free region
             #
-            with self.assertRaisesRegex(parted.PartitionException, "overlap"):
+            with six.assertRaisesRegex(self, parted.PartitionException, "overlap"):
                 part = add_partition(disk.format, all_free[1],
                                      parted.PARTITION_NORMAL,
                                      Size("10 MiB"), all_free[1].start)

--- a/tests/partitioning_test.py
+++ b/tests/partitioning_test.py
@@ -1,6 +1,8 @@
+import test_compat
 
+import six
+from six.moves.mock import Mock, patch
 import unittest
-from mock import Mock, patch
 
 import parted
 

--- a/tests/partitioning_test.py
+++ b/tests/partitioning_test.py
@@ -1,8 +1,6 @@
-import test_compat
+import test_compat  # pylint: disable=unused-import
 
-import six
-from six.moves.mock import Mock, patch
-
+from six.moves.mock import Mock, patch  # pylint: disable=no-name-in-module,import-error
 import six
 import unittest
 

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -28,7 +28,7 @@ from blivet.size import Size
 try:
     from pyanaconda import kickstart
     pyanaconda_present = True
-except ImportError:
+except (ImportError, AttributeError):
     pyanaconda_present = False
 
 

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -1,8 +1,10 @@
-import os
+import test_compat
+
 import gi
-import unittest
-from unittest.mock import call, patch, sentinel, Mock, PropertyMock
+import os
+from six.moves.mock import call, patch, sentinel, Mock, PropertyMock
 import six
+import unittest
 
 gi.require_version("BlockDev", "2.0")
 from gi.repository import BlockDev as blockdev

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -1,8 +1,8 @@
-import test_compat
+import test_compat  # pylint: disable=unused-import
 
 import gi
 import os
-from six.moves.mock import call, patch, sentinel, Mock, PropertyMock
+from six.moves.mock import call, patch, sentinel, Mock, PropertyMock  # pylint: disable=no-name-in-module,import-error
 import six
 import unittest
 

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -343,10 +343,13 @@ class LVMDevicePopulatorTestCase(PopulatorHelperTestCase):
                 return sentinel.non_vg_device
 
         get_device_by_name.side_effect = _get_device_by_name2
-        with self.assertLogs('blivet', level='WARNING') as log_cm:
+        if six.PY3:
+            with self.assertLogs('blivet', level='WARNING') as log_cm:
+                self.assertEqual(helper.run(), sentinel.lv_device)
+            log_entry = "WARNING:blivet:found non-vg device with name %s" % sentinel.vg_name
+            self.assertTrue(log_entry in log_cm.output)
+        else:
             self.assertEqual(helper.run(), sentinel.lv_device)
-        log_entry = "WARNING:blivet:found non-vg device with name %s" % sentinel.vg_name
-        self.assertTrue(log_entry in log_cm.output)
 
 
 class OpticalDevicePopulatorTestCase(PopulatorHelperTestCase):

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -2,6 +2,7 @@ import os
 import gi
 import unittest
 from unittest.mock import call, patch, sentinel, Mock, PropertyMock
+import six
 
 gi.require_version("BlockDev", "2.0")
 from gi.repository import BlockDev as blockdev
@@ -987,7 +988,7 @@ class LVMFormatPopulatorTestCase(FormatPopulatorTestCase):
 
         def gdbu(uuid, **kwargs):  # pylint: disable=unused-argument
             # This version doesn't check format UUIDs
-            return next((d for d in devicetree.devices if d.uuid == uuid), None)
+            return six.next((d for d in devicetree.devices if d.uuid == uuid), None)
         get_device_by_uuid.side_effect = gdbu
 
         with patch("blivet.static_data.lvm_info.PVsInfo.cache", new_callable=PropertyMock) as mock_pvs_cache:

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -23,7 +23,6 @@
 import six as _six
 
 mock_move = _six.MovedModule('mock', 'mock', 'unittest.mock')
-has_mock = False
 
 
 def add_move(mod):
@@ -33,14 +32,7 @@ def add_move(mod):
 
 
 def setup():
-    global has_mock
     add_move(mock_move)
 
-    try:
-        import six.moves.mock as _mock
-    except ImportError:
-        has_mock = False
-    else:
-        has_mock = True
 
 setup()

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,46 @@
+# test_compat.py
+# Python (2 -v- 3) compatibility functions.
+#
+# Copyright (C) 2017  Red Hat, Inc.
+#
+# This copyrighted material is made available to anyone wishing to use,
+# modify, copy, or redistribute it subject to the terms and conditions of
+# the GNU Lesser General Public License v.2, or (at your option) any later
+# version. This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY expressed or implied, including the implied
+# warranties of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+# the GNU Lesser General Public License for more details.  You should have
+# received a copy of the GNU Lesser General Public License along with this
+# program; if not, write to the Free Software Foundation, Inc., 51 Franklin
+# Street, Fifth Floor, Boston, MA 02110-1301, USA.  Any Red Hat trademarks
+# that are incorporated in the source code or documentation are not subject
+# to the GNU Lesser General Public License and may only be used or
+# replicated with the express permission of Red Hat, Inc.
+#
+# Red Hat Author(s): David Lehman <dlehman@redhat.com>
+#
+
+import six as _six
+
+mock_move = _six.MovedModule('mock', 'mock', 'unittest.mock')
+has_mock = False
+
+
+def add_move(mod):
+    _six.add_move(mod)
+    # https://bitbucket.org/gutworth/six/issues/116/enable-importing-from-within-custom
+    _six._importer._add_module(mod, "moves." + mod.name)
+
+
+def setup():
+    global has_mock
+    add_move(mock_move)
+
+    try:
+        import six.moves.mock as _mock
+    except ImportError:
+        has_mock = False
+    else:
+        has_mock = True
+
+setup()

--- a/tests/unsupported_disklabel_test.py
+++ b/tests/unsupported_disklabel_test.py
@@ -1,7 +1,8 @@
 # vim:set fileencoding=utf-8
+import test_compat
 
+from six.moves.mock import patch, sentinel, DEFAULT
 import unittest
-from unittest.mock import patch, sentinel, DEFAULT
 
 from blivet.actionlist import ActionList
 from blivet.deviceaction import ActionDestroyFormat

--- a/tests/unsupported_disklabel_test.py
+++ b/tests/unsupported_disklabel_test.py
@@ -2,6 +2,7 @@
 import test_compat
 
 from six.moves.mock import patch, sentinel, DEFAULT
+import six
 import unittest
 
 from blivet.actionlist import ActionList
@@ -23,15 +24,23 @@ class UnsupportedDiskLabelTestCase(unittest.TestCase):
                            fmt=get_format("disklabel", exists=True))
         disk1.format._supported = False
 
-        with self.assertLogs("blivet", level="INFO") as cm:
+        if six.PY3:
+            with self.assertLogs("blivet", level="INFO") as cm:
+                partition1 = PartitionDevice("testpart1", size=Size("150 GiB"), exists=True,
+                                             parents=[disk1], fmt=get_format("ext4", exists=True))
+            self.assertTrue("disklabel is unsupported" in "\n".join(cm.output))
+        else:
             partition1 = PartitionDevice("testpart1", size=Size("150 GiB"), exists=True,
                                          parents=[disk1], fmt=get_format("ext4", exists=True))
-        self.assertTrue("disklabel is unsupported" in "\n".join(cm.output))
 
-        with self.assertLogs("blivet", level="INFO") as cm:
+        if six.PY3:
+            with self.assertLogs("blivet", level="INFO") as cm:
+                partition2 = PartitionDevice("testpart2", size=Size("100 GiB"), exists=True,
+                                             parents=[disk1], fmt=get_format("lvmpv", exists=True))
+            self.assertTrue("disklabel is unsupported" in "\n".join(cm.output))
+        else:
             partition2 = PartitionDevice("testpart2", size=Size("100 GiB"), exists=True,
                                          parents=[disk1], fmt=get_format("lvmpv", exists=True))
-        self.assertTrue("disklabel is unsupported" in "\n".join(cm.output))
 
         # To be supported, all of a devices ancestors must be supported.
         disk2 = DiskDevice("testdisk2", size=Size("300 GiB"), exists=True,

--- a/tests/unsupported_disklabel_test.py
+++ b/tests/unsupported_disklabel_test.py
@@ -1,7 +1,7 @@
 # vim:set fileencoding=utf-8
-import test_compat
+import test_compat  # pylint: disable=unused-import
 
-from six.moves.mock import patch, sentinel, DEFAULT
+from six.moves.mock import patch, sentinel, DEFAULT  # pylint: disable=no-name-in-module,import-error
 import six
 import unittest
 

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -1,7 +1,8 @@
 # pylint: skip-file
+import test_compat
 
+from six.moves import mock
 import unittest
-from unittest import mock
 from decimal import Decimal
 
 from blivet import errors
@@ -144,6 +145,6 @@ class DependencyGuardTestCase(unittest.TestCase):
         with self.assertRaises(errors.DependencyError):
             self._test_dependency_guard_critical()
 
-        with unittest.mock.patch.object(_requires_something, '_check_avail', return_value=True):
+        with mock.patch.object(_requires_something, '_check_avail', return_value=True):
             self.assertEqual(self._test_dependency_guard_non_critical(), True)
             self.assertEqual(self._test_dependency_guard_critical(), True)

--- a/tests/util_test.py
+++ b/tests/util_test.py
@@ -2,6 +2,7 @@
 import test_compat
 
 from six.moves import mock
+import six
 import unittest
 from decimal import Decimal
 
@@ -138,9 +139,12 @@ class DependencyGuardTestCase(unittest.TestCase):
 
     def test_dependency_guard(self):
         guard = TestDependencyGuard()
-        with self.assertLogs("blivet", level="WARNING") as cm:
+        if six.PY3:
+            with self.assertLogs("blivet", level="WARNING") as cm:
+                self.assertEqual(self._test_dependency_guard_non_critical(), None)
+            self.assertTrue(TestDependencyGuard.error_msg in "\n".join(cm.output))
+        else:
             self.assertEqual(self._test_dependency_guard_non_critical(), None)
-        self.assertTrue(TestDependencyGuard.error_msg in "\n".join(cm.output))
 
         with self.assertRaises(errors.DependencyError):
             self._test_dependency_guard_critical()


### PR DESCRIPTION
This gets us to the point where we can run the unit tests under both python2 and python3 (on Fedora 25).

TODO:

- [x] work out a compatible way to run pylint under python2 or python3
- [ ] Makefile changes to run tests and pylint for both python versions
- [ ] rpm spec file changes to build for both python versions
- [ ] handle missing mock module in python2 where it isn't standard