### PR TITLE
Various pylint fixes

### DIFF
--- a/blivet/blivet.py
+++ b/blivet/blivet.py
@@ -1392,7 +1392,7 @@ class Blivet(object, metaclass=SynchronizedMeta):
         key = "devices.%d.%s" % (time.time(), suffix)
         with contextlib.closing(shelve.open(self._dump_file)) as shelf:
             try:
-                shelf[key] = [d.dict for d in self.devices]
+                shelf[key] = [d.dict for d in self.devices]  # pylint: disable=unsupported-assignment-operation
             except AttributeError:
                 log_exception_info()
 

--- a/blivet/devicefactory.py
+++ b/blivet/devicefactory.py
@@ -1662,7 +1662,7 @@ class MDFactory(DeviceFactory):
     def get_container(self, device=None, name=None, allow_existing=False):
         return self.raw_device
 
-    def _create_container(self, *args, **kwargs):
+    def _create_container(self):
         pass
 
 

--- a/blivet/devices/btrfs.py
+++ b/blivet/devices/btrfs.py
@@ -311,13 +311,13 @@ class BTRFSVolumeDevice(BTRFSDevice, ContainerDevice, RaidDevice):
                                    chunk_size=Size(1),
                                    superblock_size_func=lambda x: 0)
 
-    def _remove_parent(self, member):
+    def _remove_parent(self, parent):
         levels = (l for l in (self.data_level, self.metadata_level) if l)
         for l in levels:
-            error_msg = self._validate_parent_removal(l, member)
+            error_msg = self._validate_parent_removal(l, parent)
             if error_msg:
                 raise errors.DeviceError(error_msg)
-        super(BTRFSVolumeDevice, self)._remove_parent(member)
+        super(BTRFSVolumeDevice, self)._remove_parent(parent)
 
     def _add_subvolume(self, vol):
         if vol.name in [v.name for v in self.subvolumes]:

--- a/blivet/devices/container.py
+++ b/blivet/devices/container.py
@@ -107,24 +107,24 @@ class ContainerDevice(StorageDevice):
 
         return None
 
-    def _add_parent(self, member):
-        """ Add a member device to the container.
+    def _add_parent(self, parent):
+        """ Add a parent device to the container.
 
