### PR TITLE
Make sure an LV is deactivated before removal

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -792,6 +792,10 @@ class LVMLogicalVolumeDevice(DMDevice):
         # set up the vg's pvs so lvm can remove the lv
         self.vg.setupParents(orig=True)
 
+        # setting up VG's PVs may have caused this LV was automatically
+        # activated, make sure it is deactivated before removal
+        self.teardown()
+
     def _destroy(self):
         """ Destroy the device. """
         log_method_call(self, self.name, status=self.status)


### PR DESCRIPTION
Before and LV is removed, we may need to set its ancestors (VG
and its PVs) up which may trigger auto-activation of the LV
itself. And since we are supposed to always remove a deactivated
LV so we have to make sure the LV is deactivated before we try to
remove it.

Resolves: rhbz#1456821