### PR TITLE
Fix use of _teardown function to deactivate LV

### DIFF
--- a/blivet/devices/lvm.py
+++ b/blivet/devices/lvm.py
@@ -794,7 +794,7 @@ class LVMLogicalVolumeDevice(DMDevice):
 
         # setting up VG's PVs may have caused this LV was automatically
         # activated, make sure it is deactivated before removal
-        self.teardown()
+        self._teardown()
 
     def _destroy(self):
         """ Destroy the device. """


### PR DESCRIPTION
This commit fixes typo in use of function _teardown, which was designed
to deactivate LV before removal. Function teardown without "_" do something
else. I found it based on diff of files from proposed updates.img(which solves
issue from rhbz#1456821) and one from actual build.

Resolves: rhbz#1456821