-            :param member: the member device to add
-            :type member: :class:`.StorageDevice`
+            :param parent: the parent device to add
+            :type parent: :class:`.StorageDevice`
 
             This operates on the in-memory model and does not alter disk
             contents at all.
         """
-        log_method_call(self, self.name, member=member.name)
-        if not isinstance(member.format, self.format_class):
-            raise ValueError("member has wrong format")
+        log_method_call(self, self.name, parent=parent.name)
+        if not isinstance(parent.format, self.format_class):
+            raise ValueError("parent has wrong format")
 
-        error = self._verify_member_uuid(member)
+        error = self._verify_member_uuid(parent)
         if error:
-            raise ValueError("cannot add member with mismatched UUID")
+            raise ValueError("cannot add parent with mismatched UUID")
 
-        super(ContainerDevice, self)._add_parent(member)
+        super(ContainerDevice, self)._add_parent(parent)
 
     @abc.abstractmethod
     def _add(self, member):

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -1133,7 +1133,7 @@ class LVMInternalLogicalVolumeMixin(object):
 
     @property
     def resizable(self):
-        if DMDevice.resizable.__get__(self) and self._lv_type is LVMInternalLVtype.meta:  # pylint: disable=no-member
+        if DMDevice.resizable.__get__(self) and self._lv_type is LVMInternalLVtype.meta:  # pylint: disable=no-member,too-many-function-args
             if self._parent_lv:
                 return self._parent_lv.is_thin_pool
             else:

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -340,28 +340,28 @@ class LVMVolumeGroupDevice(ContainerDevice):
             for size_spec in pv_sizes:
                 size_spec.pv.format.free += size_spec.size
 
-    def _add_parent(self, member):
-        super(LVMVolumeGroupDevice, self)._add_parent(member)
+    def _add_parent(self, parent):
+        super(LVMVolumeGroupDevice, self)._add_parent(parent)
 
-        if (self.exists and member.format.exists and
+        if (self.exists and parent.format.exists and
                 len(self.parents) + 1 == self.pv_count):
             self._complete = True
 
         # this PV object is just being added so it has all its space available
         # (adding LVs will eat that space later)
-        if not member.format.exists:
-            member.format.free = self._get_pv_usable_space(member)
+        if not parent.format.exists:
+            parent.format.free = self._get_pv_usable_space(parent)
 
-    def _remove_parent(self, member):
+    def _remove_parent(self, parent):
         # XXX It would be nice to raise an exception if removing this member
         #     would not leave enough space, but the devicefactory relies on it
         #     being possible to _temporarily_ overcommit the VG.
         #
         #     Maybe remove_member could be a wrapper with the checks and the
         #     devicefactory could call the _ versions to bypass the checks.
-        super(LVMVolumeGroupDevice, self)._remove_parent(member)
-        member.format.free = None
-        member.format.container_uuid = None
+        super(LVMVolumeGroupDevice, self)._remove_parent(parent)
+        parent.format.free = None
+        parent.format.container_uuid = None
 
     # We can't rely on lvm to tell us about our size, free space, &c
     # since we could have modifications queued, unless the VG and all of

--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -1169,13 +1169,13 @@ class LVMInternalLogicalVolumeMixin(object):
         pass
 
     # internal LVs follow different rules limitting size
-    def _set_size(self, size):
-        if not isinstance(size, Size):
+    def _set_size(self, newsize):
+        if not isinstance(newsize, Size):
             raise ValueError("new size must of type Size")
 
         if not self.takes_extra_space:
-            if size <= self.parent_lv.size:  # pylint: disable=no-member
-                self._size = size  # pylint: disable=attribute-defined-outside-init
+            if newsize <= self.parent_lv.size:  # pylint: disable=no-member
+                self._size = newsize  # pylint: disable=attribute-defined-outside-init
             else:
                 raise ValueError("Internal LV cannot be bigger than its parent LV")
         else:
@@ -1638,15 +1638,15 @@ class LVMThinLogicalVolumeMixin(object):
     def vg_space_used(self):
         return Size(0)    # the pool's size is already accounted for in the vg
 
-    def _set_size(self, size):
-        if not isinstance(size, Size):
+    def _set_size(self, newsize):
+        if not isinstance(newsize, Size):
             raise ValueError("new size must of type Size")
 
-        size = self.vg.align(size)
-        size = self.vg.align(util.numeric_type(size))
+        newsize = self.vg.align(newsize)
+        newsize = self.vg.align(util.numeric_type(newsize))
         # just make sure the size is set (no VG size/free space check needed for
         # a thin LV)
-        DMDevice._set_size(self, size)
+        DMDevice._set_size(self, newsize)
 
     def _pre_create(self):
         # skip LVMLogicalVolumeDevice's _pre_create() method as it checks for a
@@ -1890,20 +1890,20 @@ class LVMLogicalVolumeDevice(LVMLogicalVolumeBase, LVMInternalLogicalVolumeMixin
         return super().vg
 
     @type_specific
-    def _set_size(self, size):
-        if not isinstance(size, Size):
+    def _set_size(self, newsize):
+        if not isinstance(newsize, Size):
             raise ValueError("new size must be of type Size")
 
-        size = self.vg.align(size)
-        log.debug("trying to set lv %s size to %s", self.name, size)
+        newsize = self.vg.align(newsize)
+        log.debug("trying to set lv %s size to %s", self.name, newsize)
         # Don't refuse to set size if we think there's not enough space in the
         # VG for an existing LV, since it's existence proves there is enough
         # space for it. A similar reasoning applies to shrinking the LV.
-        if not self.exists and size > self.size and size > self.vg.free_space + self.vg_space_used:
-            log.error("failed to set size: %s short", size - (self.vg.free_space + self.vg_space_used))
+        if not self.exists and newsize > self.size and newsize > self.vg.free_space + self.vg_space_used:
+            log.error("failed to set size: %s short", newsize - (self.vg.free_space + self.vg_space_used))
             raise ValueError("not enough free space in volume group")
 
-        LVMLogicalVolumeBase._set_size(self, size)
+        LVMLogicalVolumeBase._set_size(self, newsize)
 
     size = property(StorageDevice._get_size, _set_size)
 

--- a/blivet/devices/md.py
+++ b/blivet/devices/md.py
@@ -359,36 +359,36 @@ class MDRaidArrayDevice(ContainerDevice, RaidDevice):
 
     spares = property(_get_spares, _set_spares)
 
-    def _add_parent(self, member):
-        super(MDRaidArrayDevice, self)._add_parent(member)
+    def _add_parent(self, parent):
+        super(MDRaidArrayDevice, self)._add_parent(parent)
 
-        if self.status and member.format.exists:
+        if self.status and parent.format.exists:
             # we always probe since the device may not be set up when we want
             # information about it
             self._size = self.current_size
 
-        # These should be incremented when adding new member devices except
+        # These should be incremented when adding new parent devices except
         # during devicetree.populate. When detecting existing arrays we will
         # have gotten these values from udev and will use them to determine
-        # whether we found all of the members, so we shouldn't change them in
+        # whether we found all of the parents, so we shouldn't change them in
         # that case.
-        if not member.format.exists:
+        if not parent.format.exists:
             self._total_devices += 1
             self.member_devices += 1
 
-        # The new member hasn't been added yet, so account for it explicitly.
-        is_disk = self.is_disk and member.is_disk
+        # The new parent hasn't been added yet, so account for it explicitly.
+        is_disk = self.is_disk and parent.is_disk
         for p in self.parents:
             p.format._hidden = is_disk
 
-        member.format._hidden = is_disk
+        parent.format._hidden = is_disk
 
-    def _remove_parent(self, member):
-        error_msg = self._validate_parent_removal(self.level, member)
+    def _remove_parent(self, parent):
+        error_msg = self._validate_parent_removal(self.level, parent)
         if error_msg:
             raise errors.DeviceError(error_msg)
 
-        super(MDRaidArrayDevice, self)._remove_parent(member)
+        super(MDRaidArrayDevice, self)._remove_parent(parent)
         self.member_devices -= 1
 
     @property
@@ -729,22 +729,22 @@ class MDBiosRaidArrayDevice(MDRaidArrayDevice):
     def _get_member_devices(self):
         return self.parents[0].member_devices
 
-    def _add_parent(self, member):
+    def _add_parent(self, parent):
         # pylint: disable=bad-super-call
-        super(MDRaidArrayDevice, self)._add_parent(member)
+        super(MDRaidArrayDevice, self)._add_parent(parent)
 
-        if self.status and member.format.exists:
+        if self.status and parent.format.exists:
             # we always probe since the device may not be set up when we want
             # information about it
             self._size = self.current_size
 
-    def _remove_parent(self, member):
-        error_msg = self._validate_parent_removal(self.level, member)
+    def _remove_parent(self, parent):
+        error_msg = self._validate_parent_removal(self.level, parent)
         if error_msg:
             raise errors.DeviceError(error_msg)
 
         # pylint: disable=bad-super-call
-        super(MDRaidArrayDevice, self)._remove_parent(member)
+        super(MDRaidArrayDevice, self)._remove_parent(parent)
 
     def teardown(self, recursive=None):
         log_method_call(self, self.name, status=self.status,

--- a/blivet/formats/fs.py
+++ b/blivet/formats/fs.py
@@ -1305,7 +1305,7 @@ class TmpFS(NoDevFS):
         """ A filesystem is created automatically once tmpfs is mounted. """
         pass
 
-    def destroy(self, *args, **kwargs):
+    def destroy(self, **kwargs):
         """ The device and its filesystem are automatically destroyed once the
         mountpoint is unmounted.
         """
@@ -1361,7 +1361,7 @@ class TmpFS(NoDevFS):
         """ All the tmpfs mounts use the same "tmpfs" device. """
         return self._type
 
-    def _set_device(self, value):
+    def _set_device(self, devspec):
         # the DeviceFormat parent class does a
         # self.device = kwargs["device"]
         # assignment, so we need a setter for the

--- a/blivet/formats/swap.py
+++ b/blivet/formats/swap.py
@@ -141,12 +141,12 @@ class SwapSpace(DeviceFormat):
 
         return opts
 
-    def _set_options(self, opts):
-        if not opts:
+    def _set_options(self, options):
+        if not options:
             self.priority = None
             return
 
-        for option in opts.split(","):
+        for option in options.split(","):
             (opt, equals, arg) = option.partition("=")
             if equals and opt == "pri":
                 try:

--- a/blivet/platform.py
+++ b/blivet/platform.py
@@ -198,9 +198,6 @@ class X86(Platform):
     _boot_stage1_missing_error = N_("You must include at least one MBR- or "
                                     "GPT-formatted disk as an install target.")
 
-    def __init__(self):
-        super(X86, self).__init__()
-
     def set_platform_bootloader_reqs(self):
         """Return the default platform-specific partitioning information."""
         ret = Platform.set_platform_bootloader_reqs(self)

--- a/blivet/size.py
+++ b/blivet/size.py
@@ -95,6 +95,7 @@ class Size(bytesize.Size):
     def __deepcopy__(self, memo_dict):
         return Size(bytesize.Size.__deepcopy__(self, memo_dict))
 
+    # pylint: disable=arguments-differ
     def convert_to(self, spec=None):
         """ Return the size in the units indicated by the specifier.
 
