### PR TITLE
Adapt to logging module name change

### DIFF
--- a/blivet/__init__.py
+++ b/blivet/__init__.py
@@ -124,7 +124,7 @@ def enable_installer_mode():
         from pyanaconda.constants import ROOT_PATH  # pylint: disable=redefined-outer-name,no-name-in-module
         _storage_root = _sysroot = ROOT_PATH
 
-    from pyanaconda.anaconda_log import program_log_lock
+    from pyanaconda.anaconda_logging import program_log_lock
     util.program_log_lock = program_log_lock
 
     flags.installer_mode = True


### PR DESCRIPTION
The anaconda_log module has been renamed to anaconda_logging,
so change the name of the imported module accordingly.