### PR TITLE
Only run log_method_call when flags.debug is set.

### DIFF
--- a/blivet/storage_log.py
+++ b/blivet/storage_log.py
@@ -3,6 +3,8 @@ import logging
 import sys
 import traceback
 
+from .flags import flags
+
 log = logging.getLogger("blivet")
 log.addHandler(logging.NullHandler())
 
@@ -22,6 +24,9 @@ def function_name_and_depth():
 
 
 def log_method_call(d, *args, **kwargs):
+    if not flags.debug:
+        return
+
     classname = d.__class__.__name__
     (methodname, depth) = function_name_and_depth()
     spaces = depth * ' '


### PR DESCRIPTION
Some informal measurements on my workstation showed between 15-20% speedup in running `blivet/examples/list_devices.py` with this patch.