### PR TITLE
Round the recommended thpool metadata size to extents

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -1238,6 +1238,9 @@ class LVMThinPoolDevice(LVMLogicalVolumeDevice):
                                                        100)  # snapshots
         log.debug("Recommended metadata size: %s", self.metaDataSize)
 
+        self.metaDataSize = self.vg.align(self.metaDataSize, roundup=True)
+        log.debug("Rounded metadata size to extents: %s", self.metaDataSize)
+
         # we also need space for the (potential) pmspare LV (of the same size as
         # the metaDataSize)
         log.debug("Adjusting size from %s to %s", self.size, self.size - 2 * self.metaDataSize)


### PR DESCRIPTION
Otherwise LVM does it when creating the thin pool and we may end
up with not enough space in the VG to create the data part of the
pool (which happens afterwards).

Resolves: rhbz#1456528