### PR TITLE
Stop enforcing obsolete limits on partition count. (#1460668)

### DIFF
--- a/blivet/partitioning.py
+++ b/blivet/partitioning.py
@@ -136,8 +136,6 @@ def get_next_partition_type(disk, no_primary=None):
     part_type = None
     extended = disk.getExtendedPartition()
     supports_extended = disk.supportsFeature(parted.DISK_TYPE_EXTENDED)
-    logical_count = len(disk.getLogicalPartitions())
-    max_logicals = disk.getMaxLogicalPartitions()
     primary_count = disk.primaryPartitionCount
 
     if primary_count < disk.maxPrimaryPartitionCount:
@@ -153,17 +151,17 @@ def get_next_partition_type(disk, no_primary=None):
                 # there is an extended and a free primary
                 if not no_primary:
                     part_type = parted.PARTITION_NORMAL
-                elif logical_count < max_logicals:
-                    # we have an extended with logical slots, so use one.
+                else:
+                    # we have an extended, so use it.
                     part_type = parted.PARTITION_LOGICAL
         else:
             # there are two or more primary slots left. use one unless we're
             # not supposed to make primaries.
             if not no_primary:
                 part_type = parted.PARTITION_NORMAL
-            elif extended and logical_count < max_logicals:
+            elif extended:
                 part_type = parted.PARTITION_LOGICAL
-    elif extended and logical_count < max_logicals:
+    elif extended:
         part_type = parted.PARTITION_LOGICAL
 
     return part_type

--- a/tests/partitioning_test.py
+++ b/tests/partitioning_test.py
@@ -34,9 +34,9 @@ from blivet.flags import flags
 # disklabel-type-specific constants
 # keys: disklabel type string
 # values: 3-tuple of (max_primary_count, supports_extended, max_logical_count)
-disklabel_types = {'dos': (4, True, 11),
-                   'gpt': (128, False, 0),
-                   'mac': (62, False, 0)}
+disklabel_types = {'dos': (4, True),
+                   'gpt': (128, False),
+                   'mac': (62, False)}
 
 
 class PartitioningTestCase(unittest.TestCase):
@@ -48,7 +48,7 @@ class PartitioningTestCase(unittest.TestCase):
 
         disk.type = disk_type
         label_type_info = disklabel_types[disk_type]
-        (max_primaries, supports_extended, max_logicals) = label_type_info
+        (max_primaries, supports_extended) = label_type_info
 
         # primary partitions
         disk.primaryPartitionCount = primary_count
@@ -59,7 +59,6 @@ class PartitioningTestCase(unittest.TestCase):
         disk.getExtendedPartition = Mock(return_value=has_extended)
 
         # logical partitions
-        disk.getMaxLogicalPartitions = Mock(return_value=max_logicals)
         disk.getLogicalPartitions = Mock(return_value=[0] * logical_count)
 
         return disk
@@ -91,26 +90,25 @@ class PartitioningTestCase(unittest.TestCase):
                              logical_count=9)
         self.assertEqual(get_next_partition_type(disk), parted.PARTITION_LOGICAL)
 
-        # four primaries and an extended, no available logical -> None
+        # four primaries and an extended -> logical
         disk = self.get_disk(disk_type="dos", primary_count=4, has_extended=True,
                              logical_count=11)
-        self.assertEqual(get_next_partition_type(disk), None)
+        self.assertEqual(get_next_partition_type(disk), parted.PARTITION_LOGICAL)
 
         # four primaries and no extended -> None
         disk = self.get_disk(disk_type="dos", primary_count=4,
                              has_extended=False)
         self.assertEqual(get_next_partition_type(disk), None)
 
-        # free primary slot, extended, no free logical slot -> primary
+        # free primary slot, extended -> primary
         disk = self.get_disk(disk_type="dos", primary_count=3, has_extended=True,
                              logical_count=11)
         self.assertEqual(get_next_partition_type(disk), parted.PARTITION_NORMAL)
 
-        # free primary slot, extended, no free logical slot w/ no_primary
-        # -> None
+        # free primary slot, extended w/ no_primary -> logical
         disk = self.get_disk(disk_type="dos", primary_count=3, has_extended=True,
                              logical_count=11)
-        self.assertEqual(get_next_partition_type(disk, no_primary=True), None)
+        self.assertEqual(get_next_partition_type(disk, no_primary=True), parted.PARTITION_LOGICAL)
 
         #
         # GPT


### PR DESCRIPTION
Today I learned that the partition count limits in pyparted are in fact massively outdated (rhinstaller/pyparted#41). These days major/minor numbers are dynamically allocated so there is no limit except for space. There is a notable exception in mmcblk, which has a kernel config value for the number of minors per major. It defaults to 8. Good grief.