@@ -137,6 +138,7 @@ class Size(bytesize.Size):
             max_places = -1
         return bytesize.Size.human_readable(self, min_unit, max_places, xlate)
 
+    # pylint: disable=arguments-differ
     def round_to_nearest(self, size, rounding=ROUND_DEFAULT):
         """ Rounds to nearest unit specified as a named constant or a Size.
 

--- a/blivet/util.py
+++ b/blivet/util.py
@@ -167,7 +167,7 @@ def _run_program(argv, root='/', stdin=None, env_prune=None, stderr_to_stdout=Fa
         if root and root != '/':
             os.chroot(root)
 
-    with program_log_lock:
+    with program_log_lock:  # pylint: disable=not-context-manager
         program_log.info("Running... %s", " ".join(argv))
 
         env = os.environ.copy()

--- a/tests/devicelibs_test/edd_test.py
+++ b/tests/devicelibs_test/edd_test.py
@@ -109,7 +109,7 @@ class EddTestCase(unittest.TestCase):
                                 "../../tests/devicelibs_test/edd_data/",
                                 name)
 
-    def debug(self, *args):
+    def edd_debug(self, *args):
         fmt = "edd_test: "
         if len(args) >= 0:
             fmt += args[0]
@@ -135,7 +135,7 @@ class EddTestCase(unittest.TestCase):
         }
 
         edd_dict = edd.collect_edd_data(root=self.root("sata_usb"))
-        self.debug('edd_dict: %s', edd_dict)
+        self.edd_debug('edd_dict: %s', edd_dict)
         debugs = [
             ("edd: found device 0x%x at %s", 0x80,
              '/sys/firmware/edd/int13_dev80/'),
@@ -174,7 +174,7 @@ class EddTestCase(unittest.TestCase):
         }
 
         edd_dict = edd.get_edd_dict(devices, root=self.root("sata_usb"))
-        self.debug('edd_dict: %s', edd_dict)
+        self.edd_debug('edd_dict: %s', edd_dict)
         lib.assertVerboseEqual(len(edd_dict), 2)
         lib.assertVerboseEqual(edd_dict["sda"], 0x80)
         lib.assertVerboseEqual(edd_dict["sdb"], 0x81)
@@ -235,7 +235,7 @@ class EddTestCase(unittest.TestCase):
                                sysfspath="/sys/firmware/edd/int13_dev85/"),
         }
         edd_dict = edd.collect_edd_data(root=self.root('absurd_virt'))
-        self.debug('edd_dict: %s', edd_dict)
+        self.edd_debug('edd_dict: %s', edd_dict)
         lib.assertVerboseEqual(len(edd_dict), 6)
         lib.assertVerboseEqual(fakeedd[0x80], edd_dict[0x80])
         lib.assertVerboseEqual(fakeedd[0x81], edd_dict[0x81])
@@ -313,7 +313,7 @@ class EddTestCase(unittest.TestCase):
                    )
 
         edd_dict = edd.get_edd_dict(devices, root=self.root("absurd_virt"))
-        self.debug('edd_dict: %s', edd_dict)
+        self.edd_debug('edd_dict: %s', edd_dict)
         lib.assertVerboseEqual(len(edd_dict), 6)
         # this order is *completely unlike* the order in virt-manager,
         # but it does appear to be what EDD is displaying.
@@ -419,7 +419,7 @@ class EddTestCase(unittest.TestCase):
         }
 
         edd_dict = edd.collect_edd_data(root=self.root('strawberry_mountain'))
-        self.debug('edd_dict: %s', edd_dict)
+        self.edd_debug('edd_dict: %s', edd_dict)
         debugs = [
             ("edd: found device 0x%x at %s", 0x80,
              '/sys/firmware/edd/int13_dev80/'),
@@ -481,7 +481,7 @@ class EddTestCase(unittest.TestCase):
 
         edd_dict = edd.get_edd_dict(devices,
                                     root=self.root('strawberry_mountain'))
-        self.debug('edd_dict: %s', edd_dict)
+        self.edd_debug('edd_dict: %s', edd_dict)
         debugs = [
             ("edd: data extracted from 0x%x:%r", 0x80, fakeedd[0x80]),
             ("edd: data extracted from 0x%x:%r", 0x81, fakeedd[0x81]),
@@ -563,7 +563,7 @@ class EddTestCase(unittest.TestCase):
         }
 
         edd_dict = edd.collect_edd_data(root=self.root("bad_sata_virt"))
-        self.debug('edd_dict: %s', edd_dict)
+        self.edd_debug('edd_dict: %s', edd_dict)
         debugs = [
             ("edd: found device 0x%x at %s", 0x80,
              '/sys/firmware/edd/int13_dev80/'),
@@ -605,7 +605,7 @@ class EddTestCase(unittest.TestCase):
         }
 
         edd_dict = edd.get_edd_dict(devices, root=self.root('bad_sata_virt'))
-        self.debug('edd_dict: %s', edd_dict)
+        self.edd_debug('edd_dict: %s', edd_dict)
         debugs = [
             ("edd: found device 0x%x at %s", 0x80,
              '/sys/firmware/edd/int13_dev80/'),
@@ -686,7 +686,7 @@ class EddTestCase(unittest.TestCase):
         }
 
         edd_dict = edd.collect_edd_data(root=self.root('mostly_fixed_virt'))
-        self.debug('edd_dict: %s', edd_dict)
+        self.edd_debug('edd_dict: %s', edd_dict)
         debugs = [
             ("edd: found device 0x%x at %s", 0x80,
              '/sys/firmware/edd/int13_dev80/'),
@@ -745,7 +745,7 @@ class EddTestCase(unittest.TestCase):
         }
 
         edd_dict = edd.get_edd_dict(devices, root=self.root('mostly_fixed_virt'))
-        self.debug('edd_dict: %s', edd_dict)
+        self.edd_debug('edd_dict: %s', edd_dict)
         debugs = [
             ("edd: found device 0x%x at %s", 0x80,
              '/sys/firmware/edd/int13_dev80/'),

--- a/tests/devices_test/device_methods_test.py
+++ b/tests/devices_test/device_methods_test.py
@@ -251,7 +251,7 @@ class PartitionDeviceMethodsTestCase(StorageDeviceMethodsTestCase):
         self.patchers["disk"] = patch.object(self.device_class, "disk", new=PropertyMock())
 
     @patch("blivet.devices.partition.DeviceFormat")
-    def test_create(self, *args):  # pylint: disable=unused-argument
+    def test_create(self, *args):  # pylint: disable=unused-argument,arguments-differ
         with patch.object(self.device, "_wipe"):
             super().test_create()
 

--- a/tests/parentlist_test.py
+++ b/tests/parentlist_test.py
@@ -20,7 +20,7 @@ class ParentListTestCase(unittest.TestCase):
         self.assertEqual(pl[:], pl.items)
 
         with self.assertRaises(TypeError):
-            pl[2] = 99
+            pl[2] = 99  # pylint: disable=unsupported-assignment-operation
 
         newval = 99
         self.assertEqual(99 in pl, False)

--- a/tests/populator_test.py
+++ b/tests/populator_test.py
@@ -750,7 +750,8 @@ class FormatPopulatorTestCase(PopulatorHelperTestCase):
                              self.helper_class,
                              msg="get_format_helper failed for %s" % self.udev_type)
 
-    def test_run(self):
+    # pylint: disable=unused-argument
+    def test_run(self, *args):
         if self.udev_type is None:
             return
 

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -11,7 +11,7 @@ class BlivetLintConfig(PocketLintConfig):
         PocketLintConfig.__init__(self)
 
         self.falsePositives = [FalsePositive(r"BTRFSVolumeDevice._create: Instance of 'DeviceFormat' has no 'label' member"),
-                               FalsePositive(r"Catching an exception which doesn't inherit from BaseException: (BlockDev|DM|Crypto|Swap|LVM|Btrfs|MDRaid|G)Error$"),
+                               FalsePositive(r"Catching an exception which doesn't inherit from (BaseException|Exception): (BlockDev|DM|Crypto|Swap|LVM|Btrfs|MDRaid|G)Error$"),
                                FalsePositive(r"Function 'run_program' has no 'called' member"),
                                FalsePositive(r"(PartitioningTestCase|PartitionDeviceTestCase).*: Instance of 'DeviceFormat' has no .* member"),
                                FalsePositive(r"Instance of 'int' has no .* member"),

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -10,12 +10,8 @@ class BlivetLintConfig(PocketLintConfig):
     def __init__(self):
         PocketLintConfig.__init__(self)
 
-        self.falsePositives = [FalsePositive(r"BTRFSVolumeDevice._create: Instance of 'DeviceFormat' has no 'label' member"),
-                               FalsePositive(r"Catching an exception which doesn't inherit from (BaseException|Exception): (BlockDev|DM|Crypto|Swap|LVM|Btrfs|MDRaid|G)Error$"),
-                               FalsePositive(r"Function 'run_program' has no 'called' member"),
-                               FalsePositive(r"(PartitioningTestCase|PartitionDeviceTestCase).*: Instance of 'DeviceFormat' has no .* member"),
+        self.falsePositives = [FalsePositive(r"Catching an exception which doesn't inherit from (BaseException|Exception): (BlockDev|DM|Crypto|Swap|LVM|Btrfs|MDRaid|G)Error$"),
                                FalsePositive(r"Instance of 'int' has no .* member"),
-                               FalsePositive(r"Instance of 'LUKSDevice' has no .* member"),
                                FalsePositive(r"Method 'do_task' is abstract in class 'Task' but is not overridden"),
                                FalsePositive(r"Method 'do_task' is abstract in class 'UnimplementedTask' but is not overridden"),
                                FalsePositive(r"No value for argument 'member_count' in unbound method call$"),

--- a/tests/pylint/runpylint.py
+++ b/tests/pylint/runpylint.py
@@ -19,7 +19,8 @@ class BlivetLintConfig(PocketLintConfig):
                                FalsePositive(r"Method 'do_task' is abstract in class 'Task' but is not overridden"),
                                FalsePositive(r"Method 'do_task' is abstract in class 'UnimplementedTask' but is not overridden"),
                                FalsePositive(r"No value for argument 'member_count' in unbound method call$"),
-                               FalsePositive(r"No value for argument 'smallest_member_size' in unbound method call$")
+                               FalsePositive(r"No value for argument 'smallest_member_size' in unbound method call$"),
+                               FalsePositive(r"Parameters differ from overridden 'do_task' method$")
                                ]
 
     @property


### PR DESCRIPTION
We now have new pylint in Fedora and it has a lot of new awesome warnings and errors.

Test will still fail on this because pylint started writing the score to stdout and pocketlint thinks it is an error. https://github.com/rhinstaller/pocketlint/pull/16 should fix this