### PR TITLE
Use the uuid module instead of the uuidgen tool

### DIFF
--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -26,6 +26,7 @@ from decimal import Decimal
 import os
 import shlex
 import tempfile
+import uuid as uuid_mod
 
 from . import fslabeling
 from ..errors import FormatCreateError, FSError, FSResizeError
@@ -764,8 +765,7 @@ class FS(DeviceFormat):
         self.notifyKernel()
 
     def _getRandomUUID(self):
-        uuid = util.capture_output(["uuidgen"]).strip()
-        return uuid
+        return str(uuid_mod.uuid4())
 
     @property
     def needsFSCheck(self):


### PR DESCRIPTION
The uuid module is shipped together with Python so we should use
it instead of requiring an extra utility.

note: This requires a *rhbz#* reference to be added.